### PR TITLE
fix usage id

### DIFF
--- a/packages/api/src/store/stream-table.ts
+++ b/packages/api/src/store/stream-table.ts
@@ -99,7 +99,7 @@ export default class StreamTable extends Table<Stream> {
       for (const row of res.rows) {
         let dayStartTimestamp = new Date(row.day).setUTCHours(0, 0, 0, 0);
         usage.push({
-          id: new Date(row.day).toLocaleDateString("en-CA"),
+          id: new Date(row.day).toISOString().split("T")[0],
           date: dayStartTimestamp,
           sourceSegments: +row.sourcesegments,
           transcodedSegments: +row.transcodedsegments,
@@ -142,7 +142,7 @@ export default class StreamTable extends Table<Stream> {
         } else {
           let dayStartTimestamp = new Date(row.day).setUTCHours(0, 0, 0, 0);
           usage.push({
-            id: new Date(row.day).toLocaleDateString("en-CA"),
+            id: new Date(row.day).toISOString().split("T")[0],
             date: dayStartTimestamp,
             sourceSegments: +row.sourcesegments,
             transcodedSegments: +row.transcodedsegments,


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR fixes the usage ID format so that it displays as `yyyy-mm-dd` rather then `m/d/yyyy`.