### PR TITLE
add docs redirects

### DIFF
--- a/packages/www/pages/docs/guides/index.mdx
+++ b/packages/www/pages/docs/guides/index.mdx
@@ -27,7 +27,7 @@ able to create a RTMP stream. [ffmpeg](https://ffmpeg.org/) or
 but you can also use any RTMP library, for example
 [Streamaxia](https://www.streamaxia.com/) in iOS.
 
-### [Feature Support Matrix](/docs/support-matrix)
+### [Feature Support Matrix](/docs/guides/support-matrix)
 
 You can use the feature support matrix to understand whether Livepeer.com
 supports your feature requirements.

--- a/packages/www/vercel.json
+++ b/packages/www/vercel.json
@@ -4,7 +4,8 @@
   "redirects": [
     {
       "source": "/tv",
-      "destination": "https://media.livepeer.org/play?url=https%3A%2F%2Fd21gyr0uv5jqnv.cloudfront.net%2F4br7%252Badam_obs%2Findex.m3u8"
+      "destination": "https://media.livepeer.org/play?url=https%3A%2F%2Fd21gyr0uv5jqnv.cloudfront.net%2F4br7%252Badam_obs%2Findex.m3u8",
+      "permanent": false
     },
     {
       "source": "/docs/support-matrix",

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,74 @@
     {
       "source": "/tv",
       "destination": "https://media.livepeer.org/play?url=https%3A%2F%2Fd21gyr0uv5jqnv.cloudfront.net%2F4br7%252Badam_obs%2Findex.m3u8"
+    },
+    {
+      "source": "/docs/support-matrix",
+      "destination": "/docs/guides/support-matrix"
+    },
+    {
+      "source": "/docs/dashboard/create-a-stream",
+      "destination": "/docs/guides/dashboard/create-a-stream"
+    },
+    {
+      "source": "/docs/dashboard/stream-page-specifications",
+      "destination": "/docs/guides/dashboard/stream-page-specifications"
+    },
+    {
+      "source": "/docs/dashboard/broadcast-a-stream-session",
+      "destination": "/docs/guides/dashboard/broadcast-a-stream-session"
+    },
+    {
+      "source": "/docs/dashboard/stream-rendition-properties",
+      "destination": "/docs/guides/dashboard/stream-rendition-properties"
+    },
+    {
+      "source": "/docs/dashboard/playback-a-stream",
+      "destination": "/docs/guides/dashboard/playback-a-stream"
+    },
+    {
+      "source": "/docs/dashboard/delete-a-stream",
+      "destination": "/docs/guides/dashboard/delete-a-stream"
+    },
+    {
+      "source": "/docs/api/create-api-key",
+      "destination": "/docs/guides/api/create-api-key"
+    },
+    {
+      "source": "/docs/api/base-urls",
+      "destination": "/docs/guides/api/base-urls"
+    },
+    {
+      "source": "/docs/api/create-a-stream",
+      "destination": "/docs/guides/api/create-a-stream"
+    },
+    {
+      "source": "/docs/api/broadcast-a-live-stream",
+      "destination": "/docs/guides/api/broadcast-a-live-stream"
+    },
+    {
+      "source": "/docs/api/playback-a-live-stream",
+      "destination": "/docs/guides/api/playback-a-live-stream"
+    },
+    {
+      "source": "/docs/api/list-all-streams",
+      "destination": "/docs/guides/api/list-all-streamsm"
+    },
+    {
+      "source": "/docs/api/delete-a-stream",
+      "destination": "/docs/guides/api/delete-a-stream"
+    },
+    {
+      "source": "/docs/api-keys/when-do-you-need-an-API-key",
+      "destination": "/docs/guides/api-keys/when-do-you-need-an-API-key"
+    },
+    {
+      "source": "/docs/api-keys/create-an-api-key",
+      "destination": "/docs/guides/api-keys/create-an-api-key"
+    },
+    {
+      "source": "/docs/api-keys/delete-an-api-key",
+      "destination": "/docs/guides/api-keys/delete-an-api-key"
     }
   ]
 }


### PR DESCRIPTION
We moved the guides from `/docs/[slug]` to `/docs/guides/[slug]`. This PR adds a redirect for the old urls.