### PR TITLE
enable cors

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -53,6 +53,7 @@
     "body-parser": "^1.19.0",
     "browser-process-hrtime": "^1.0.0",
     "camelcase": "^5.3.1",
+    "cors": "^2.8.5",
     "cross-env": "^5.2.0",
     "dotenv": "^8.1.0",
     "email-validator": "^2.0.4",

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -4,6 +4,7 @@ import morgan from 'morgan'
 import logger from './logger'
 import appRouter from './app-router'
 import 'source-map-support/register'
+import cors from 'cors'
 
 export default async function makeApp(params) {
   const {
@@ -72,6 +73,18 @@ export default async function makeApp(params) {
     // process.exit(1)
   }
   const app = express()
+  const whitelist = [
+    'https://livepeer.com',
+    'https://livepeer.monster',
+    /\.livepeerorg.vercel\.app$/,
+    /\.livepeerorg.now\.sh$/,
+  ]
+  app.use(
+    cors({
+      origin: whitelist,
+      credentials: true,
+    }),
+  )
   app.use(
     morgan('dev', {
       skip: (req, res) => {

--- a/packages/www/hooks/use-api.tsx
+++ b/packages/www/hooks/use-api.tsx
@@ -6,7 +6,7 @@ import {
   Error as ApiError,
   ApiToken,
   Stream,
-  Webhook,
+  Webhook
 } from "@livepeer.com/api";
 import qs from "qs";
 
@@ -76,9 +76,15 @@ const makeContext = (state: ApiState, setState) => {
       if (state.token && !headers.has("authorization")) {
         headers.set("authorization", `JWT ${state.token}`);
       }
-      const res = await fetch(`/api${url}`, {
+      const endpoint =
+        window.location.hostname !== "localhost" &&
+        window.location.hostname !== "livepeer.monster" &&
+        window.location.hostname !== "livepeer.com"
+          ? `https://livepeer.monster/api${url}`
+          : `/api${url}`;
+      const res = await fetch(endpoint, {
         ...opts,
-        headers,
+        headers
       });
       if (res.status === 204) {
         return [res];
@@ -98,8 +104,8 @@ const makeContext = (state: ApiState, setState) => {
         method: "POST",
         body: JSON.stringify({ email, password }),
         headers: {
-          "content-type": "application/json",
-        },
+          "content-type": "application/json"
+        }
       });
       if (res.status !== 201) {
         return body;
@@ -110,7 +116,7 @@ const makeContext = (state: ApiState, setState) => {
       if (process.env.NODE_ENV === "production") {
         const data = jwt.decode(token);
         window.analytics.identify(data.sub, {
-          email: email,
+          email: email
         });
       }
 
@@ -124,8 +130,8 @@ const makeContext = (state: ApiState, setState) => {
         method: "POST",
         body: JSON.stringify({ email, password }),
         headers: {
-          "content-type": "application/json",
-        },
+          "content-type": "application/json"
+        }
       });
       if (res.status !== 201) {
         return body;
@@ -139,8 +145,8 @@ const makeContext = (state: ApiState, setState) => {
         method: "POST",
         body: JSON.stringify({ email, emailValidToken }),
         headers: {
-          "content-type": "application/json",
-        },
+          "content-type": "application/json"
+        }
       });
       setState({ ...state, userRefresh: Date.now() });
     },
@@ -151,8 +157,8 @@ const makeContext = (state: ApiState, setState) => {
         method: "POST",
         body: JSON.stringify({ email }),
         headers: {
-          "content-type": "application/json",
-        },
+          "content-type": "application/json"
+        }
       });
       return body;
     },
@@ -163,8 +169,8 @@ const makeContext = (state: ApiState, setState) => {
         method: "POST",
         body: JSON.stringify({ email, resetToken, password }),
         headers: {
-          "content-type": "application/json",
-        },
+          "content-type": "application/json"
+        }
       });
       if (res.status !== 201) {
         return body;
@@ -191,8 +197,8 @@ const makeContext = (state: ApiState, setState) => {
         method: "POST",
         body: JSON.stringify({ email: email, admin: admin }),
         headers: {
-          "content-type": "application/json",
-        },
+          "content-type": "application/json"
+        }
       });
 
       if (res.status !== 201) {
@@ -258,8 +264,8 @@ const makeContext = (state: ApiState, setState) => {
         method: "POST",
         body: JSON.stringify(params),
         headers: {
-          "content-type": "application/json",
-        },
+          "content-type": "application/json"
+        }
       });
 
       if (res.status !== 201) {
@@ -278,7 +284,7 @@ const makeContext = (state: ApiState, setState) => {
 
     async deleteStream(id: string): Promise<void> {
       const [res, body] = await context.fetch(`/stream/${id}`, {
-        method: "DELETE",
+        method: "DELETE"
       });
       if (res.status !== 204) {
         throw new Error(body);
@@ -293,8 +299,8 @@ const makeContext = (state: ApiState, setState) => {
         method: "PATCH",
         body: JSON.stringify({ record }),
         headers: {
-          "content-type": "application/json",
-        },
+          "content-type": "application/json"
+        }
       });
 
       if (res.status !== 204) {
@@ -324,8 +330,8 @@ const makeContext = (state: ApiState, setState) => {
         method: "POST",
         body: JSON.stringify(params),
         headers: {
-          "content-type": "application/json",
-        },
+          "content-type": "application/json"
+        }
       });
 
       if (res.status !== 201) {
@@ -336,7 +342,7 @@ const makeContext = (state: ApiState, setState) => {
 
     async deleteWebhook(id: string): Promise<void> {
       const [res, body] = await context.fetch(`/webhook/${id}`, {
-        method: "DELETE",
+        method: "DELETE"
       });
       if (res.status !== 204) {
         throw new Error(body.errors.join(", "));
@@ -359,8 +365,8 @@ const makeContext = (state: ApiState, setState) => {
         method: "POST",
         body: JSON.stringify(params),
         headers: {
-          "content-type": "application/json",
-        },
+          "content-type": "application/json"
+        }
       });
       if (res.status !== 201) {
         throw new Error(JSON.stringify(res.errors));
@@ -370,12 +376,12 @@ const makeContext = (state: ApiState, setState) => {
 
     async deleteApiToken(id: string): Promise<void> {
       const [res, body] = await context.fetch(`/api-token/${id}`, {
-        method: "DELETE",
+        method: "DELETE"
       });
       if (res.status !== 204) {
         throw new Error(body);
       }
-    },
+    }
   };
   return context;
 };
@@ -384,7 +390,7 @@ export const ApiContext = createContext(makeContext({} as ApiState, () => {}));
 
 export const ApiProvider = ({ children }) => {
   const [state, setState] = useState<ApiState>({
-    token: getStoredToken(),
+    token: getStoredToken()
   });
 
   const context = makeContext(state, setState);

--- a/packages/www/hooks/use-api.tsx
+++ b/packages/www/hooks/use-api.tsx
@@ -77,9 +77,8 @@ const makeContext = (state: ApiState, setState) => {
         headers.set("authorization", `JWT ${state.token}`);
       }
       const endpoint =
-        window.location.hostname !== "localhost" &&
-        window.location.hostname !== "livepeer.monster" &&
-        window.location.hostname !== "livepeer.com"
+        window.location.hostname.includes("livepeerorg.vercel.app") ||
+        window.location.hostname.includes("livepeerorg.now.sh")
           ? `https://livepeer.monster/api${url}`
           : `/api${url}`;
       const res = await fetch(endpoint, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6464,9 +6464,10 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cors@latest:
+cors@^2.8.5, cors@latest:
   version "2.8.5"
   resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
   dependencies:
     object-assign "^4"
     vary "^1"


### PR DESCRIPTION
This PR enables CORs and teaches the frontend to use the `livepeer.monster/api` endpoint when on a vercel preview url.