### PR TITLE
fix hot reloading

### DIFF
--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -76,6 +76,7 @@ export default async function makeApp(params) {
   const whitelist = [
     "https://livepeer.com",
     "https://livepeer.monster",
+    "http://localhost:3000",
     /\.livepeerorg.vercel\.app$/,
     /\.livepeerorg.now\.sh$/,
   ];

--- a/packages/www/hooks/use-api.tsx
+++ b/packages/www/hooks/use-api.tsx
@@ -125,7 +125,7 @@ const makeContext = (state: ApiState, setState) => {
           : `/api${url}`;
 
       if (process.env.NODE_ENV === "development") {
-        endpoint = `http://0.0.0.0:3004/api${url}`;
+        endpoint = `http://localhost:3004/api${url}`;
       }
 
       const res = await fetch(endpoint, {

--- a/packages/www/hooks/use-api.tsx
+++ b/packages/www/hooks/use-api.tsx
@@ -116,12 +116,18 @@ const makeContext = (state: ApiState, setState) => {
       if (state.token && !headers.has("authorization")) {
         headers.set("authorization", `JWT ${state.token}`);
       }
-      const endpoint =
+
+      let endpoint =
         window.location.hostname.includes("livepeer.monster") ||
         window.location.hostname.includes("livepeerorg.vercel.app") ||
         window.location.hostname.includes("livepeerorg.now.sh")
           ? `https://livepeer.monster/api${url}`
           : `/api${url}`;
+
+      if (process.env.NODE_ENV === "development") {
+        endpoint = `http://0.0.0.0:3004/api${url}`;
+      }
+
       const res = await fetch(endpoint, {
         ...opts,
         headers,

--- a/packages/www/package.json
+++ b/packages/www/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prepare": "yarn run md-docs && cd ../api && yarn run prepare",
     "md-docs": "npx swagger-markdown -i ../api/src/schema/schema.yaml -o ./reference-api.md",
-    "dev": "next --port=3008",
+    "dev": "next",
     "build": "next build",
     "start": "next start",
     "postbuild": "next-sitemap"


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Serving the frontend over a proxy (port 3004) while in dev mode currently breaks Next.js hot reloading which makes frontend development a pain. This PR fixes that issue by making API requests using an absolute url while in dev mode and accessing the frontend over the default next port (3000).