### PR TITLE
api: fix orchestrator discovery auth webhook id check

### DIFF
--- a/packages/api/src/controllers/orchestrator.js
+++ b/packages/api/src/controllers/orchestrator.js
@@ -20,7 +20,7 @@ async function discoveryAuthWebhookHandler(req, res) {
     return res.status(400).send({ message: err.message });
   }
   for (let i = 0; i < prices.length; i++) {
-    if (prices[i].address == req.body.id) {
+    if (prices[i].address.toLowerCase() == req.body.id.toLowerCase()) {
       responseObj["priceInfo"] = prices[i].priceInfo;
       break;
     }


### PR DESCRIPTION

**What does this pull request do? Explain your changes. (required)**

In the handler for the orchestrator discovery auth webhook, convert both the address from `LP_PRICES` and the id from the request body to lowercase 

Fixes #293 

