### PR TITLE
Implement basic auth and limit stream hooks to admins only

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -56,6 +56,7 @@
     "analytics-node": "^3.4.0-beta.1",
     "any-base": "^1.1.0",
     "aws-serverless-express": "^3.3.6",
+    "basic-auth": "^2.0.1",
     "body-parser": "^1.19.0",
     "browser-process-hrtime": "^1.0.0",
     "camelcase": "^5.3.1",

--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -1233,7 +1233,7 @@ async function terminateStreamReq(req, stream) {
 
 const streamDetectionEvent = "stream.detection";
 
-app.post("/hook", async (req, res) => {
+app.post("/hook", authMiddleware({ anyAdmin: true }), async (req, res) => {
   if (!req.body || !req.body.url) {
     res.status(422);
     return res.json({
@@ -1399,6 +1399,7 @@ app.post("/hook", async (req, res) => {
 
 app.post(
   "/hook/detection",
+  authMiddleware({ anyAdmin: true }),
   validatePost("detection-webhook-payload"),
   async (req, res) => {
     const { manifestID, seqNo, sceneClassification } = req.body;

--- a/packages/api/src/controllers/stream.test.js
+++ b/packages/api/src/controllers/stream.test.js
@@ -1039,6 +1039,7 @@ describe("controllers/stream", () => {
         expect(res.status).toBe(201);
         const data = await res.json();
         expect(data.profiles).toEqual(testStream.profiles);
+        client.jwtAuth = adminToken.token;
         const hookRes = await client.post("/stream/hook", {
           url: `https://example.com/live/${data.id}/0.ts`,
         });

--- a/packages/api/src/controllers/stream.test.js
+++ b/packages/api/src/controllers/stream.test.js
@@ -901,6 +901,8 @@ describe("controllers/stream", () => {
           const res = await client.post("/stream", postMockStream);
           expect(res.status).toBe(201);
           stream = await res.json();
+          // Hooks can only be called by admin users
+          client.jwtAuth = adminToken.token;
         });
 
         it("should return success if no webhook registered", async () => {

--- a/packages/api/src/controllers/stream.test.js
+++ b/packages/api/src/controllers/stream.test.js
@@ -690,7 +690,13 @@ describe("controllers/stream", () => {
     let stream;
     let data;
     let res;
-    let client, adminUser, adminToken, nonAdminUser, nonAdminToken;
+    let client,
+      adminUser,
+      adminToken,
+      adminApiKey,
+      nonAdminUser,
+      nonAdminToken,
+      nonAdminApiKey;
 
     beforeEach(async () => {
       ({
@@ -700,6 +706,18 @@ describe("controllers/stream", () => {
         nonAdminUser,
         nonAdminToken,
       } = await setupUsers(server));
+      adminApiKey = uuid();
+      await server.store.create({
+        id: adminApiKey,
+        kind: "api-token",
+        userId: adminUser.id,
+      });
+      nonAdminApiKey = uuid();
+      await server.store.create({
+        id: nonAdminApiKey,
+        kind: "api-token",
+        userId: nonAdminUser.id,
+      });
 
       await server.store.create(mockStore);
       stream = {
@@ -825,6 +843,57 @@ describe("controllers/stream", () => {
           expect(res.status).toBe(200);
           data = await res.json();
           expect(data.detection).toEqual(defaultDetection);
+        });
+      });
+
+      describe("authorization", () => {
+        let url;
+
+        beforeEach(() => {
+          url = happyCases[0].replace("STREAM_ID", stream.id);
+        });
+
+        it("should not accept non-admin users", async () => {
+          client.jwtAuth = nonAdminToken.token;
+          res = await client.post("/stream/hook", { url });
+          expect(res.status).toBe(403);
+          data = await res.json();
+          expect(data.errors[0]).toContain("admin");
+        });
+
+        const testBasic = async (userPassword, statusCode, error) => {
+          client.jwtAuth = undefined;
+          client.basicAuth = userPassword;
+          res = await client.post("/stream/hook", { url });
+          expect(res.status).toBe(statusCode);
+          if (error) {
+            data = await res.json();
+            expect(data.errors[0]).toEqual(error);
+          }
+        };
+
+        it("should parse basic auth", async () => {
+          await testBasic("hey:basic", 403, "no token basic found");
+        });
+
+        it("should accept valid token in basic auth", async () => {
+          await testBasic(`${adminUser.id}:${adminApiKey}`, 200);
+        });
+
+        it("should only accept token with corresponding user id", async () => {
+          await testBasic(
+            `${nonAdminUser.id}:${adminApiKey}`,
+            403,
+            expect.stringMatching(/no token .+ found/)
+          );
+        });
+
+        it("should still only accept admin users", async () => {
+          await testBasic(
+            `${nonAdminUser.id}:${nonAdminApiKey}`,
+            403,
+            expect.stringContaining("admin")
+          );
         });
       });
     });

--- a/packages/api/src/controllers/user.test.js
+++ b/packages/api/src/controllers/user.test.js
@@ -478,6 +478,28 @@ describe("controllers/user", () => {
       resJson = await res.json();
       expect(res.status).toBe(403);
       expect(resJson.errors[0]).toBe("user does not have admin priviledges");
+
+      // adding emailValid true to admin user
+      const adminUserRes = await server.store.get(
+        `user/${adminUser.id}`,
+        false
+      );
+      adminUser = { ...adminUserRes, emailValid: true };
+      await server.store.replace(adminUser);
+
+      // only jwt auth should be allowed access to this list API
+      client.apiKey = adminApiKey;
+      res = await client.get("/user");
+      resJson = await res.json();
+      expect(res.status).toBe(403);
+      expect(resJson.errors[0]).toBe("user does not have admin priviledges");
+
+      client.apiKey = undefined;
+      client.basicAuth = `${adminUser.id}:${adminApiKey}`;
+      res = await client.get("/user");
+      resJson = await res.json();
+      expect(res.status).toBe(403);
+      expect(resJson.errors[0]).toBe("user does not have admin priviledges");
     });
 
     it("should return verified user", async () => {

--- a/packages/api/src/middleware/auth.js
+++ b/packages/api/src/middleware/auth.js
@@ -56,7 +56,7 @@ function authFactory(params) {
       throw new ForbiddenError(`unsupported authorization type ${tokenType}`);
     }
 
-    user = await req.store.get(`user/${userId}`);
+    user = await db.user.get(userId);
     if (!user) {
       throw new InternalServerError(`no user found for token ${authToken}`);
     }

--- a/packages/api/src/middleware/auth.js
+++ b/packages/api/src/middleware/auth.js
@@ -29,9 +29,7 @@ function authFactory(params) {
       throw new ForbiddenError(`no authorization header provided`);
     } else if (["Bearer", "Basic"].includes(tokenType)) {
       const isBasic = tokenType === "Basic";
-      tokenObject = await req.store.get(
-        `api-token/${isBasic ? basicUser.pass : req.token}`
-      );
+      tokenObject = await db.apiToken.get(isBasic ? basicUser.pass : req.token);
       const matchesBasicUser = tokenObject?.userId === basicUser?.name;
       if (!tokenObject || (isBasic && !matchesBasicUser)) {
         throw new ForbiddenError(`no token object ${tokenValue} found`);

--- a/packages/api/src/middleware/auth.js
+++ b/packages/api/src/middleware/auth.js
@@ -36,7 +36,7 @@ function authFactory(params) {
       tokenObject = await db.apiToken.get(tokenId);
       const matchesBasicUser = tokenObject?.userId === basicUser?.name;
       if (!tokenObject || (isBasic && !matchesBasicUser)) {
-        throw new ForbiddenError(`no token object ${tokenValue} found`);
+        throw new ForbiddenError(`no token ${tokenId} found`);
       }
 
       userId = tokenObject.userId;

--- a/packages/api/src/middleware/auth.js
+++ b/packages/api/src/middleware/auth.js
@@ -29,7 +29,11 @@ function authFactory(params) {
       throw new ForbiddenError(`no authorization header provided`);
     } else if (["Bearer", "Basic"].includes(tokenType)) {
       const isBasic = tokenType === "Basic";
-      tokenObject = await db.apiToken.get(isBasic ? basicUser.pass : req.token);
+      const tokenId = isBasic ? basicUser?.pass : req.token;
+      if (!tokenId) {
+        throw new ForbiddenError(`no authorization token provided`);
+      }
+      tokenObject = await db.apiToken.get(tokenId);
       const matchesBasicUser = tokenObject?.userId === basicUser?.name;
       if (!tokenObject || (isBasic && !matchesBasicUser)) {
         throw new ForbiddenError(`no token object ${tokenValue} found`);

--- a/packages/api/src/test-helpers.ts
+++ b/packages/api/src/test-helpers.ts
@@ -50,12 +50,14 @@ export class TestClient {
   server: TestServer;
   apiKey: string;
   jwtAuth: string;
+  basicAuth: string;
   googleAuthorization: string;
 
   constructor(opts: {
     server: TestServer;
     apiKey?: string;
     jwtAuth?: string;
+    basicAuth?: string;
     googleAuthorization?: string;
   }) {
     if (!opts.server) {
@@ -69,6 +71,9 @@ export class TestClient {
     }
     if (opts.jwtAuth) {
       this.jwtAuth = opts.jwtAuth;
+    }
+    if (opts.basicAuth) {
+      this.basicAuth = opts.basicAuth;
     }
     if (opts.googleAuthorization) {
       this.googleAuthorization = opts.googleAuthorization;
@@ -87,6 +92,13 @@ export class TestClient {
       headers = {
         ...headers,
         authorization: `JWT ${this.jwtAuth}`,
+      };
+    }
+    if (this.basicAuth) {
+      const basic64 = Buffer.from(this.basicAuth).toString("base64");
+      headers = {
+        ...headers,
+        authorization: `Basic ${basic64}`,
       };
     }
     const res = await isoFetch(

--- a/yarn.lock
+++ b/yarn.lock
@@ -7180,9 +7180,10 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
-basic-auth@~2.0.1:
+basic-auth@^2.0.1, basic-auth@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
+  integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
   dependencies:
     safe-buffer "5.1.2"
 


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This is to add an authorization layer to the hooks called on the stream object by go-livepeer.

Solution has been discussed in the issue: https://github.com/livepeer/go-livepeer/issues/1278

**Specific updates (required)**
 - Add support to HTTP Basic Auth in auth middleware
 - Make stream auth and detection hooks admin-only
 - TODO: Add an admin token to go-livepeer deployments for them to call the API

## -

- **How did you test each of these updates (required)**
 - For now mostly `yarn test` which already got some errors on the tests calling the hooks with a non admin token
 - TODO: Create some tests for the Basic auth logic

**Does this pull request close any open issues?**
Fixes https://github.com/livepeer/go-livepeer/issues/1278

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
