### PR TITLE
Allow to delete many streams at once in UI

### DIFF
--- a/packages/www/components/DeleteStreamModal/index.tsx
+++ b/packages/www/components/DeleteStreamModal/index.tsx
@@ -5,15 +5,24 @@ type DeleteStreamModalProps = {
   streamName: string;
   onClose: Function;
   onDelete: Function;
+  numStreamsToDelete?: number;
 };
 
-export default ({ streamName, onClose, onDelete }: DeleteStreamModalProps) => {
+export default ({
+  streamName,
+  onClose,
+  onDelete,
+  numStreamsToDelete
+}: DeleteStreamModalProps) => {
   return (
     <Modal onClose={onClose}>
       <h3>Are you sure?</h3>
       <Box sx={{ my: 3 }}>
-        Are you sure you want to delete stream "{streamName}"? Deleting a stream
-        cannot be undone.
+        {numStreamsToDelete > 1
+          ? `Are you sure you want to delete ${numStreamsToDelete} streams? Deleting streams
+        cannot be undone.`
+          : `Are you sure you want to delete stream "${streamName}"? Deleting a stream
+        cannot be undone.`}
       </Box>
       <Flex sx={{ justifyContent: "flex-end" }}>
         <Button

--- a/packages/www/hooks/use-api.tsx
+++ b/packages/www/hooks/use-api.tsx
@@ -518,6 +518,19 @@ const makeContext = (state: ApiState, setState) => {
       }
     },
 
+    async deleteStreams(ids: Array<string>): Promise<void> {
+      const [res, body] = await context.fetch(`/stream`, {
+        method: "DELETE",
+        body: JSON.stringify({ ids }),
+        headers: {
+          "content-type": "application/json"
+        }
+      });
+      if (res.status !== 204) {
+        throw new Error(body);
+      }
+    },
+
     async setRecord(
       streamId: string,
       record: boolean


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Allows to delete many streams at once.
In my tests I'm creating streams using API, and so there are many unneeded stream objects left in my streams list, it would take too much time to delete them one-by-one using UI. And I saw one user in the Discord asking if it possible to delete many streams at once.


**Specific updates (required)**
- Adds checkbox to select all streams
- Adds endpoint to delete many streams
- Slightly changes delete modal dialog's text if more than one stream selected


**How did you test each of these updates (required)**
Manually


**Screenshots (optional):**
![image](https://user-images.githubusercontent.com/2035357/94352145-01b36700-006a-11eb-82d8-d4d248f2fa17.png)


**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
