### PR TITLE
api:discovery auth webhook implementation for /api/broadcaster/hook

### DIFF
--- a/packages/api/src/app-router.js
+++ b/packages/api/src/app-router.js
@@ -53,6 +53,7 @@ export default async function makeApp(params) {
     orchestrators = "[]",
     broadcasters = "[]",
     ingest = "[]",
+    prices = "[]",
     insecureTestToken,
     firestoreCredentials,
     firestoreCollection,
@@ -111,7 +112,7 @@ export default async function makeApp(params) {
     );
   }
 
-  app.use(hardcodedNodes({ orchestrators, broadcasters, ingest }));
+  app.use(hardcodedNodes({ orchestrators, broadcasters, ingest, prices }))
 
   // Add a controller for each route at the /${httpPrefix} route
   const prefixRouter = Router(); // amalgamates our endpoints together and serves them out

--- a/packages/api/src/controllers/orchestrator.js
+++ b/packages/api/src/controllers/orchestrator.js
@@ -11,4 +11,23 @@ const getOrchestrators = async (req, res, next) => {
 app.get("/", getOrchestrators);
 app.get("/ext/:token", getOrchestrators);
 
+async function discoveryAuthWebhookHandler(req, res) {
+  const responseObj = {};
+  let prices = [];
+  try {
+    prices = await req.getPrices();
+  } catch (err) {
+    return res.status(400).send({ message: err.message });
+  }
+  for (let i = 0; i < prices.length; i++) {
+    if (prices[i].address == req.body.id) {
+      responseObj["priceInfo"] = prices[i].priceInfo;
+      break;
+    }
+  }
+  return res.status(200).json(responseObj);
+}
+
+app.get("/hook/auth", discoveryAuthWebhookHandler);
+
 export default app;

--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -27,6 +27,7 @@ export default async function makeApp(params) {
     fallbackProxy,
     orchestrators,
     broadcasters,
+    prices,
     s3Url,
     s3UrlExternal,
     s3Access,

--- a/packages/api/src/middleware/hardcoded-nodes.js
+++ b/packages/api/src/middleware/hardcoded-nodes.js
@@ -7,14 +7,16 @@ export default function hardcodedNodes({
   broadcasters,
   orchestrators,
   ingest,
+  prices,
 }) {
   try {
     broadcasters = JSON.parse(broadcasters);
     orchestrators = JSON.parse(orchestrators);
     ingest = JSON.parse(ingest);
+    prices = JSON.parse(prices);
   } catch (e) {
     console.error(
-      "Error parsing LP_BROADCASTERS and LP_ORCHESTRATORS and LP_INGEST"
+      "Error parsing LP_BROADCASTERS, LP_ORCHESTRATORS, LP_INGEST and AND LP_PRICES"
     );
     throw e;
   }
@@ -27,6 +29,9 @@ export default function hardcodedNodes({
     }
     if (!req.getIngest) {
       req.getIngest = async () => ingest;
+    }
+    if (!req.prices) {
+      req.getPrices = async () => prices;
     }
     next();
   };

--- a/packages/api/src/middleware/hardcoded-nodes.test.js
+++ b/packages/api/src/middleware/hardcoded-nodes.test.js
@@ -45,12 +45,23 @@ describe("kubernetes middleware", () => {
     },
   ];
 
+  const prices = [
+    {
+      address: "0xfoo",
+      priceInfo: {
+        pricePerUnit: "100",
+        pixelsPerUnit: "20",
+      },
+    },
+  ];
+
   beforeEach(async () => {
     req = {};
     middleware = hardcodedNodes({
       broadcasters: JSON.stringify(broadcasters),
       orchestrators: JSON.stringify(orchestrators),
       ingest: JSON.stringify(ingest),
+      prices: JSON.stringify(prices),
     });
     await new Promise((resolve) => {
       middleware(req, {}, resolve);
@@ -67,11 +78,21 @@ describe("kubernetes middleware", () => {
     expect(response).toEqual(orchestrators);
   });
 
+  it("should return ingest from getIngest()", async () => {
+    expect(await req.getIngest()).toEqual(ingest);
+  });
+
+  it("should return prices from getPrices()", async () => {
+    expect(await req.getPrices()).toEqual(prices);
+  });
+
   it("should throw an error with bad JSON", async () => {
     expect(() => {
       hardcodedNodes({
         broadcasters: "this is not json",
         orchestrators: "neither is this",
+        ingest: "definitely not this",
+        prices: "nor this",
       });
     }).toThrow();
   });

--- a/packages/api/src/parse-cli.js
+++ b/packages/api/src/parse-cli.js
@@ -116,6 +116,12 @@ export default function parseCli(argv) {
           type: "string",
           default: "[]",
         },
+        prices: {
+          describe:
+          'hardcoded list of prices for broadcasters to return from /api/orchestrator/hook/auth',
+          type: 'string',
+          default: '[]'
+        },
         supportAddr: {
           describe:
             "email address where outgoing emails originate. should be of the form name/email@example.com",


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Implements a discovery webhook for broadcasters. The current implementation returns a 200 OK for all broadcasters. If provided as `LP_BROADCASTERS` will also return a response object with the set price info.

- returns 200 OK with an [optional response](https://github.com/livepeer/go-livepeer/blob/a5fa25aec93d01218cb36125d0690fb067d16b4c/server/rpc.go#L325) if a broadcaster is authenticated
- returns another status if broadcaster is not authenticated (e.g. blacklisted)

relies on `LP_BROADCASTERS` to be extended when this endpoint is used in our setup 

```
    LP_BROADCASTERS: |-
      [
        {
          "address": "https://mdw.livepeer.monster",
          "eth": {
            "address": "0xc3c7c4c8f7061b7d6a72766eee5359fe4f36e61e",
            "priceInfo": {"pricePerUnit: "0", pixelsPerUnit: "0"}
          }
        }
      ]
```

**Does this pull request close any open issues?**
Fixes #205 

