### PR TITLE
Add `ingestType` field, set it on first use

### DIFF
--- a/packages/api/src/controllers/stream.test.js
+++ b/packages/api/src/controllers/stream.test.js
@@ -699,12 +699,103 @@ describe("controllers/stream", () => {
       expect(sessions[0].recordingUrl).toEqual(`https://test/recordings/${sess2r.id}/index.m3u8`);
     });
   });
+
+  describe("prevent misusage", () => {
+    let client, adminUser, adminToken, nonAdminUser, nonAdminToken;
+
+    beforeEach(async () => {
+      ({
+        client,
+        adminUser,
+        adminToken,
+        nonAdminUser,
+        nonAdminToken,
+      } = await setupUsers(server));
+    });
+
+    it("should prevent misusage for rtmp", async () => {
+      await server.store.create(mockStore);
+      // create stream
+      let res = await client.post("/stream", smallerStream);
+      expect(res.status).toBe(201);
+      const createdStream = await res.json();
+      expect(createdStream.ingestType).toBeUndefined();
+      // call setactive - should set ingestType to rtmp
+      res = await client.put(`/stream/${createdStream.id}/setactive`, { active: true });
+      expect(res.status).toBe(204);
+      res = await client.get(`/stream/${createdStream.id}`);
+      expect(res.status).toBe(200);
+      let csup = await res.json();
+      expect(csup.ingestType).toEqual("rtmp");
+      // now should reject http transcode
+      res = await client.post("/stream/hook", { url: `http://localhost/live/${createdStream.id}` });
+      expect(res.status).toBe(403);
+      res = await client.put(`/stream/${createdStream.id}/setactive`, { active: false });
+      expect(res.status).toBe(204);
+      res = await client.put(`/stream/${createdStream.id}/setactive`, { active: true });
+      expect(res.status).toBe(204);
+      // create session
+      res = await client.post(`/stream/${createdStream.id}/stream`, {
+        ...smallerStream,
+        name: "sess2",
+      });
+      expect(res.status).toBe(201);
+      let sess2 = await res.json();
+      expect(sess2.parentId).toEqual(createdStream.id);
+      // should allow transcoding for session object
+      res = await client.post("/stream/hook", { url: `http://localhost/live/${sess2.id}` });
+      expect(res.status).toBe(200);
+    });
+
+    it("should prevent misusage for http", async () => {
+      await server.store.create(mockStore);
+      // create stream
+      let res = await client.post("/stream", smallerStream);
+      expect(res.status).toBe(201);
+      const createdStream = await res.json();
+      expect(createdStream.ingestType).toBeUndefined();
+      // allow http transcoding
+      res = await client.post("/stream/hook", { url: `http://localhost/live/${createdStream.id}` });
+      expect(res.status).toBe(200);
+      res = await client.get(`/stream/${createdStream.id}`);
+      expect(res.status).toBe(200);
+      let csup = await res.json();
+      expect(csup.ingestType).toEqual("http");
+      // now rtmp should be rejected
+      res = await client.put(`/stream/${createdStream.id}/setactive`, { active: true });
+      expect(res.status).toBe(403);
+      // in case someone created session object through API - it should be rejected too
+      // create session
+      res = await client.post(`/stream/${createdStream.id}/stream`, {
+        ...smallerStream,
+        name: "sess2",
+      });
+      expect(res.status).toBe(201);
+      let sess2 = await res.json();
+      expect(sess2.parentId).toEqual(createdStream.id);
+      res = await client.post("/stream/hook", { url: `http://localhost/live/${sess2.id}` });
+      expect(res.status).toBe(403);
+    });
+  });
 });
 
 const smallStream = {
   id: "231e7a49-8351-400b-a3df-0bcde13754e4",
   name: "small01",
   record: true,
+  profiles: [
+    {
+      fps: 0,
+      name: "240p0",
+      width: 426,
+      height: 240,
+      bitrate: 250000,
+    },
+  ],
+};
+
+const smallerStream = {
+  name: "smaller01",
   profiles: [
     {
       fps: 0,

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -288,6 +288,14 @@ components:
         suspended:
           type: boolean
           description: If currently suspended
+        ingestType:
+          type: string
+          description: 
+             Set on first usage. Once type is set, this object will not accept
+             ingests of other types.
+          enum:
+            - http
+            - rtmp
 
     error:
       required:

--- a/packages/www/pages/app/stream/[id].tsx
+++ b/packages/www/pages/app/stream/[id].tsx
@@ -845,6 +845,10 @@ const ID = () => {
                       {region} {broadcasterHost ? " / " + broadcasterHost : ""}
                       {stream && stream.mistHost ? " / " + stream.mistHost : ""}
                     </Cell>
+                    <Cell>Stream type</Cell>
+                    <Cell>
+                      {stream && stream.ingestType ? stream.ingestType : "not set yet"}
+                    </Cell>
                     {broadcasterPlaybackUrl ? (
                       <>
                         <Cell>Broadcaster playback</Cell>


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Allow streams to be used only for one ingest type

<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**
Adds `ingestType` field. On first use set it to `http` or `rtmp`. 
After it is set reject ingest of different type.


<!--- List out all significant updates your code introduces -->

## -

- **How did you test each of these updates (required)**
Unit tests

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**
Fixes #359 

<!-- Fixes # -->

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
