### PR TITLE
api: discovery auth webhook get->post request

### DIFF
--- a/packages/api/src/controllers/orchestrator.js
+++ b/packages/api/src/controllers/orchestrator.js
@@ -28,6 +28,6 @@ async function discoveryAuthWebhookHandler(req, res) {
   return res.status(200).json(responseObj);
 }
 
-app.get("/hook/auth", discoveryAuthWebhookHandler);
+app.post("/hook/auth", discoveryAuthWebhookHandler);
 
 export default app;


### PR DESCRIPTION
Updates the endpoint added in #209 to a `POST` one instead of `GET` as described in the [docs](https://github.com/livepeer/go-livepeer/blob/nv/transcode-auth/doc/rtmpwebhookauth.md#orchestrators)