### PR TITLE
display spinner while ingest pair urls are loading

### DIFF
--- a/packages/www/pages/app/stream/[id].tsx
+++ b/packages/www/pages/app/stream/[id].tsx
@@ -297,6 +297,9 @@ export default () => {
                     </A>
                   </Link>
                 </Box>
+                {!ingest.length && (
+                  <Spinner sx={{ mb: 3, width: 32, height: 32 }} />
+                )}
                 {ingest.map((_, i) => {
                   return (
                     <>


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR displays a spinner while ingest pairs are loading.

**Screenshots (optional):**
<img width="751" alt="Screen Shot 2020-11-24 at 1 26 33 PM" src="https://user-images.githubusercontent.com/555740/100136372-f78aca80-2e58-11eb-96cc-cd9c020e79d7.png">
