### PR TITLE
User session

### DIFF
--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -225,6 +225,23 @@ app.post(
     const id = stream.playbackId.slice(0, 4) + uuid().slice(4)
     const createdAt = Date.now()
 
+    // find previous sessions to form 'user' session
+    const query = []
+      query.push(sql`data->>'parentId' = ${stream.id}`)
+
+    if (!all) {
+      query.push(sql`data->>'deleted' IS NULL`)
+    }
+    if (streamsonly) {
+    } else if (sessionsonly) {
+      query.push(sql`data->>'parentId' IS NOT NULL`)
+    }
+    if (active) {
+      query.push(sql`data->>'isActive' = 'true'`)
+    }
+
+    const [output, newCursor] = await db.stream.find(query, { cursor, limit })
+
     const doc = wowzaHydrate({
       ...req.body,
       kind: 'stream',

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -120,11 +120,17 @@ components:
           readOnly: true
           description: Timestamp (in milliseconds) at which stream object was created
           example: 1587667174725
+          index: true
         parentId:
           type: string
           example: de7818e7-610a-4057-8f6f-b785dc1e6f88
           description: Points to parent stream object
           index: true
+        previousSessions:
+          description: Ids of the previous sessions which are part of `user's` session
+          type: array
+          items:
+            type: string
         streamKey:
           type: string
           example: hgebdhhigq

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -91,6 +91,7 @@ components:
         lastSeen:
           type: number
           example: 1587667174725
+          index: true
         sourceSegments:
           type: number
           example: 1
@@ -126,6 +127,9 @@ components:
           example: de7818e7-610a-4057-8f6f-b785dc1e6f88
           description: Points to parent stream object
           index: true
+        partialSession:
+          description: Indicates that this is not final object of `user's` session
+          type: boolean
         previousSessions:
           description: Ids of the previous sessions which are part of `user's` session
           type: array

--- a/packages/api/src/store/table.ts
+++ b/packages/api/src/store/table.ts
@@ -70,7 +70,7 @@ export default class Table<T extends DBObject> {
     query: FindQuery | Array<SQLStatement> = {},
     opts: FindOptions = {},
   ): Promise<[Array<T>, string]> {
-    const { cursor = '', limit = 100, useReplica = true } = opts
+    const { cursor = '', limit = 100, useReplica = true, order = 'id ASC' } = opts
 
     const q = sql`SELECT * FROM `.append(this.name)
     let filters = []
@@ -101,7 +101,7 @@ export default class Table<T extends DBObject> {
       q.append(' ')
     }
 
-    q.append(' ORDER BY id ASC')
+    q.append(` ORDER BY ${order}`)
     q.append(sql` LIMIT ${limit}`)
 
     let res

--- a/packages/api/src/store/types.ts
+++ b/packages/api/src/store/types.ts
@@ -22,6 +22,7 @@ export interface QueryOptions {
 export interface FindOptions extends QueryOptions {
   cursor?: string
   limit?: number
+  order?: string
 }
 
 export interface GetOptions {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Record needed information to restore 'user' session out of
consecutive transcoding sessions

**Specific updates (required)**
- add 'previousSessions' field to the Stream object
- when new Session Stream object created check if there is exist
another session object for the same stream that is no longer
than five minutes old - then new session is considered to be part
of the same 'user' session. So new object's `previousSessions`
field gets populated with id of the previous session object
- return 'previousSessions' field in the /hook endpoint


<!--- List out all significant updates your code introduces -->

## -

-

**How did you test each of these updates (required)**
manually

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
