### PR TITLE
Add 'region' field to the stream object,

### DIFF
--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -273,6 +273,10 @@ app.post(
         })
       }
     }
+    let region
+    if (req.config.ownRegion) {
+      region = req.config.ownRegion
+    }
 
     const doc = wowzaHydrate({
       ...req.body,
@@ -286,6 +290,7 @@ app.post(
       createdAt,
       parentId: stream.id,
       previousSessions,
+      region,
     })
 
     doc.profiles = hackMistSettings(

--- a/packages/api/src/parse-cli.js
+++ b/packages/api/src/parse-cli.js
@@ -176,6 +176,10 @@ export default function parseCli(argv) {
         'base-stream-name': {
           describe:
             'base stream name to be used in wildcard-based routing scheme.',
+        },
+        'own-region': {
+          describe:
+            "identify region in which this server runs (fra, mdw, etc)",
           type: 'string',
         },
       })

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -248,6 +248,10 @@ components:
           type: object
           additionalProperties:
             type: string
+        region:
+          type: string
+          example: fra
+          description: Region in which this session object was created
 
     error:
       required:


### PR DESCRIPTION

<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
Adds 'region' field to the stream object,
populate it at creation of session object
This will allow to track region in which stream happened.

<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**
- Added '-own-region' cli option
- Added 'region' field to the 'stream' object. This field gets populate in the session creation endpoint

<!--- List out all significant updates your code introduces -->

## -

-

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
