### PR TITLE
Suspend streams

### DIFF
--- a/packages/api/src/controllers/mist-api.js
+++ b/packages/api/src/controllers/mist-api.js
@@ -1,0 +1,110 @@
+import logger from "../logger";
+import fetch from "isomorphic-fetch";
+import crypto from "crypto";
+import querystring from "querystring";
+
+let challengeResponse;
+let challenge;
+
+function hashChallenge(authChallenge, password) {
+  const passHashed = crypto.createHash("md5").update(password).digest("hex");
+  challengeResponse = crypto
+    .createHash("md5")
+    .update(passHashed + authChallenge)
+    .digest("hex");
+  challenge = authChallenge;
+}
+
+export async function listActiveStreams(mistHost, mistPort, login, password) {
+  try {
+    const req = {
+      active_streams: 1,
+    };
+    if (challengeResponse) {
+      req.authorize = {
+        username: login,
+        password: challengeResponse,
+      };
+    }
+    const params = {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: querystring.encode({ command: JSON.stringify(req) }),
+    };
+    logger.info(
+      `requesting active streams list with request ${JSON.stringify(
+        req,
+        null,
+        2
+      )}`
+    );
+    const res1 = await fetch(`http://${mistHost}:${mistPort}/api2`, params);
+
+    if (res1.status != 200) {
+      logger.error(`Unexpected status=${res1.status}`);
+      return false;
+    }
+    const body = await res1.json();
+    const authStatus = ((body || {}).authorize || {}).status;
+    if (authStatus === "CHALL") {
+      hashChallenge(((body || {}).authorize || {}).challenge, password);
+      return await listActiveStreams(mistHost, mistPort, login, password);
+    } else if (authStatus !== "OK") {
+      logger.error(`Unexpected authorize status=${authStatus}`);
+      return [];
+    }
+    const activeStreams = (body || {}).active_streams;
+    return Array.isArray(activeStreams) ? activeStreams : [];
+  } catch (e) {
+    console.error(e);
+    return [];
+  }
+}
+
+export async function terminateStream(
+  mistHost,
+  mistPort,
+  streamName,
+  login,
+  password
+) {
+  try {
+    const req = {
+      nuke_stream: streamName,
+    };
+    if (challengeResponse) {
+      req.authorize = {
+        username: login,
+        password: challengeResponse,
+      };
+    }
+    const params = {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: querystring.encode({ command: JSON.stringify(req) }),
+    };
+    const res1 = await fetch(`http://${mistHost}:${mistPort}/api2`, params);
+
+    if (res1.status != 200) {
+      logger.error(`Unexpected status=${res1.status}`);
+      return false;
+    }
+    const body = await res1.json();
+    const authStatus = ((body || {}).authorize || {}).status;
+    if (authStatus === "CHALL") {
+      hashChallenge(((body || {}).authorize || {}).challenge, password);
+      return await nukeStream(mistHost, mistPort, streamName, login, password);
+    } else if (authStatus !== "OK") {
+      logger.error(`Unexpected authorize status=${authStatus}`);
+      return false;
+    }
+  } catch (e) {
+    console.error(e);
+    return false;
+  }
+  return true;
+}

--- a/packages/api/src/parse-cli.js
+++ b/packages/api/src/parse-cli.js
@@ -196,6 +196,19 @@ export default function parseCli(argv) {
           describe: "url of the Consul agent",
           type: "string",
         },
+        "mist-port": {
+          describe: "port of the Mist server",
+          default: 4242,
+          type: "number",
+        },
+        "mist-username": {
+          describe: "username for Mist server",
+          type: "string",
+        },
+        "mist-password": {
+          describe: "password for Mist server",
+          type: "string",
+        },
       })
       .help()
       .parse(argv)

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -285,6 +285,9 @@ components:
         mistHost:
           type: string
           description: Hostname of the Mist server that processes that stream
+        suspended:
+          type: boolean
+          description: If currently suspended
 
     error:
       required:

--- a/packages/api/src/store/stream-table.ts
+++ b/packages/api/src/store/stream-table.ts
@@ -292,6 +292,7 @@ export default class StreamTable extends Table<Stream> {
       lastSeen: 0,
       isActive: false,
       record: false, // hide until recording feature gets out of beta
+      suspended: false,
       sourceSegments: 0,
       transcodedSegments: 0,
       sourceSegmentsDuration: 0,
@@ -302,18 +303,25 @@ export default class StreamTable extends Table<Stream> {
     }
   }
 
-  removePrivateFields(obj: Stream): Stream {
+  removePrivateFields(obj: Stream, isAdmin: boolean = false): Stream {
     for (const fn of privateFields) {
       delete obj[fn];
+    }
+    if (!isAdmin) {
+      for (const fn of adminOnlyFields) {
+        delete obj[fn];
+      }
     }
     return obj;
   }
 
-  removePrivateFieldsMany(objs: Array<Stream>): Array<Stream> {
-    return objs.map(this.removePrivateFields);
+  removePrivateFieldsMany(objs: Array<Stream>, isAdmin: boolean = false): Array<Stream> {
+    return objs.map(o => this.removePrivateFields(o, isAdmin));
   }
 
 }
+
+const adminOnlyFields = ["mistHost", "broadcasterHost"];
 
 const privateFields = ["recordObjectStoreId", "previousSessions",
   "partialSession", "previousStats", "lastSessionId", 'userSessionCreatedAt'];

--- a/packages/www/components/AdminStreamsTable/index.tsx
+++ b/packages/www/components/AdminStreamsTable/index.tsx
@@ -59,6 +59,13 @@ const AdminStreamsTable = ({ id }: { id: string }) => {
           return cell.value ? "Active" : "Idle";
         },
       },
+      {
+        Header: "Suspended",
+        accessor: "suspended",
+        Cell: (cell) => {
+          return cell.value ? "Suspended" : "Normal";
+        },
+      },
     ],
     [nextCursor, lastFilters]
   );

--- a/packages/www/components/ConfirmationModal/index.tsx
+++ b/packages/www/components/ConfirmationModal/index.tsx
@@ -1,0 +1,48 @@
+import Modal from "../Modal";
+import { Box, Button, Flex, Spinner } from "@theme-ui/components";
+import { FunctionComponent, useState } from "react";
+
+type ConfirmationModalProps = {
+  title?: string;
+  actionText: string;
+  onClose: Function;
+  onAction: Function;
+  numStreamsToDelete?: number;
+};
+
+const ConfirmationModal: FunctionComponent<ConfirmationModalProps> = ({
+  title = "Are you sure?",
+  onClose,
+  onAction,
+  actionText,
+  children,
+}) => {
+  const [showWheel, setShowWheel] = useState(false);
+  return (
+    <Modal onClose={onClose}>
+      <h3>{title}</h3>
+      <Box sx={{ my: 3 }}>{children}</Box>
+      <Flex sx={{ justifyContent: "flex-end" }}>
+        <Button
+          type="button"
+          variant="outlineSmall"
+          onClick={onClose}
+          sx={{ mr: 2 }}>
+          Cancel
+        </Button>
+        {showWheel ? (
+          <Spinner></Spinner>
+        ) : (
+        <Button type="button" variant="primarySmall" onClick={() => {
+          setShowWheel(true);
+          onAction();
+        }}>
+          {actionText}
+        </Button>
+        )}
+      </Flex>
+    </Modal>
+  );
+};
+
+export default ConfirmationModal;

--- a/packages/www/components/DeleteStreamModal/index.tsx
+++ b/packages/www/components/DeleteStreamModal/index.tsx
@@ -8,7 +8,7 @@ type DeleteStreamModalProps = {
   numStreamsToDelete?: number;
 };
 
-export default ({
+const DeleteStreamModal = ({
   streamName,
   onClose,
   onDelete,
@@ -39,3 +39,5 @@ export default ({
     </Modal>
   );
 };
+
+export default DeleteStreamModal;

--- a/packages/www/components/StreamSessionsTable/index.tsx
+++ b/packages/www/components/StreamSessionsTable/index.tsx
@@ -27,6 +27,7 @@ const StreamSessionsTable = ({
 }) => {
   const [streamsSessions, setStreamsSessions] = useState([]);
   const { user, getStreamSessions } = useApi();
+  const [sessionsLoading, setSessionsLoading] = useState(false);
   useEffect(() => {
     getStreamSessions(streamId, undefined, 0)
       .then(([streams, nextCursor]) => {
@@ -40,11 +41,15 @@ const StreamSessionsTable = ({
       return;
     }
     const interval = setInterval(() => {
-      getStreamSessions(streamId, undefined, 0)
-        .then(([streams, nextCursor]) => {
-          setStreamsSessions(streams);
-        })
-        .catch((err) => console.error(err)); // todo: surface this
+      if (!sessionsLoading) {
+        setSessionsLoading(true);
+        getStreamSessions(streamId, undefined, 0)
+          .then(([streams, nextCursor]) => {
+            setStreamsSessions(streams);
+          })
+          .catch((err) => console.error(err)) // todo: surface this
+          .finally(()=> setSessionsLoading(false));
+      }
     }, 10000);
     return () => clearInterval(interval);
   }, [streamId, isVisible]);

--- a/packages/www/hooks/use-api.tsx
+++ b/packages/www/hooks/use-api.tsx
@@ -569,6 +569,42 @@ const makeContext = (state: ApiState, setState) => {
       return [streams, nextCursor];
     },
 
+    async suspendStream(id: string, suspended: boolean): Promise<void> {
+      const [res, body] = await context.fetch(`/stream/${id}/suspended`, {
+        method: "PATCH",
+        body: JSON.stringify({ suspended }),
+        headers: {
+          "content-type": "application/json",
+        },
+      });
+      if (res.status !== 204) {
+        if (body && body.errors) {
+          throw new Error(body.errors);
+        }
+        throw new Error(body);
+      }
+      if (body && body.errors) {
+        throw new Error(body.errors);
+      }
+      return;
+    },
+
+    async terminateStream(id: string): Promise<boolean> {
+      const [res, body] = await context.fetch(`/stream/${id}/terminate`, {
+        method: "DELETE",
+      });
+      if (res.status !== 200) {
+        if (body && body.errors) {
+          throw new Error(body.errors);
+        }
+        throw new Error(body);
+      }
+      if (body && body.errors) {
+        throw new Error(body.errors);
+      }
+      return body.result;
+    },
+
     async deleteStream(id: string): Promise<void> {
       const [res, body] = await context.fetch(`/stream/${id}`, {
         method: "DELETE",

--- a/packages/www/lib/theme.tsx
+++ b/packages/www/lib/theme.tsx
@@ -179,6 +179,15 @@ export const theme = {
         boxShadow: "0px 0px 0px 3px rgba(148, 60, 255, 0.3)",
       },
     },
+    close: {
+      color: 'primary',
+    },
+    'close-info': {
+      color: 'primary',
+    },
+    'close-attention': {
+      color: 'background',
+    },
   },
   forms: {
     input: {
@@ -346,6 +355,23 @@ export const theme = {
       maxWidth: "100%",
     },
   },
+  alerts: {
+    attention: {
+      backgroundColor: 'red'
+    },
+    info: {
+      color: "#fff",
+      border: "2px solid #943CFF",
+      letterSpacing: "0",
+      display: "flex",
+      alignItems: "center",
+      background: "linear-gradient(-131deg, #ef00ff 0%, #7300ff 100%)",
+      WebkitBackgroundClip: "text",
+      WebkitTextFillColor: "transparent",
+      marginRight: "30px",
+
+    }
+  }
 };
 
 const ThemeProvider = memo(({ children, ...props }) => (


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Suspend streams
Terminate running live streams

@wohlner - I've named field `suspended` instead of `suspend` - it is more in line with other fields like `deleted`. But I can rename it to `suspend` if needed.


- **How did you test each of these updates (required)**
Manually

**Does this pull request close any open issues?**
Fixes #327

**Screenshots (optional):**
Suspend checkbox:
![image](https://user-images.githubusercontent.com/2035357/114324697-308bb900-9b34-11eb-964e-c190ba6e83ba.png)
---
Confirm dialog 1
![image](https://user-images.githubusercontent.com/2035357/114324710-3e413e80-9b34-11eb-81e0-06d8d7675c42.png)
---
Confirm dialog 2
![image](https://user-images.githubusercontent.com/2035357/114324718-4ac59700-9b34-11eb-9736-ef69fa08436d.png)
---

Admin-only button that will just stop running stream without suspending
![image](https://user-images.githubusercontent.com/2035357/114324728-603ac100-9b34-11eb-9ad3-c1c686375464.png)

---
'Suspended' column on admin's streams page
![image](https://user-images.githubusercontent.com/2035357/114324929-c07e3280-9b35-11eb-857f-1a21541d0bb7.png)

