### PR TITLE
add deactivate-many endpoint

### DIFF
--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -792,7 +792,7 @@ app.post("/", authMiddleware({}), validatePost("stream"), async (req, res) => {
   );
 });
 
-app.put("/:id/setactive", authMiddleware({}), async (req, res) => {
+app.put("/:id/setactive", authMiddleware({ anyAdmin: true }), async (req, res) => {
   const { id } = req.params;
   // logger.info(`got /setactive/${id}: ${JSON.stringify(req.body)}`)
   const useReplica = !req.body.active;

--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -23,12 +23,9 @@ import { db } from "../store";
 import sql from "sql-template-strings";
 import { BadRequestError, NotFoundError } from "../store/errors";
 
-const WEBHOOK_TIMEOUT = 5 * 1000;
 export const USER_SESSION_TIMEOUT = 5 * 60 * 1000; // 5 min
 const ACTIVE_TIMEOUT = 90 * 1000;
 
-const isLocalIP = require("is-local-ip");
-const { Resolver } = require("dns").promises;
 
 const app = Router();
 const hackMistSettings = (req, profiles) => {

--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -864,6 +864,33 @@ app.put("/:id/setactive", authMiddleware({ anyAdmin: true }), async (req, res) =
   res.end();
 });
 
+// sets 'isActive' field to false for many objects at once
+app.patch(
+  "/deactivate-many",
+  authMiddleware({ anyAdmin: true }),
+  validatePost("deactivate-many-payload"),
+  async (req, res) => {
+    let upRes;
+    try {
+      upRes = await db.stream.markIsActiveFalseMany(req.body.ids);
+
+      if (upRes.rowCount) {
+        console.log(
+          `set isActive=false for ids=${req.body.ids} rowCount=${upRes.rowCount}`
+        );
+      }
+    } catch (e) {
+      console.error(
+        `error setting stream active to false ids=${req.body.ids} err=${e}`
+      );
+      upRes = { rowCount: 0 };
+    }
+
+    res.status(200);
+    return res.json({ rowCount: upRes?.rowCount ?? 0 });
+  }
+);
+
 app.patch(
   "/:id",
   authMiddleware({}),

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -435,6 +435,16 @@ components:
           type: boolean
           description: If currently suspended
 
+    deactivate-many-payload:
+      type: object
+      additionalProperties: false
+      properties:
+        ids:
+          type: array
+          minItems: 1
+          items:
+            type: string
+
     stream-patch-payload:
       type: object
       additionalProperties: false

--- a/packages/api/src/store/stream-table.ts
+++ b/packages/api/src/store/stream-table.ts
@@ -291,6 +291,17 @@ export default class StreamTable extends Table<WithID<Stream>> {
     return upRes;
   }
 
+  async markIsActiveFalseMany(ids: Array<string>) {
+    const res = await this.db.query(
+      `UPDATE ${this.name
+      } SET data = jsonb_set(data, '{isActive}', 'false'::jsonb) WHERE id IN (${ids
+        .map((_, i) => "$" + (i + 1))
+        .join(",")})`,
+      ids
+    );
+    return res;
+  }
+
   addDefaultFieldsMany(objs: Array<Stream>): Array<Stream> {
     return objs.map(this.addDefaultFields);
   }


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
adds `deactivate-many` endpoint that allows to set  isActive fields to false
for multiple objects at once

<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

## -

- **How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
