### PR TITLE
URL for playing back recordings now taken from /api/ingest endpoint

### DIFF
--- a/packages/www/components/StreamSessionsTable/index.tsx
+++ b/packages/www/components/StreamSessionsTable/index.tsx
@@ -8,8 +8,6 @@ import { pathJoin, breakablePath } from "../../lib/utils";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import Copy from "../../public/img/copy.svg";
 
-const baseRecordingsURL = "https://mdw-cdn.livepeer.monster/recordings";
-
 type RecordingURLProps = {
   manifestId: string;
   baseUrl: string;
@@ -31,7 +29,7 @@ export const RecordingURL = ({
     }
   }, [isCopied]);
   const fullUrl = hasRecording
-    ? pathJoin(pathJoin(baseUrl, manifestId), "index.m3u8")
+    ? pathJoin(baseUrl, "recordings", manifestId, "index.m3u8")
     : "";
   const anchor = true;
   return (
@@ -89,7 +87,17 @@ export default ({
   mt?: string | number;
 }) => {
   const [streamsSessions, setStreamsSessions] = useState([]);
-  const { getStreamSessions } = useApi();
+  const [baseUrl, setBaseUrl] = useState(null);
+  const { getStreamSessions, getIngest } = useApi();
+  useEffect(() => {
+    getIngest()
+      .then((ingest) => {
+        if (ingest && ingest.length) {
+          setBaseUrl(ingest[0].playback)
+        }
+      })
+      .catch((err) => console.error(err)); // todo: surface this
+  }, [streamId]);
   useEffect(() => {
     getStreamSessions(streamId)
       .then(streams => setStreamsSessions(streams))
@@ -142,7 +150,7 @@ export default ({
               <RecordingURL
                 manifestId={stream.id}
                 hasRecording={!!stream.recordObjectStoreId}
-                baseUrl={baseRecordingsURL}
+                baseUrl={baseUrl}
               />
             </TableRow>
           );

--- a/packages/www/lib/utils.tsx
+++ b/packages/www/lib/utils.tsx
@@ -19,7 +19,7 @@ export const getComponent = (component) => {
   }
 };
 
-export function pathJoin(p1: string, p2: string): string {
+export function pathJoin2(p1: string, p2: string): string {
   if (!p1) {
     return p2;
   }
@@ -30,6 +30,10 @@ export function pathJoin(p1: string, p2: string): string {
     p2 = p2.slice(1);
   }
   return p1 + "/" + (p2 || "");
+}
+
+export function pathJoin(...items: Array<string>): string {
+  return items.reduce(pathJoin2, '')
 }
 
 export function breakablePath(path: string): string {

--- a/packages/www/pages/app/stream/[id].tsx
+++ b/packages/www/pages/app/stream/[id].tsx
@@ -157,7 +157,7 @@ export default () => {
   };
   const getPlaybackURL = (stream: Stream): string => {
     return ingest.length
-      ? pathJoin(ingest[0].playback, `${stream.playbackId}/index.m3u8`)
+      ? pathJoin(ingest[0].playback, 'hls', `${stream.playbackId}/index.m3u8`)
       : stream.playbackId || "";
   };
   const doSetRecord = async (stream: Stream, record: boolean) => {


### PR DESCRIPTION
'playback' part of LP_INGEST command line parameter now should be
specified without '/hls' part

<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

## -

-

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
