### PR TITLE
Update stream endpoint to support a userId param

### DIFF
--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -116,7 +116,7 @@ app.get("/", authMiddleware({}), async (req, res) => {
   }
 
   const query = parseFilters(fieldsMap, filters);
-  if (!all || all === "false") {
+  if (userId || !all || all === "false") {
     query.push(sql`stream.data->>'deleted' IS NULL`);
   }
   if (streamsonly && streamsonly !== "false") {
@@ -124,14 +124,15 @@ app.get("/", authMiddleware({}), async (req, res) => {
   } else if (sessionsonly && sessionsonly !== "false") {
     query.push(sql`stream.data->>'parentId' IS NOT NULL`);
   }
-  if (active && active !== "false") {
-    query.push(sql`stream.data->>'isActive' = 'true'`);
-  }
-  if (nonLivepeerOnly && nonLivepeerOnly !== "false") {
-    query.push(sql`users.data->>'email' NOT LIKE '%livepeer%'`);
-  }
   if (userId) {
     query.push(sql`stream.data->>'userId' = ${userId}`);
+  } else {
+    if (active && active !== "false") {
+      query.push(sql`stream.data->>'isActive' = 'true'`);
+    }
+    if (nonLivepeerOnly && nonLivepeerOnly !== "false") {
+      query.push(sql`users.data->>'email' NOT LIKE '%livepeer%'`);
+    }
   }
 
   order = parseOrder(fieldsMap, order);

--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -90,7 +90,7 @@ const fieldsMap = {
   "user.email": `users.data->>'email'`,
 };
 
-app.get("/", authMiddleware({ admin: true }), async (req, res) => {
+app.get("/", authMiddleware({}), async (req, res) => {
   let {
     limit,
     cursor,

--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -107,7 +107,8 @@ app.get("/", authMiddleware({}), async (req, res) => {
     limit = undefined;
   }
 
-  if (userId && req.user.admin !== true && req.user.id !== userId) {
+  if (req.user.admin !== true && (!userId || req.user.id !== userId)) {
+    // Not admin, and requesting all streams, or streams that don't belong to the user.
     res.status(403);
     return res.json({
       errors: ["user can only request information on their own streams"],

--- a/packages/api/src/controllers/stream.test.js
+++ b/packages/api/src/controllers/stream.test.js
@@ -373,8 +373,8 @@ describe("controllers/stream", () => {
       expect(res.status).toBe(403);
     });
 
-    it("should not get all streams for admin user", async () => {
-      client.apiKey = adminApiKey;
+    it("should not get all streams for non admin user", async () => {
+      client.apiKey = nonAdminApiKey;
       client.jwtAuth = null;
       const res = await client.get(`/stream`);
       expect(res.status).toBe(403);

--- a/packages/www/hooks/use-api.tsx
+++ b/packages/www/hooks/use-api.tsx
@@ -519,7 +519,7 @@ const makeContext = (state: ApiState, setState) => {
 
     async getStreams(userId): Promise<Array<Stream>> {
       const [res, streams] = await context.fetch(
-        `/stream/user/${userId}?streamsonly=1`
+        `/stream?userId=${userId}&streamsonly=1`
       );
       if (res.status !== 200) {
         throw new Error(streams);


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

<!-- A clear and concise description of what this pull request does. -->

- `/api/stream` now supports `userId` query param, that filters streams by that userId.
- User streams table now hits `/api/stream`. The old endpoint remains unchanged for backwards compatibility.

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

<!-- Fixes # -->

- closes #256 
- closes #257
- closes #258

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
