### PR TITLE
Add `publicUrl` field to the object-store object

### DIFF
--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -588,7 +588,8 @@ app.post('/hook', async (req, res) => {
     return res.json({ errors: ['not found'] })
   }
   let objectStore,
-    recordObjectStore = undefined
+    recordObjectStore = undefined,
+    recordObjectStoreUrl
   if (stream.objectStoreId) {
     const os = await req.store.get(
       `object-store/${stream.objectStoreId}`,
@@ -630,6 +631,9 @@ app.post('/hook', async (req, res) => {
       })
     }
     recordObjectStore = ros.url
+    if (ros.publicUrl) {
+      recordObjectStoreUrl = ros.publicUrl
+    }
   }
 
   // Use our parents' playbackId for sharded playback
@@ -645,6 +649,7 @@ app.post('/hook', async (req, res) => {
     profiles: stream.profiles,
     objectStore,
     recordObjectStore,
+    recordObjectStoreUrl,
   })
 })
 

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -263,6 +263,10 @@ components:
           description: Livepeer-compatible object store URL
           example: s3://access-key:secret-key@us-west-2/bucket-name
           writeOnly: true
+        publicUrl:
+          type: string
+          description: Public URL at which data in this object storage can be accessed
+          example: https://reg-rec.livepeer.live/some/path
         id:
           type: string
           example: 09F8B46C-61A0-4254-9875-F71F4C605BC7


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Adds `publicUrl` field to the object-store object
`publicUrl` is a URL at which data stored to the object store can be publicly accessed.
For example, data stored to https://storage.googleapis.com/record-test/b64d415a-cc4b-465d-9faf-09a0132c2759/darkbook.lan/source/0.ts, but can be accessed from http://store.livepeer.live/record-test/b64d415a-cc4b-465d-9faf-09a0132c2759/nodeid/source/0.ts

Needed for stream recordings
https://github.com/livepeer/go-livepeer/pull/1582
