### PR TITLE
fix vercel build

### DIFF
--- a/packages/www/package.json
+++ b/packages/www/package.json
@@ -3,6 +3,7 @@
   "name": "@livepeer.com/www",
   "version": "1.0.0-alpha.7",
   "scripts": {
+    "prepare": "cd ../api && yarn run prepare:babel",
     "dev": "next --port=3008",
     "build": "next build",
     "start": "next start"

--- a/packages/www/package.json
+++ b/packages/www/package.json
@@ -3,7 +3,7 @@
   "name": "@livepeer.com/www",
   "version": "1.0.0-alpha.7",
   "scripts": {
-    "prepare": "cd ../api && yarn run prepare:babel",
+    "prepare": "cd ../api && yarn run prepare",
     "dev": "next --port=3008",
     "build": "next build",
     "start": "next start"


### PR DESCRIPTION
Apparently doing a yarn install in a subpackage of a Yarn workspace doesn't run the whole workspace's prepare step? Not quite understanding how it works but...

```
git clean -fdx
cd packages/www/
yarn install
▶ node -p 'require("@livepeer.com/api")'
internal/modules/cjs/loader.js:337
      throw err;
      ^

Error: Cannot find module '/Users/iameli/code/livepeer.com/node_modules/@livepeer.com/api/dist/index.js'. Please verify that the package.json has a valid "main" entry
```
So currently trying attempting a build where I put this in `packages/www/package.json`: `"prepare": "cd ../api && yarn run prepare"`,