### PR TITLE
api: allow segment transcodes to use content detection

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -36,7 +36,7 @@
     "go-livepeer": "run-p \"go-livepeer:**\" --",
     "go-livepeer:broadcaster": "bin/livepeer -broadcaster -datadir ./bin/broadcaster -orchAddr 127.0.0.1:3086 -rtmpAddr 0.0.0.0:3035 -httpAddr :3085 -cliAddr :3075 -v 6 -authWebhookUrl http://127.0.0.1:3004/api/stream/hook -orchWebhookUrl http://127.0.0.1:3004/api/orchestrator",
     "go-livepeer:orchestrator": "bin/livepeer -orchestrator -datadir ./bin/orchestrator -transcoder -serviceAddr 127.0.0.1:3086 -cliAddr :3076 -v 6",
-    "test": "jest \"${PWD}/src\" -i",
+    "test": "jest \"${PWD}/src\" -i --silent",
     "test:build": "parcel build --no-autoinstall --no-minify --bundle-node-modules -t browser --out-dir ../dist-worker ../src/worker.js",
     "coverage": "yarn run test --coverage"
   },

--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -1311,7 +1311,7 @@ app.post(
   validatePost("detection-webhook-payload"),
   async (req, res) => {
     const { manifestID, seqNo, sceneClassification } = req.body;
-    const stream = await db.stream.getByPlaybackId(manifestID);
+    const stream = await db.stream.getByIdOrPlaybackId(manifestID);
     if (!stream) {
       return res.status(404).json({ errors: ["stream not found"] });
     }

--- a/packages/api/src/controllers/stream.test.js
+++ b/packages/api/src/controllers/stream.test.js
@@ -916,15 +916,15 @@ describe("controllers/stream", () => {
         expect(res.status).toBe(404);
         data = await res.json();
         expect(data.errors[0]).toEqual("stream not found");
+      });
 
+      it("should allow for content detection on ids instead of playbackIds", async () => {
         res = await client.post("/stream/hook/detection", {
           manifestID: stream.id,
           seqNo: 1,
           sceneClassification: [],
         });
-        expect(res.status).toBe(404);
-        data = await res.json();
-        expect(data.errors[0]).toEqual("stream not found");
+        expect(res.status).toBe(204);
       });
 
       it("should only accept a scene classification array", async () => {

--- a/packages/api/src/store/stream-table.ts
+++ b/packages/api/src/store/stream-table.ts
@@ -220,6 +220,14 @@ export default class StreamTable extends Table<WithID<Stream>> {
     return usage;
   }
 
+  async getByIdOrPlaybackId(id: string, opts?: QueryOptions) {
+    const [s1, s2] = await Promise.all([
+      this.get(id, opts),
+      this.getByPlaybackId(id, opts),
+    ]);
+    return s1 || s2;
+  }
+
   async getByStreamKey(
     streamKey: string,
     opts?: QueryOptions


### PR DESCRIPTION
This allows the detection webhook to be called by either playbackID or stream id, which is needed to accommodate external Mist deployments.