### PR TITLE
api: cache k8s control plane responses

### DIFF
--- a/packages/api/__mocks__/@kubernetes/client-node.js
+++ b/packages/api/__mocks__/@kubernetes/client-node.js
@@ -1,5 +1,8 @@
 import { broadcasterResponse, orchestratorResponse } from './test-data.json'
 
+// Triggering intentional failures
+export const testOpts = { fail: false }
+
 // For testing the no-endpoints case
 const scrub = (response) => {
   // Cheap "deep copy"
@@ -13,6 +16,9 @@ const orchestratorResponseNoAddress = scrub(orchestratorResponse)
 
 export class KubeApiClient {
   async readNamespacedEndpoints(serviceName, namespaceName) {
+    if (testOpts.fail === true) {
+      throw new Error('intentional test failure')
+    }
     if (serviceName === 'broadcaster') {
       return broadcasterResponse
     }

--- a/packages/api/src/middleware/kubernetes.js
+++ b/packages/api/src/middleware/kubernetes.js
@@ -33,6 +33,7 @@ export default function kubernetesMiddleware({
       if (cache[cacheKey]) {
         console.log(
           'WARNING: kubernetes control plane unavailable, returning cached data',
+          e,
         )
         return cache[cacheKey]
       }
@@ -41,6 +42,7 @@ export default function kubernetesMiddleware({
       )
       throw e
     }
+    throw new Error('???')
   }
 
   const getBroadcasters = async () => {

--- a/packages/api/src/middleware/kubernetes.js
+++ b/packages/api/src/middleware/kubernetes.js
@@ -21,6 +21,7 @@ export default function kubernetesMiddleware({
 
   // Try to read namespaced endpoints, return most recent data if we can't
   const cachedReadNamespacedEndpoints = async (kubeService, kubeNamespace) => {
+    // % isn't allowed in k8s names, so it's a suitable delimiter
     const cacheKey = `${kubeService}%${kubeNamespace}`
     try {
       const endpoints = await timeout(5000, () =>

--- a/packages/api/src/middleware/kubernetes.js
+++ b/packages/api/src/middleware/kubernetes.js
@@ -31,13 +31,13 @@ export default function kubernetesMiddleware({
       return endpoints
     } catch (e) {
       if (cache[cacheKey]) {
-        console.log(
+        console.error(
           'WARNING: kubernetes control plane unavailable, returning cached data',
           e,
         )
         return cache[cacheKey]
       }
-      console.log(
+      console.error(
         'ERROR: kubernetes control plane unavailable, cached data unavailable, cannot provide orchestrator list',
       )
       throw e

--- a/packages/api/src/middleware/kubernetes.js
+++ b/packages/api/src/middleware/kubernetes.js
@@ -13,14 +13,39 @@ export default function kubernetesMiddleware({
   kubeBroadcasterTemplate,
   kubeOrchestratorTemplate,
 }) {
+  const cache = {}
   const kc = new k8s.KubeConfig()
   kc.loadFromDefault()
 
   const kubeApi = kc.makeApiClient(k8s.CoreV1Api)
 
+  // Try to read namespaced endpoints, return most recent data if we can't
+  const cachedReadNamespacedEndpoints = async (kubeService, kubeNamespace) => {
+    const cacheKey = `${kubeService}%${kubeNamespace}`
+    try {
+      const endpoints = await timeout(5000, () =>
+        kubeApi.readNamespacedEndpoints(kubeService, kubeNamespace),
+      )
+      cache[cacheKey] = endpoints
+      return endpoints
+    } catch (e) {
+      if (cache[cacheKey]) {
+        console.log(
+          'WARNING: kubernetes control plane unavailable, returning cached data',
+        )
+        return cache[cacheKey]
+      }
+      console.log(
+        'ERROR: kubernetes control plane unavailable, cached data unavailable, cannot provide orchestrator list',
+      )
+      throw e
+    }
+  }
+
   const getBroadcasters = async () => {
-    const endpoints = await timeout(5000, () =>
-      kubeApi.readNamespacedEndpoints(kubeBroadcasterService, kubeNamespace),
+    const endpoints = await cachedReadNamespacedEndpoints(
+      kubeBroadcasterService,
+      kubeNamespace,
     )
     const ret = []
     if (endpoints.body && endpoints.body.subsets) {
@@ -43,8 +68,9 @@ export default function kubernetesMiddleware({
   }
 
   const getOrchestrators = async () => {
-    const endpoints = await timeout(5000, () =>
-      kubeApi.readNamespacedEndpoints(kubeOrchestratorService, kubeNamespace),
+    const endpoints = await cachedReadNamespacedEndpoints(
+      kubeOrchestratorService,
+      kubeNamespace,
     )
     const ret = []
     if (endpoints.body && endpoints.body.subsets) {

--- a/packages/api/src/middleware/kubernetes.js
+++ b/packages/api/src/middleware/kubernetes.js
@@ -42,7 +42,6 @@ export default function kubernetesMiddleware({
       )
       throw e
     }
-    throw new Error('???')
   }
 
   const getBroadcasters = async () => {

--- a/packages/api/src/util.js
+++ b/packages/api/src/util.js
@@ -4,10 +4,15 @@ export const timeout = (ms, fn) => {
       reject(Error('timed out'))
     }, ms)
 
-    fn().then((...ret) => {
-      clearTimeout(handle)
-      resolve(...ret)
-    })
+    fn()
+      .then((...ret) => {
+        clearTimeout(handle)
+        resolve(...ret)
+      })
+      .catch((err) => {
+        clearTimeout(handle)
+        reject(err)
+      })
   })
 }
 


### PR DESCRIPTION
Allows service to survive failure of the Kubernetes control plane by caching responses. We should create a Papertrail alert for this happening though.