### PR TITLE
For 'user' session always return same id

### DIFF
--- a/packages/api/src/controllers/helpers.js
+++ b/packages/api/src/controllers/helpers.js
@@ -292,3 +292,20 @@ export function parseFilters(fieldsMap, val) {
   }
   return q;
 }
+
+export function pathJoin2(p1, p2) {
+  if (!p1) {
+    return p2;
+  }
+  if (p1[p1.length - 1] === "/") {
+    p1 = p1.slice(0, p1.length - 1);
+  }
+  if (p2 && p2[0] === "/") {
+    p2 = p2.slice(1);
+  }
+  return p1 + "/" + (p2 || "");
+}
+
+export function pathJoin(...items) {
+  return items.reduce(pathJoin2, "");
+}

--- a/packages/api/src/store/stream-table.ts
+++ b/packages/api/src/store/stream-table.ts
@@ -272,4 +272,19 @@ export default class StreamTable extends Table<Stream> {
       ...obj
     }
   }
+
+  removePrivateFields(obj: Stream): Stream {
+    for (const fn of privateFields) {
+      delete obj[fn];
+    }
+    return obj;
+  }
+
+  removePrivateFieldsMany(objs: Array<Stream>): Array<Stream> {
+    return objs.map(this.removePrivateFields);
+  }
+
 }
+
+const privateFields = ["recordObjectStoreId", "previousSessions",
+  "partialSession", "previousStats", "lastSessionId", 'userSessionCreatedAt'];

--- a/packages/api/src/test-server.js
+++ b/packages/api/src/test-server.js
@@ -36,6 +36,9 @@ params.supportAddr = supportAddr;
 params.sendgridTemplateId = sendgridTemplateId;
 params.sendgridApiKey = sendgridApiKey;
 params.postgresUrl = `postgresql://postgres@127.0.0.1/test_${Date.now()}`;
+params.recordObjectStoreId = "mock_store";
+params.ingest =
+  '[{"ingest": "rtmp://test/live","playback": "https://test/hls","base": "https://test"}]';
 
 if (!params.insecureTestToken) {
   params.insecureTestToken = uuid();


### PR DESCRIPTION


**What does this pull request do? Explain your changes. (required)**
For 'user' session always return same id and createdAt,
also return statistics (fields   "sourceBytes", "transcodedBytes",
"sourceSegments", "transcodedSegments", "sourceSegmentsDuration",
"transcodedSegmentsDuration") combined for all 'user' session.


**Specific updates (required)**

## -

- **How did you test each of these updates (required)**
Unit test


**Does this pull request close any open issues?**
Fixes #287 #286 
**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
