### PR TITLE
Make webhooks able to subscribe to multiple events at once

### DIFF
--- a/packages/api/src/controllers/stream.test.js
+++ b/packages/api/src/controllers/stream.test.js
@@ -792,7 +792,7 @@ describe("controllers/stream", () => {
           await server.db.webhook.create({
             id: uuid(),
             kind: "webhook",
-            event: "stream.detection",
+            events: ["stream.detection"],
             userId: stream.userId,
             createdAt: Date.now(),
             url: "https://zoo.tv/abuse/hook",
@@ -962,7 +962,7 @@ describe("controllers/stream", () => {
             name: "detection-webhook",
             kind: "webhook",
             createdAt: Date.now(),
-            event: "stream.detection",
+            events: ["stream.detection"],
             url: `http://localhost:${webhookServer.port}/captain/hook`,
           });
         });

--- a/packages/api/src/controllers/webhook.js
+++ b/packages/api/src/controllers/webhook.js
@@ -1,18 +1,39 @@
-import { parse as parseUrl } from "url";
+import { URL } from "url";
 import { authMiddleware } from "../middleware";
 import { validatePost } from "../middleware";
 import Router from "express/lib/router";
 import logger from "../logger";
 import uuid from "uuid/v4";
-import {
-  makeNextHREF,
-  trackAction,
-  getWebhooks,
-  parseFilters,
-  parseOrder,
-} from "./helpers";
+import { makeNextHREF, trackAction, parseFilters, parseOrder } from "./helpers";
 import { db } from "../store";
 import sql from "sql-template-strings";
+import { UnprocessableEntityError } from "../store/errors";
+
+function validateWebhookPayload(id, userId, createdAt, payload) {
+  try {
+    new URL(payload.url);
+  } catch (e) {
+    console.error(`couldn't parse the provided url: ${payload.url}`);
+    throw new UnprocessableEntityError(`bad url: ${url}`);
+  }
+
+  if (!payload.events && !payload.event) {
+    throw new UnprocessableEntityError(
+      `must provide "events" field with subscriptions`
+    );
+  }
+
+  return {
+    id,
+    userId,
+    createdAt,
+    kind: "webhook",
+    name: payload.name,
+    events: payload.events ?? [payload.event],
+    url: payload.url,
+    blocking: payload.blocking ?? true,
+  };
+}
 
 const app = Router();
 
@@ -113,34 +134,7 @@ app.get("/", authMiddleware({}), async (req, res) => {
 
 app.post("/", authMiddleware({}), validatePost("webhook"), async (req, res) => {
   const id = uuid();
-  const createdAt = Date.now();
-
-  let urlObj;
-  try {
-    urlObj = parseUrl(req.body.url);
-  } catch (e) {
-    console.error(`couldn't parse the url provided ${req.body.url}`);
-    res.status(400);
-    return res.end();
-  }
-
-  if (!req.body.events && !req.body.event) {
-    return res
-      .status(422)
-      .json({ errors: [`must provide "events" field with subscriptions`] });
-  }
-
-  const doc = {
-    id,
-    userId: req.user.id,
-    kind: "webhook",
-    name: req.body.name,
-    createdAt: createdAt,
-    events: req.body.events ?? [req.body.event],
-    url: req.body.url,
-    blocking: req.body.blocking === undefined ? true : !!req.body.blocking,
-  };
-
+  const doc = validateWebhookPayload(id, req.user.id, Date.now(), req.body);
   try {
     await req.store.create(doc);
     trackAction(
@@ -190,23 +184,10 @@ app.put(
       return res.json({ errors: ["not found"] });
     }
 
-    let urlObj;
+    const { id, userId, createdAt } = webhook;
+    const doc = validateWebhookPayload(id, userId, createdAt, req.body);
     try {
-      urlObj = parseUrl(req.body.url);
-    } catch (e) {
-      console.error(`couldn't parse the url provided ${req.body.url}`);
-      res.status(400);
-      return res.end();
-    }
-
-    if (!req.body.events && !req.body.event) {
-      return res
-        .status(422)
-        .json({ errors: [`must provide "events" field with subscriptions`] });
-    }
-
-    try {
-      await req.store.replace(req.body);
+      await req.store.replace(doc);
     } catch (e) {
       console.error(e);
       throw e;

--- a/packages/api/src/controllers/webhook.test.js
+++ b/packages/api/src/controllers/webhook.test.js
@@ -175,12 +175,30 @@ describe("controllers/webhook", () => {
     });
 
     it("update a webhook", async () => {
-      let modifiedHook = { ...generatedWebhook };
-      modifiedHook.name = "modified_name";
-      const res = await client.put(`/webhook/${modifiedHook.id}`, modifiedHook);
+      const { id } = generatedWebhook;
+      const modifiedHook = { ...generatedWebhook, name: "modified_name" };
+
+      const res = await client.put(`/webhook/${id}`, modifiedHook);
       const resJson = await res.json();
       expect(res.status).toBe(200);
-      expect(resJson.id).toEqual(generatedWebhook.id);
+      expect(resJson.id).toEqual(id);
+
+      const updated = await client.get(`/webhook/${id}`).then((r) => r.json());
+      expect(updated.userId).toEqual(adminUser.id);
+      expect(updated.name).toEqual("modified_name");
+    });
+
+    it("disallows setting webhook for another user", async () => {
+      const { id } = generatedWebhook;
+      const modifiedHook = { ...generatedWebhook, userId: nonAdminUser.id };
+
+      const res = await client.put(`/webhook/${id}`, modifiedHook);
+      const resJson = await res.json();
+      expect(res.status).toBe(200);
+      expect(resJson.id).toEqual(id);
+
+      const updated = await client.get(`/webhook/${id}`).then((r) => r.json());
+      expect(updated.userId).toEqual(adminUser.id);
     });
 
     it("delete a webhook", async () => {

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -34,8 +34,8 @@ components:
       table: webhook
       required:
         - name
-        - event
         - url
+      additionalProperties: false
       properties:
         id:
           type: string
@@ -58,12 +58,18 @@ components:
             Timestamp (in milliseconds) at which stream object was created
           example: 1587667174725
         event:
-          type: string
-          enum:
-            - stream.started
-            - stream.detection
-            - stream.idle
-            - recording.ready
+          index: true
+          writeOnly: true
+          $ref: "#/components/schemas/webhook/properties/events/items"
+        events:
+          type: array
+          items:
+            type: string
+            enum:
+              - stream.started
+              - stream.detection
+              - stream.idle
+              - recording.ready
         url:
           type: string
           format: uri

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -58,8 +58,10 @@ components:
             Timestamp (in milliseconds) at which stream object was created
           example: 1587667174725
         event:
-          index: true
           writeOnly: true
+          deprecated: true
+          description:
+            "@deprecated Non-persisted field. To be used on creation API only."
           $ref: "#/components/schemas/webhook/properties/events/items"
         events:
           type: array

--- a/packages/api/src/store/webhook-table.ts
+++ b/packages/api/src/store/webhook-table.ts
@@ -2,11 +2,16 @@ import sql from "sql-template-strings";
 
 import { Webhook } from "../schema/types";
 import Table from "./table";
-import { WithID } from "./types";
 
 export type DBWebhook = Omit<Webhook, "event"> & {
   id: string;
   events: Webhook["events"];
+  /**
+  @deprecated: This is to make DBWebhook type unassignable to Webhook and avoid
+  programming mistakes. Always use DBWebhook unless in the API controller where
+  the conversion of field .event to .events will take place.
+  **/
+  event?: "deprecated";
 };
 
 export default class WebhookTable extends Table<DBWebhook> {

--- a/packages/api/src/store/webhook-table.ts
+++ b/packages/api/src/store/webhook-table.ts
@@ -4,9 +4,10 @@ import { Webhook } from "../schema/types";
 import Table from "./table";
 import { WithID } from "./types";
 
-export type DBWebhook = WithID<
-  Omit<Webhook, "event"> & { events: Webhook["events"] }
->;
+export type DBWebhook = Omit<Webhook, "event"> & {
+  id: string;
+  events: Webhook["events"];
+};
 
 export default class WebhookTable extends Table<DBWebhook> {
   async listSubscribed(

--- a/packages/api/src/store/webhook-table.ts
+++ b/packages/api/src/store/webhook-table.ts
@@ -18,8 +18,8 @@ export default class WebhookTable extends Table<DBWebhook> {
   ) {
     const query = [sql`data->>'userId' = ${userId}`];
     if (event) {
-      const jsonEv = JSON.stringify(event);
-      query.push(sql`data->'events' @> ${jsonEv} OR data->>'event' = ${event}`);
+      const jsonEvent = JSON.stringify(event);
+      query.push(sql`data->'events' @> ${jsonEvent}`);
     }
     if (!includeDeleted) {
       query.push(sql`data->>'deleted' IS NULL`);
@@ -28,15 +28,6 @@ export default class WebhookTable extends Table<DBWebhook> {
       limit,
       cursor,
     });
-    return { data: webhooks.map(this.compatEventsField), cursor: nextCursor };
-  }
-
-  compatEventsField(maybeLegacy: WithID<Webhook>): DBWebhook {
-    if (!maybeLegacy.event) {
-      return maybeLegacy as DBWebhook;
-    }
-    const webhook: DBWebhook = { ...maybeLegacy, events: [maybeLegacy.event] };
-    delete webhook["event"];
-    return webhook;
+    return { data: webhooks, cursor: nextCursor };
   }
 }

--- a/packages/api/src/store/webhook-table.ts
+++ b/packages/api/src/store/webhook-table.ts
@@ -4,7 +4,11 @@ import { Webhook } from "../schema/types";
 import Table from "./table";
 import { WithID } from "./types";
 
-export default class WebhookTable extends Table<WithID<Webhook>> {
+export type DBWebhook = WithID<
+  Omit<Webhook, "event"> & { events: Webhook["events"] }
+>;
+
+export default class WebhookTable extends Table<DBWebhook> {
   async listSubscribed(
     userId: string,
     event: string,
@@ -14,15 +18,25 @@ export default class WebhookTable extends Table<WithID<Webhook>> {
   ) {
     const query = [sql`data->>'userId' = ${userId}`];
     if (event) {
-      query.push(sql`data->>'event' = ${event}`);
+      const jsonEv = JSON.stringify(event);
+      query.push(sql`data->'events' @> ${jsonEv} OR data->>'event' = ${event}`);
     }
     if (!includeDeleted) {
       query.push(sql`data->>'deleted' IS NULL`);
     }
-    const [webhooks, nextCursor] = await this.db.webhook.find(query, {
+    const [webhooks, nextCursor] = await this.find(query, {
       limit,
       cursor,
     });
-    return { data: webhooks, cursor: nextCursor };
+    return { data: webhooks.map(this.compatEventsField), cursor: nextCursor };
+  }
+
+  compatEventsField(maybeLegacy: WithID<Webhook>): DBWebhook {
+    if (!maybeLegacy.event) {
+      return maybeLegacy as DBWebhook;
+    }
+    const webhook: DBWebhook = { ...maybeLegacy, events: [maybeLegacy.event] };
+    delete webhook["event"];
+    return webhook;
   }
 }

--- a/packages/api/src/webhooks/cannon.test.ts
+++ b/packages/api/src/webhooks/cannon.test.ts
@@ -113,7 +113,7 @@ describe("webhook cannon", () => {
       name: "test webhook 1",
       kind: "webhook",
       createdAt: Date.now(),
-      event: "stream.started",
+      events: ["stream.started"],
       url: "http://localhost:30000/webhook",
       // url: 'https://livepeer.com/'
     };
@@ -139,7 +139,6 @@ describe("webhook cannon", () => {
     // await db.close();
   });
 
-
   it("should have a test server", async () => {
     // webhookServer.use(bodyParser);
     webhookServer.app.get("/self-test", (req, res) => {
@@ -151,8 +150,11 @@ describe("webhook cannon", () => {
   });
 
   it("should be able to receive the webhook event", async () => {
-
-    await server.store.create({ id: "streamid", userId: nonAdminUser.id, kind: "stream"});
+    await server.store.create({
+      id: "streamid",
+      userId: nonAdminUser.id,
+      kind: "stream",
+    });
 
     // create the webhook
     let res = await client.post("/webhook", { ...mockWebhook });
@@ -209,7 +211,7 @@ describe("webhook cannon", () => {
     await sem.wait(3000);
     expect(resp).toBe(200);
     // need to wait until cannon will write webhook response to db
-    await sleep(2000)
+    await sleep(2000);
   });
 });
 

--- a/packages/api/src/webhooks/cannon.test.ts
+++ b/packages/api/src/webhooks/cannon.test.ts
@@ -1,6 +1,5 @@
 import express from "express";
 import fetch from "isomorphic-fetch";
-import { DB } from "../store/db";
 import schema from "../schema/schema.json";
 import WebhookCannon from "./cannon";
 import makeStore from "../store";
@@ -11,7 +10,7 @@ import {
   startAuxTestServer,
   AuxTestServer,
 } from "../test-helpers";
-import { semaphore } from "../util";
+import { semaphore, sleep } from "../util";
 
 const bodyParser = require("body-parser");
 jest.setTimeout(15000);
@@ -20,20 +19,12 @@ describe("webhook cannon", () => {
   let server: TestServer;
   let webhookServer: AuxTestServer;
   let testHost;
-  let db;
 
   let mockAdminUser;
   let mockNonAdminUser;
   let postMockStream;
   let mockWebhook;
-  let client,
-    adminUser,
-    adminToken,
-    nonAdminUser,
-    nonAdminToken,
-    generatedWebhook,
-    generatedWebhook2,
-    generatedWebhookNonAdmin;
+  let client, adminUser, adminToken, nonAdminUser, nonAdminToken;
 
   async function setupUsers(server) {
     const client = new TestClient({
@@ -118,6 +109,16 @@ describe("webhook cannon", () => {
       // url: 'https://livepeer.com/'
     };
 
+    webhookServer = await startAuxTestServer(30000);
+    testHost = `http://localhost:${webhookServer.port}`;
+    console.log("beforeALL done");
+  });
+
+  afterAll(async () => {
+    await webhookServer.close();
+  });
+
+  beforeEach(async () => {
     ({
       client,
       adminUser,
@@ -125,18 +126,12 @@ describe("webhook cannon", () => {
       nonAdminUser,
       nonAdminToken,
     } = await setupUsers(server));
-    console.log("beforeALL done");
   });
 
-  beforeAll(async () => {
-    webhookServer = await startAuxTestServer(30000);
-    testHost = `http://localhost:${webhookServer.port}`;
-  });
-
-  afterAll(async () => {
-    await webhookServer.close();
-    server.queue.close();
-    // await db.close();
+  afterEach(async () => {
+    // need to wait until cannon writes webhook responses to db
+    await sleep(200);
+    await clearDatabase(server);
   });
 
   it("should have a test server", async () => {
@@ -149,20 +144,13 @@ describe("webhook cannon", () => {
     expect(text).toEqual("self test was good");
   });
 
-  it("should be able to receive the webhook event", async () => {
-    await server.store.create({
-      id: "streamid",
-      userId: nonAdminUser.id,
-      kind: "stream",
-    });
-
+  it("should be able to create webhooks", async () => {
     // create the webhook
     let res = await client.post("/webhook", { ...mockWebhook });
     let resJson = await res.json();
     console.log("webhook body: ", resJson);
     expect(res.status).toBe(201);
     expect(resJson.blocking).toBe(true);
-    generatedWebhook = resJson;
     res = await client.post("/webhook", {
       ...mockWebhook,
       name: "test 2",
@@ -173,50 +161,155 @@ describe("webhook cannon", () => {
     console.log("webhook body: ", resJson);
     expect(res.status).toBe(201);
     expect(resJson.name).toBe("test 2");
-    generatedWebhook2 = resJson;
+  });
 
-    client.jwtAuth = nonAdminToken["token"];
-    res = await client.post("/webhook", {
-      ...mockWebhook,
-      name: "test non admin",
-    });
-    resJson = await res.json();
-    console.log("webhook body: ", resJson);
-    expect(res.status).toBe(201);
-    expect(resJson.name).toBe("test non admin");
-    generatedWebhookNonAdmin = resJson;
-    client.jwtAuth = adminToken["token"];
+  describe("receiving events", () => {
+    let webhookCallback: (body: any) => void;
 
-    // test endpoint
-    const sem = semaphore();
-    let resp: number = -1;
-    webhookServer.app.use(bodyParser.json());
-    webhookServer.app.post("/webhook", (req, res) => {
-      console.log("WEBHOOK WORKS , body", req.body);
-      resp = 200;
-      res.end();
-      sem.release();
+    beforeAll(() => {
+      webhookServer.app.use(bodyParser.json());
+      webhookServer.app.post("/webhook", (req, res) => {
+        console.log("WEBHOOK WORKS , body", req.body);
+        webhookCallback(req.body);
+        res.status(204).end();
+      });
     });
 
-    await server.queue.emit({
-      id: "webhook_test_12",
-      time: Date.now(),
-      channel: "test.channel",
-      event: "stream.started",
-      streamId: "streamid",
-      userId: nonAdminUser.id,
-      isConsumed: false,
+    beforeEach(async () => {
+      webhookCallback = () => {};
+
+      await server.store.create({
+        id: "streamid",
+        userId: nonAdminUser.id,
+        kind: "stream",
+      });
+      client.jwtAuth = nonAdminToken["token"];
     });
 
-    await sem.wait(3000);
-    expect(resp).toBe(200);
-    // need to wait until cannon will write webhook response to db
-    await sleep(2000);
+    it("should be able to receive the webhook event", async () => {
+      const res = await client.post("/webhook", {
+        ...mockWebhook,
+        name: "test non admin",
+      });
+      const resJson = await res.json();
+      console.log("webhook body: ", resJson);
+      expect(res.status).toBe(201);
+      expect(resJson.name).toBe("test non admin");
+
+      const sem = semaphore();
+      let called = false;
+      webhookCallback = () => {
+        called = true;
+        sem.release();
+      };
+
+      await server.queue.emit({
+        id: "webhook_test_12",
+        time: Date.now(),
+        channel: "test.channel",
+        event: "stream.started",
+        streamId: "streamid",
+        userId: nonAdminUser.id,
+        isConsumed: false,
+      });
+
+      await sem.wait(3000);
+      expect(called).toBe(true);
+    });
+
+    it("should call multiple webhooks", async () => {
+      let res = await client.post("/webhook", {
+        ...mockWebhook,
+        name: "test-1",
+      });
+      expect(res.status).toBe(201);
+      res = await client.post("/webhook", {
+        ...mockWebhook,
+        name: "test-2",
+      });
+      expect(res.status).toBe(201);
+
+      const sem = semaphore();
+      let callCount = 0;
+      webhookCallback = () => {
+        callCount++;
+        if (callCount === 2) sem.release();
+      };
+
+      await server.queue.emit({
+        id: "webhook_test_12",
+        time: Date.now(),
+        channel: "test.channel",
+        event: "stream.started",
+        streamId: "streamid",
+        userId: nonAdminUser.id,
+        isConsumed: false,
+      });
+
+      await sem.wait(3000);
+      expect(callCount).toBe(2);
+    });
+
+    it("should send multiple events to same webhook", async () => {
+      const res = await client.post("/webhook", {
+        ...mockWebhook,
+        name: "test-multi",
+        events: ["stream.started", "stream.idle"],
+      });
+      expect(res.status).toBe(201);
+
+      let callCount = 0;
+      let receivedEvent: string;
+      let sem = semaphore();
+      webhookCallback = (body) => {
+        receivedEvent = body.event;
+        callCount++;
+        sem.release();
+      };
+
+      await server.queue.emit({
+        id: "webhook_test_12",
+        time: Date.now(),
+        channel: "test.channel",
+        event: "stream.started",
+        streamId: "streamid",
+        userId: nonAdminUser.id,
+        isConsumed: false,
+      });
+
+      await sem.wait(3000);
+      expect(callCount).toBe(1);
+      expect(receivedEvent).toBe("stream.started");
+
+      sem = semaphore();
+      await server.queue.emit({
+        id: "webhook_test_42",
+        time: Date.now(),
+        channel: "test.channel",
+        event: "stream.idle",
+        streamId: "streamid",
+        userId: nonAdminUser.id,
+        isConsumed: false,
+      });
+
+      await sem.wait(3000);
+      expect(callCount).toBe(2);
+      expect(receivedEvent).toBe("stream.idle");
+
+      // does not receive some random event
+      sem = semaphore();
+      await server.queue.emit({
+        id: "webhook_test_93",
+        time: Date.now(),
+        channel: "test.channel",
+        event: "stream.unknown",
+        streamId: "streamid",
+        userId: nonAdminUser.id,
+        isConsumed: false,
+      });
+
+      await sem.wait(1000);
+      expect(callCount).toBe(2);
+    });
   });
 });
-
-function sleep(ms) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -1,8 +1,9 @@
 import { DB } from "../store/db";
-import { Webhook, User, Stream } from "../schema/types";
+import { User, Stream } from "../schema/types";
 import MessageQueue from "../store/rabbit-queue";
 // import { getWebhooks } from "../controllers/helpers";
 import Model from "../store/model";
+import { DBWebhook } from "../store/webhook-table";
 import { fetchWithTimeout } from "../util";
 import logger from "../logger";
 
@@ -20,7 +21,7 @@ const MAX_RETRIES = 20;
 
 export interface WebhookMessage {
   id: string;
-  event: Webhook["event"];
+  event: DBWebhook["events"][0];
   userId: string;
   streamId: string;
   payload?: Object;
@@ -116,7 +117,7 @@ export default class WebhookCannon {
 
   async _fireHook(
     event: WebhookMessage,
-    webhook: Webhook,
+    webhook: DBWebhook,
     sanitized: Stream,
     user: User,
     verifyUrl = true
@@ -167,7 +168,7 @@ export default class WebhookCannon {
         timeout: WEBHOOK_TIMEOUT,
         body: JSON.stringify({
           id: webhook.id,
-          event: webhook.event,
+          event: event.event,
           stream: sanitized,
           payload: event.payload,
         }),
@@ -204,7 +205,7 @@ export default class WebhookCannon {
   }
 
   async storeResponse(
-    webhook: Webhook,
+    webhook: DBWebhook,
     event: WebhookMessage,
     resp: Response,
     duration = 0


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This is to change the webhooks spec a bit by allowing them to subscribe to multiple
events at once with an `events` array instead of a single `event` subs.

We still want to keep retrocompatibility in the API since some documents have already 
been distributed where the `event` field is used instead of `events`, but we can
actually break the backward compatibility in the database for now, since the only
webhooks that exist are ones created by Livepeer employeed for testing. 

So we'll just deploy this change and then truncate the existing prod and staging
tables so we don't have webhooks in the legacy format saved anywhere (even though
they wouldn't cause much trouble anyway, would just never be used).

For simplicity, we also don't have any index in the `events` field, but it is possible to
be made in the future with [a GIN index](https://www.postgresql.org/docs/9.4/datatype-json.html) on the specific array field, which can be used
for this `@>` operator. It didn't "just work" when I experimented with it, so I kept the simple
version with no index for now.

## -

- **How did you test each of these updates (required)**
`yarn test`

**Does this pull request close any open issues?**
Closes https://github.com/livepeer/livepeer-com/issues/502

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
