### PR TITLE
add '-supress-record-in-hook' command line option

### DIFF
--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -897,7 +897,7 @@ app.post("/hook", async (req, res) => {
       stream.recordObjectStoreId = req.config.recordObjectStoreId;
     }
   }
-  if (stream.recordObjectStoreId) {
+  if (stream.recordObjectStoreId && !req.config.supressRecordInHook) {
     const ros = await db.objectStore.get(stream.recordObjectStoreId);
     if (!ros) {
       res.status(500);

--- a/packages/api/src/parse-cli.js
+++ b/packages/api/src/parse-cli.js
@@ -179,6 +179,11 @@ export default function parseCli(argv) {
             "id of the object store that should be used for `record: true` requests that don't otherwise have an os",
           type: "string",
         },
+        "supress-record-in-hook": {
+          describe:
+            "do not return record object store in /stream/hook response, even if it is specified in the stream object",
+          type: "boolean",
+        },
         "base-stream-name": {
           describe:
             "base stream name to be used in wildcard-based routing scheme.",


### PR DESCRIPTION

<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
add '-supress-record-in-hook' command line option
setting to true prevents returning record store credentials
in /stream/hook
Need to prevent secondary broadcasters from doing recording.


<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

## -

- **How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**
Fixes livepeer/go-livepeer#1767

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
