### PR TITLE
temporarily hide blog from footer until we have content

### DIFF
--- a/packages/www/components/Footer/index.tsx
+++ b/packages/www/components/Footer/index.tsx
@@ -43,11 +43,11 @@ export default () => {
             </Flex>
           </Box>
           <Flex sx={{ justifyContent: "center", alignItems: "center" }}>
-            <Link href="/blog" passHref>
+            {/* <Link href="/blog" passHref>
               <a sx={{ textDecoration: "none", mr: 4, color: "accent" }}>
                 Blog
               </a>
-            </Link>
+            </Link> */}
             <Link href="/[slug]" as="/team" passHref>
               <a sx={{ textDecoration: "none", mr: 4, color: "accent" }}>
                 Team


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This just temporarily hides the blog from the footer until we have published posts.