### PR TITLE
conditionally add count to response header

### DIFF
--- a/packages/api/src/controllers/session.js
+++ b/packages/api/src/controllers/session.js
@@ -41,7 +41,8 @@ const fieldsMap = {
 };
 
 app.get("/", authMiddleware({}), async (req, res, next) => {
-  let { limit, cursor, all, order, filters, userId, parentId } = req.query;
+  let { limit, cursor, all, order, filters, userId, parentId, count } =
+    req.query;
   const { forceUrl } = req.query;
   if (isNaN(parseInt(limit))) {
     limit = undefined;
@@ -66,8 +67,11 @@ app.get("/", authMiddleware({}), async (req, res, next) => {
   }
   order = parseOrder(fieldsMap, order);
 
-  const fields =
+  let fields =
     "session.id as id, session.data as data, users.id as usersId, users.data as usersdata, stream.data as stream";
+  if (count) {
+    fields = fields + ", count(*) OVER() AS count";
+  }
   const from = `session left join users on session.data->>'userId' = users.id
   left join stream on session.data->>'parentId' = stream.id`;
   const [output, newCursor] = await db.session.find(query, {
@@ -76,7 +80,10 @@ app.get("/", authMiddleware({}), async (req, res, next) => {
     fields,
     from,
     order,
-    process: ({ data, usersdata, stream }) => {
+    process: ({ data, usersdata, stream, count: c }) => {
+      if (count) {
+        res.set("X-Total-Count", c);
+      }
       return req.user.admin
         ? {
             ...data,


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Displaying "Total results" is a requirement in the dashboard redesign. This PR conditionally includes the total count in the response header when getting a list of either streams, sessions, api keys, or webhooks. 

![image](https://user-images.githubusercontent.com/555740/123517033-0e9ece80-d66d-11eb-8156-a309bff4b947.png)
