### PR TITLE
Do not use replica if /setactive sets active to true

### DIFF
--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -385,7 +385,8 @@ app.post('/', authMiddleware({}), validatePost('stream'), async (req, res) => {
 app.put('/:id/setactive', authMiddleware({}), async (req, res) => {
   const { id } = req.params
   // logger.info(`got /setactive/${id}: ${JSON.stringify(req.body)}`)
-  const stream = await req.store.get(`stream/${id}`, false)
+  const useReplica = !req.body.active
+  const stream = await db.stream.get(id, { useReplica })
   if (!stream || stream.deleted || !req.user.admin) {
     res.status(404)
     return res.json({ errors: ['not found'] })


### PR DESCRIPTION

**What does this pull request do? Explain your changes. (required)**
If stream starts streaming right after creation sometimes stream object is not propagated to replica yet, so /setactive handler can't find it and rejects stream.


**Specific updates (required)**
Do not use replica /setactive sets stream to active

<!--- List out all significant updates your code introduces -->

## -

-

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
