### PR TITLE
api: fix my bug with geolocation, /user goes upstream now

### DIFF
--- a/packages/api/src/app-router.js
+++ b/packages/api/src/app-router.js
@@ -27,7 +27,6 @@ const GEOLOCATION_ENDPOINTS = [
   'orchestrator',
   'ingest',
   'geolocate',
-  'user',
 ]
 
 export default async function makeApp(params) {


### PR DESCRIPTION
Just a typo in the devops side. Whoops. https://github.com/livepeer/livepeer-infra/commit/ec3aa3746c513fe4236a1ae519156da54863cbd9