### PR TITLE
Add option to force use of main db in /api/stream/key endpoint

### DIFF
--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -162,21 +162,17 @@ app.get('/playback/:playbackId', authMiddleware({}), async (req, res) => {
 
 // returns stream by steamKey
 app.get('/key/:streamKey', authMiddleware({}), async (req, res) => {
-  const {
-    data: [stream],
-  } = await req.store.queryObjects({
-    kind: 'stream',
-    query: { streamKey: req.params.streamKey },
-  })
+  const useReplica = req.query.main !== 'true'
+  const [docs] = await db.stream.find({ streamKey: req.params.streamKey }, { useReplica })
   if (
-    !stream ||
-    ((stream.userId !== req.user.id || stream.deleted) && !req.user.admin)
+    !docs.length ||
+    ((docs[0].userId !== req.user.id || docs[0].deleted) && !req.user.admin)
   ) {
     res.status(404)
     return res.json({ errors: ['not found'] })
   }
   res.status(200)
-  res.json(stream)
+  res.json(docs[0])
 })
 
 // Needed for Mist server


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
Add `?main` query param to the `/api/stream/key` endpoint - if true that
forces use of main (not replica) db

<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

## -

-

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
