### PR TITLE
disable cache on blog for now

### DIFF
--- a/packages/www/pages/blog/[slug].tsx
+++ b/packages/www/pages/blog/[slug].tsx
@@ -143,25 +143,8 @@ const Post = ({
 
 export default Post;
 
-export async function getStaticPaths() {
-  const graphQLClient = new GraphQLClient(
-    "https://dp4k3mpw.api.sanity.io/v1/graphql/production/default"
-  );
-  const { allPost } = await graphQLClient.request(print(allPosts), {
-    where: {},
-  });
-
-  let paths = [];
-  for (const post of allPost) {
-    paths.push({ params: { slug: post.slug.current } });
-  }
-  return {
-    fallback: true,
-    paths,
-  };
-}
-
-export async function getStaticProps({ params, preview = false }) {
+export async function getServerSideProps({ params }) {
+  const { slug } = params;
   const graphQLClient = new GraphQLClient(
     "https://dp4k3mpw.api.sanity.io/v1/graphql/production/default"
   );
@@ -175,8 +158,43 @@ export async function getStaticProps({ params, preview = false }) {
   return {
     props: {
       ...data.allPost[0],
-      preview: false,
     },
-    revalidate: 1,
   };
 }
+// export async function getStaticPaths() {
+//   const graphQLClient = new GraphQLClient(
+//     "https://dp4k3mpw.api.sanity.io/v1/graphql/production/default"
+//   );
+//   const { allPost } = await graphQLClient.request(print(allPosts), {
+//     where: {},
+//   });
+
+//   let paths = [];
+//   for (const post of allPost) {
+//     paths.push({ params: { slug: post.slug.current } });
+//   }
+//   return {
+//     fallback: true,
+//     paths,
+//   };
+// }
+
+// export async function getStaticProps({ params, preview = false }) {
+//   const graphQLClient = new GraphQLClient(
+//     "https://dp4k3mpw.api.sanity.io/v1/graphql/production/default"
+//   );
+
+//   let data: any = await graphQLClient.request(print(allPosts), {
+//     where: {
+//       slug: { current: { eq: params.slug } },
+//     },
+//   });
+
+//   return {
+//     props: {
+//       ...data.allPost[0],
+//       preview: false,
+//     },
+//     revalidate: 1,
+//   };
+// }

--- a/packages/www/pages/blog/category/[slug].tsx
+++ b/packages/www/pages/blog/category/[slug].tsx
@@ -4,22 +4,8 @@ import allCategories from "../../../queries/allCategories.gql";
 import allPosts from "../../../queries/allPosts.gql";
 import BlogIndex from "../index";
 
-export async function getStaticPaths() {
-  const { allCategory } = await request(
-    "https://dp4k3mpw.api.sanity.io/v1/graphql/production/default",
-    print(allCategories)
-  );
-  let paths = [];
-  for (const category of allCategory) {
-    paths.push({ params: { slug: category.slug.current } });
-  }
-  return {
-    fallback: true,
-    paths,
-  };
-}
-
-export async function getStaticProps({ params }) {
+export async function getServerSideProps({ params }) {
+  const { slug } = params;
   const { allCategory: categories } = await request(
     "https://dp4k3mpw.api.sanity.io/v1/graphql/production/default",
     print(allCategories)
@@ -38,8 +24,45 @@ export async function getStaticProps({ params }) {
       categories: categories.reverse(),
       posts,
     },
-    revalidate: 1,
   };
 }
+
+// export async function getStaticPaths() {
+//   const { allCategory } = await request(
+//     "https://dp4k3mpw.api.sanity.io/v1/graphql/production/default",
+//     print(allCategories)
+//   );
+//   let paths = [];
+//   for (const category of allCategory) {
+//     paths.push({ params: { slug: category.slug.current } });
+//   }
+//   return {
+//     fallback: true,
+//     paths,
+//   };
+// }
+
+// export async function getStaticProps({ params }) {
+//   const { allCategory: categories } = await request(
+//     "https://dp4k3mpw.api.sanity.io/v1/graphql/production/default",
+//     print(allCategories)
+//   );
+//   categories.push({ title: "All", slug: { current: "" } });
+//   const {
+//     allPost: posts,
+//   } = await request(
+//     "https://dp4k3mpw.api.sanity.io/v1/graphql/production/default",
+//     print(allPosts),
+//     { where: { category: { slug: { current: { eq: params.slug } } } } }
+//   );
+
+//   return {
+//     props: {
+//       categories: categories.reverse(),
+//       posts,
+//     },
+//     revalidate: 1,
+//   };
+// }
 
 export default BlogIndex;


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
There seems to be an issue with the next.js incremental builds feature where the pages never revalidate. This PR disables the cache for blog pages by changing `getStaticProps` to `getServerSideProps` so pages are served at runtime as opposed to build time.