### PR TITLE
API and UI for 'user' sessions with recordings

### DIFF
--- a/packages/api/src/store/table.ts
+++ b/packages/api/src/store/table.ts
@@ -70,7 +70,8 @@ export default class Table<T extends DBObject> {
     query: FindQuery | Array<SQLStatement> = {},
     opts: FindOptions = {},
   ): Promise<[Array<T>, string]> {
-    const { cursor = '', limit = 100, useReplica = true, order = 'id ASC' } = opts
+    const { cursor = '', useReplica = true, order = 'id ASC' } = opts
+    const limit = opts.hasOwnProperty('limit') ? opts.limit : 100
 
     const q = sql`SELECT * FROM `.append(this.name)
     let filters = []
@@ -102,7 +103,9 @@ export default class Table<T extends DBObject> {
     }
 
     q.append(` ORDER BY ${order}`)
-    q.append(sql` LIMIT ${limit}`)
+    if (limit) {
+      q.append(sql` LIMIT ${limit}`)
+    }
 
     let res
     if (useReplica) {

--- a/packages/www/hooks/use-api.tsx
+++ b/packages/www/hooks/use-api.tsx
@@ -502,11 +502,11 @@ const makeContext = (state: ApiState, setState) => {
     },
 
     async getStreamSessions(id): Promise<Array<Stream>> {
-      const [res, streams] = await context.fetch(`/stream/sessions/${id}`);
+      const [res, streams] = await context.fetch(`/stream/${id}/sessions`);
       if (res.status !== 200) {
         throw new Error(streams);
       }
-      return streams.sort((a, b) => (b.lastSeen || 0) - (a.lastSeen || 0));
+      return streams;
     },
 
     async deleteStream(id: string): Promise<void> {

--- a/packages/www/pages/app/stream/[id].tsx
+++ b/packages/www/pages/app/stream/[id].tsx
@@ -92,7 +92,7 @@ const Cell = ({ children }) => {
   return <Box sx={{ m: "0.4em" }}>{children}</Box>;
 };
 
-export default () => {
+const ID = () => {
   useLoggedIn();
   const {
     user,
@@ -489,7 +489,7 @@ export default () => {
                 Delete
               </Button>
             </Flex>
-            {/* <StreamSessionsTable streamId={stream.id} /> */}
+            {user.admin ? <StreamSessionsTable streamId={stream.id} /> : null}
           </>
         ) : notFound ? (
           <Box>Not found</Box>
@@ -503,3 +503,4 @@ export default () => {
     </TabbedLayout>
   );
 };
+export default ID;


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
UI for recordings

**Specific updates (required)**
- adds /stream/:streamId/sessions endpoint that returns 'user' session with recording urls	
- adds sessions table on stream info page which shows status (only if recording url is not ready) and recording url

**Screenshots (optional):**

![image](https://user-images.githubusercontent.com/2035357/102266184-c6199200-3f20-11eb-9386-026c97c65920.png)
![image](https://user-images.githubusercontent.com/2035357/102266398-0c6ef100-3f21-11eb-8356-c5353cb956a1.png)

