### PR TITLE
Fix some broken links on the docs landing page

### DIFF
--- a/packages/www/docs/guides/index.mdx
+++ b/packages/www/docs/guides/index.mdx
@@ -26,8 +26,8 @@ description: Livepeer.com Video Guides Overview
 
 <DocsGrid cols={3}>
     <NavigationCard href='/docs/guides/start-live-streaming/debug-live-stream-issues' title='Debug live stream issues'/>
-    <NavigationCard href='/docs/guides/using-livepeer-com-in-your-app' title='Using livepeer.com in your app' />
-    <NavigationCard href='/docs/guides/example-app' title='Clone an example application' />
+    <NavigationCard href='/docs/guides/using-livepeer-in-your-app' title='Using livepeer.com in your app' />
+    <NavigationCard href='/docs/guides/using-livepeer-in-your-app/example-app' title='Clone an example application' />
 </DocsGrid>
 
 <DocsGrid cols={3}>


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Before this patch, clicking on these two cards on the docs landing page lead to a 404.
Even after this patch, `/docs/guides/using-livepeer-in-your-app` doesn't really contain anything useful - so feel free to change that.

<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

- *See commit history*

**How did you test each of these updates (required)**

~~No testing done, sorry~~ :neutral_face: 
Tested the links on the CI-created vercel link https://github.com/livepeer/livepeer-com/pull/435#issuecomment-856971504 - they don't 404 anymore.

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
