### PR TITLE
fix(api): Fix some small issues in the Push Target API

### DIFF
--- a/packages/api/src/controllers/push-target.test.ts
+++ b/packages/api/src/controllers/push-target.test.ts
@@ -119,7 +119,7 @@ describe("controllers/push-target", () => {
       }
       const res = await client.get(`/push-target?userId=${nonAdminUser.id}`);
       expect(res.status).toBe(200);
-      expect(await res.json()).toEqual([userPushTarget]);
+      expect(await res.json()).toEqual([{ ...userPushTarget, url: undefined }]);
     });
 
     it("should throw 403 error if JWT is not verified", async () => {
@@ -196,6 +196,7 @@ describe("controllers/push-target", () => {
 
         const pageItems = (await res.json()) as PushTarget[];
         expect(pageItems.length).toBe(page < 3 ? 5 : 3);
+        pageItems.forEach((pt) => expect(pt.url).toBeUndefined());
         listedIDs.push(...pageItems.map((t) => t.id));
       }
       expect(listedIDs.length).toEqual(13);

--- a/packages/api/src/controllers/push-target.ts
+++ b/packages/api/src/controllers/push-target.ts
@@ -66,12 +66,16 @@ app.use(authMiddleware({}));
 
 app.use(
   mung.json(function cleanWriteOnlyResponses(data, req) {
-    if (req.user.admin || !data || !("id" in data)) {
+    if (req.user.admin) {
       return data;
     }
-    return Array.isArray(data)
-      ? db.pushTarget.cleanWriteOnlyResponses(data)
-      : db.pushTarget.cleanWriteOnlyResponse(data);
+    if (Array.isArray(data)) {
+      return db.pushTarget.cleanWriteOnlyResponses(data);
+    }
+    if ("id" in data) {
+      return db.pushTarget.cleanWriteOnlyResponse(data);
+    }
+    return data;
   })
 );
 

--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -92,7 +92,7 @@ function validatePushTargets(userId, profiles, pushTargets) {
   }
 
   if (!pushTargets) {
-    return Promise.resolve(null);
+    return Promise.resolve([]);
   }
   return Promise.all(
     pushTargets.map((p) => validatePushTarget(userId, profileNames, p))

--- a/packages/api/src/store/table.ts
+++ b/packages/api/src/store/table.ts
@@ -295,21 +295,24 @@ export default class Table<T extends DBObject> {
 
   cleanWriteOnlyResponses(docs: Array<T>): Array<T> {
     // obfuscate writeOnly fields in objects returned
-    const writeOnlyFields = {};
+    const writeOnlyFields = [];
     if (this.schema.properties) {
       for (const [fieldName, fieldArray] of Object.entries(
         this.schema.properties
       )) {
         if (fieldArray.writeOnly) {
-          writeOnlyFields[fieldName] = null;
+          writeOnlyFields.push(fieldName);
         }
       }
     }
 
-    return docs.map((x) => ({
-      ...x,
-      ...writeOnlyFields,
-    }));
+    return docs.map((doc) => {
+      const cleaned = { ...doc };
+      for (const field of writeOnlyFields) {
+        delete cleaned[field];
+      }
+      return cleaned;
+    });
   }
 
   // on startup: auto-create table if it doesn't exist


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This fixes 2 issues in the just-merged push-target API, before it goes live to production.
Each of the fixes is on a separate commit.

First one is to avoid setting the default value of the `push-target` field to `null`, which feels
 weird when using the API and could lead to errors if a developer doesn't expect that to happen.
 It also wouldn't even be valid given the object JSON schema, so it makes a lot of sense to use
 just an empty array there. Now the possibilities are: 
 - streams created before the feature: there will be no `pushTarget` field in there
 - streams created after the feature but with no push target: an empty push targets array
 - streams created with push targets: the push targets array always with an id+profile (the
 spec is only for creation)

Second fix was actually a bug in the push-target listing API, which wasn't cleaning write-only
fields in the response so even non-admin fields were getting the `url`s in the payload. Added
some tests to check if that starts happening again.

**Specific updates (required)**
 - Replace `null` with a `[]` for the default value of the `pushTargets` field
 - Properly filter write-only fields in the push-targets list API response

## -

- **How did you test each of these updates (required)**
 - Ran tests
 - Called the respective APIs (push-target list and stream create) and validated the created/response objects

**Does this pull request close any open issues?**
Also related to https://github.com/livepeer/livepeer-com/issues/431

**Checklist:**

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
