### PR TITLE
add ability to hide certain docs from nav

### DIFF
--- a/packages/www/components/DocsLayout/sideNav.tsx
+++ b/packages/www/components/DocsLayout/sideNav.tsx
@@ -18,6 +18,7 @@ type Child = {
   title: string;
   description: string;
   slug: string;
+  hide: boolean;
   children: {
     title: string;
     description: string;
@@ -164,43 +165,45 @@ const Menu = ({ menu }: MenuProps) => {
         route.children.length > 0 ? (
           <CollapsibleMenuItem route={route} key={idx} />
         ) : (
-          <Link href={`/${route.slug}`} key={idx} passHref>
-            <a
-              sx={{
-                fontSize: "14px",
-                letterSpacing: "-0.02em",
-                color: "#3C3C3C",
-                mt: "16px !important",
-                cursor: "pointer",
-                position: "relative",
-                fontWeight: currentPath === `/${route.slug}` ? "600" : "400",
-                pl: "24px",
-              }}>
-              <div
+          !route.hide && (
+            <Link href={`/${route.slug}`} key={idx} passHref>
+              <a
                 sx={{
-                  position: "absolute",
-                  left: "0",
-                  width: "4px",
-                  height: "100%",
-                  transition: "all 0.2s",
-                  background:
-                    currentPath === `/${route.slug}`
-                      ? "#943CFF"
-                      : "transparent",
-                  borderRadius: " 0 2px 2px 0",
-                }}
-              />
-              <span
-                sx={{
+                  fontSize: "14px",
+                  letterSpacing: "-0.02em",
                   color: "#3C3C3C",
-                  ":hover": {
-                    color: "#000000",
-                  },
+                  mt: "16px !important",
+                  cursor: "pointer",
+                  position: "relative",
+                  fontWeight: currentPath === `/${route.slug}` ? "600" : "400",
+                  pl: "24px",
                 }}>
-                <Marked>{route.title}</Marked>
-              </span>
-            </a>
-          </Link>
+                <div
+                  sx={{
+                    position: "absolute",
+                    left: "0",
+                    width: "4px",
+                    height: "100%",
+                    transition: "all 0.2s",
+                    background:
+                      currentPath === `/${route.slug}`
+                        ? "#943CFF"
+                        : "transparent",
+                    borderRadius: " 0 2px 2px 0",
+                  }}
+                />
+                <span
+                  sx={{
+                    color: "#3C3C3C",
+                    ":hover": {
+                      color: "#000000",
+                    },
+                  }}>
+                  <Marked>{route.title}</Marked>
+                </span>
+              </a>
+            </Link>
+          )
         )
       )}
     </div>

--- a/packages/www/pages/docs/[[...slug]].tsx
+++ b/packages/www/pages/docs/[[...slug]].tsx
@@ -269,6 +269,7 @@ export const getStaticProps = async (context: GetStaticPathsContext) => {
       slug: `docs${each.slug !== "" ? `/${each.slug}` : ""}`,
       title: each.frontMatter.title,
       description: each.frontMatter.description,
+      hide: each.frontMatter?.hide ? true : false,
     };
   });
 
@@ -286,6 +287,7 @@ export const getStaticProps = async (context: GetStaticPathsContext) => {
       slug: each.slug,
       title: each.title,
       description: each.description,
+      hide: each.hide,
       children: sorted
         .filter(
           (child) =>
@@ -299,6 +301,7 @@ export const getStaticProps = async (context: GetStaticPathsContext) => {
             slug: eachChild.slug,
             title: eachChild.title,
             description: eachChild.description,
+            hide: eachChild.hide,
             children: sorted.filter(
               (secondChild) =>
                 secondChild.slug.split("/")[2] ===

--- a/yarn.lock
+++ b/yarn.lock
@@ -12842,6 +12842,7 @@ init-package-json@^1.10.3:
 inline-style-parser@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.1.1.tgz#ec8a3b429274e9c0a1f1c4ffa9453a7fef72cea1"
+  integrity sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==
 
 inline-style-prefixer@^4.0.0:
   version "4.0.2"


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR lets you add a hide field using markdown frontmatter in order to hide documentation articles from the sidebar. 

Example usage:
```mdx
---
title: Webhooks
description: Livepeer.com webhooks
hide: true
---
```