### PR TITLE
Save stream duration to the API db 

### DIFF
--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -53,6 +53,14 @@ components:
         transcodedSegments:
           type: number
           example: 2
+        sourceSegmentsDuration:
+          type: number
+          example: 1
+          description: Duration of all the source segments, sec
+        transcodedSegmentsDuration:
+          type: number
+          example: 2
+          description: Duration of all the transcoded segments, sec
         deleted:
           type: boolean
           description: Set to true when stream deleted

--- a/packages/www/pages/app/stream/[id].tsx
+++ b/packages/www/pages/app/stream/[id].tsx
@@ -344,8 +344,18 @@ export default () => {
               <Cell>{stream.isActive ? "Active" : "Idle"}</Cell>
               {user.admin ? (
                 <>
+                  <Cell> </Cell>
+                  <Cell><strong>Admin only fields:</strong></Cell>
                   <Cell>Deleted</Cell>
                   <Cell>{stream.deleted ? <strong>Yes</strong> : "No"}</Cell>
+                  <Cell>Source segments</Cell>
+                  <Cell>{stream.sourceSegments || 0}</Cell>
+                  <Cell>Transcoded segments</Cell>
+                  <Cell>{stream.transcodedSegments || 0}</Cell>
+                  <Cell>Source duration</Cell>
+                  <Cell>{stream.sourceSegmentsDuration || 0} sec</Cell>
+                  <Cell>Transcoded duration</Cell>
+                  <Cell>{stream.transcodedSegmentsDuration || 0} sec</Cell>
                 </>
               ) : null}
             </Box>


### PR DESCRIPTION
- Add `sourceSegmentsDuration` and `transcodedSegmentsDuration` field to the `Stream` object

- In stream-info-service parse durations of segments from .m3u8 manifest and save to `sourceSegmentsDuration` and `transcodedSegmentsDuration` fields
- Show content of `sourceSegmentsDuration` and `transcodedSegmentsDuration` fields on stream info page (only for admins)

<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

## -

-

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
