### PR TITLE
Add `createdAt` and other timestamp fields to user object

### DIFF
--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -660,6 +660,10 @@ app.put("/:id/setactive", authMiddleware({}), async (req, res) => {
     lastSeen: stream.lastSeen,
   });
 
+  db.user.update(stream.userId, {
+    lastStreamedAt: Date.now(),
+  });
+
   if (stream.parentId) {
     const pStream = await req.store.get(`stream/${id}`, false);
     if (pStream && !pStream.deleted) {

--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -670,6 +670,7 @@ app.put("/:id/setactive", authMiddleware({}), async (req, res) => {
       await db.stream.update(pStream.id, {
         isActive: stream.isActive,
         lastSeen: stream.lastSeen,
+        activeRegion: stream.isActive ? stream.region : undefined,
       });
     }
   }

--- a/packages/api/src/middleware/auth.js
+++ b/packages/api/src/middleware/auth.js
@@ -1,6 +1,7 @@
 import { InternalServerError, ForbiddenError } from "../store/errors";
 import jwt from "jsonwebtoken";
 import tracking from "./tracking";
+import { db } from "../store";
 
 /**
  * creates an authentication middleware that can be customized.
@@ -23,7 +24,7 @@ function authFactory(params) {
       }
       userId = tokenObject.userId;
       // track last seen
-      tracking.record(req.store, tokenObject);
+      tracking.recordToken(db, tokenObject);
     } else if (authToken.startsWith("JWT")) {
       const jwtToken = authToken.substr(4);
       try {
@@ -31,6 +32,7 @@ function authFactory(params) {
           audience: req.config.jwtAudience,
         });
         userId = verified.sub;
+        tracking.recordUser(db, userId);
       } catch (err) {
         throw new ForbiddenError(err.message);
       }

--- a/packages/api/src/middleware/tracking.js
+++ b/packages/api/src/middleware/tracking.js
@@ -1,15 +1,28 @@
 "use strict";
 
 const tracking = {
-  record: function record(store, tokenObject) {
-    tokenObject.lastSeen = Date.now();
-    store
-      .replace(tokenObject)
+  recordToken: function recordToken(db, tokenObject) {
+    db.apiToken
+      .update(tokenObject.id, {
+        lastSeen: Date.now(),
+      })
       .then((_) => {
         // all good
       })
       .catch((e) => {
-        console.log("tracking record error: ", e);
+        console.log("token tracking record error: ", e);
+      });
+  },
+  recordUser: function recordUser(db, userId) {
+    db.user
+      .update(userId, {
+        lastSeen: Date.now(),
+      })
+      .then((_) => {
+        // all good
+      })
+      .catch((e) => {
+        console.log("user tracking record error: ", e);
       });
   },
 };

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -276,6 +276,10 @@ components:
           type: string
           example: fra
           description: Region in which this session object was created
+        activeRegion:
+          type: string
+          example: fra
+          description: Region in which this stream was last time streamed
 
     error:
       required:

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -588,6 +588,33 @@ components:
         ccBrand:
           type: string
           example: 1234
+        createdAt:
+          type: number
+          readOnly: true
+          description:
+            Timestamp (in milliseconds) at which user object was created
+          example: 1587667174725
+        verifiedAt:
+          type: number
+          description:
+            Timestamp (in milliseconds) at which user object was verified
+          example: 1587667174725
+        planChangedAt:
+          type: number
+          description:
+            Timestamp (in milliseconds) at which user object was verified
+          example: 1587667174725
+        lastStreamedAt:
+          type: number
+          description:
+            Timestamp (in milliseconds) at which user streamed RTMP stream
+            last time
+          example: 1587667174725
+        lastSeen:
+          type: number
+          description:
+            Timestamp (in milliseconds) at which user's password was used
+          example: 1587667174725
     usage:
       type: object
       table: usage


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Add createdAt, verifiedAt, planChangedAt, lastStreamedAt, and lastSeen
fields to the user object

<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->


**Specific updates (required)**

## -

- **How did you test each of these updates (required)**
Manually

**Does this pull request close any open issues?**
Fixes #243 

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
