### PR TITLE
Respect user-supplied FPS for MistServer

### DIFF
--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -21,7 +21,6 @@ const resolver = new Resolver()
 
 const app = Router()
 const hackMistSettings = (req, profiles) => {
-  // FIXME: tempoarily, Mist can only make passthrough FPS streams with 2-second gop sizes
   if (
     !req.headers['user-agent'] ||
     !req.headers['user-agent'].toLowerCase().includes('mistserver')
@@ -32,10 +31,12 @@ const hackMistSettings = (req, profiles) => {
   return profiles.map((profile) => {
     profile = {
       ...profile,
-      fps: 0,
     }
     if (typeof profile.gop === 'undefined') {
       profile.gop = '2.0'
+    }
+    if (typeof profile.fps === 'undefined') {
+      profile.fps = 0
     }
     return profile
   })


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

<!-- A clear and concise description of what this pull request does. -->

Use user-supplied framerate with Mist. (Had previously disabled it as LPMS couldn't handle FPS conversions well, but want to try it out now)

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

- Use user-supplied FPS with MistServer
- Still use passthrough FPS if user doesn't supply any FPS

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*NB: New to codebase and mostly mirrored similar code around the change. Haven't tested anything :wink: *

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
