### PR TITLE
set useReplica to false inside usage endpoint

### DIFF
--- a/packages/api/src/controllers/usage.js
+++ b/packages/api/src/controllers/usage.js
@@ -17,7 +17,7 @@ app.get("/", authMiddleware({ anyAdmin: true }), async (req, res) => {
     fromTime,
     toTime,
     {
-      useReplica: false,
+      useReplica: true,
     }
   );
 

--- a/packages/api/src/controllers/usage.js
+++ b/packages/api/src/controllers/usage.js
@@ -34,7 +34,10 @@ app.post(
     let toTime = +new Date();
 
     let lastUpdatedRow = (
-      await db.usage.find({}, { limit: 1, order: "data->>'date' DESC" })
+      await db.usage.find(
+        {},
+        { limit: 1, order: "data->>'date' DESC", useReplica: false }
+      )
     )[0];
 
     // get last updated date from cache

--- a/packages/api/src/controllers/usage.js
+++ b/packages/api/src/controllers/usage.js
@@ -17,7 +17,7 @@ app.get("/", authMiddleware({ anyAdmin: true }), async (req, res) => {
     fromTime,
     toTime,
     {
-      useReplica: true,
+      useReplica: false,
     }
   );
 
@@ -46,7 +46,7 @@ app.post(
     toTime = new Date().getTime();
 
     let usageHistory = await db.stream.usageHistory(fromTime, toTime, {
-      useReplica: true,
+      useReplica: false,
     });
 
     // store each day of usage


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR sets `useReplica` to `false` in the new usage endpoint in an attempt to fix the `conflict with recovery` postgres error being thrown.