### PR TITLE
www: add dockerized build (attempt 2)

### DIFF
--- a/.github/workflows/www.yml
+++ b/.github/workflows/www.yml
@@ -2,23 +2,7 @@ on: push
 jobs:
   build:
     runs-on: ubuntu-18.04
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_HOST_AUTH_METHOD: "trust"
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready --health-interval 10s --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-      rabbitmq:
-        image: rabbitmq
-        env:
-          RABBITMQ_DEFAULT_VHOST: "livepeer"
-        ports:
-          - 5672:5672
+
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -37,14 +21,6 @@ jobs:
           docker version
           docker login -u $DOCKER_USER -p $DOCKER_PASS
 
-      - name: yarn install
-        run: |
-          yarn install --frozen-lockfile
-
-      - name: yarn test
-        run: |
-          yarn test
-
       - name: docker build
         env:
           BRANCH: ${{ steps.extract_branch.outputs.branch }}
@@ -55,8 +31,9 @@ jobs:
           DOCKER_BUILDKIT: 1
         run: |
           export DOCKER_TAG=$(echo $BRANCH | tr -cd '[:alnum:]_')
-          yarn run lerna-run docker:build --scope=@livepeer.com/api
-          yarn run lerna-run docker:push --scope=@livepeer.com/api
+          cd packages/www
+          yarn run docker:build
+          yarn run docker:push
 
           # Livepeer internal build alerting
           curl -X POST https://holy-bread-207a.livepeer.workers.dev

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 **/.nyc_output
 **/build
 **/.next
+**/out
 **/coverage
 **/dist
 **/public

--- a/packages/www/.gitignore
+++ b/packages/www/.gitignore
@@ -40,3 +40,4 @@ jspm_packages
 .env.build
 .env.local
 .now
+out

--- a/packages/www/Dockerfile
+++ b/packages/www/Dockerfile
@@ -4,8 +4,9 @@ FROM node:12
 
 WORKDIR /app
 ADD package.json package.json
+ADD yarn.lock yarn.lock
 ADD lerna.json lerna.json
 ADD . .
-RUN yarn install
+RUN yarn install --frozen-lockfile
 WORKDIR /app/packages/www
 CMD yarn run start

--- a/packages/www/Dockerfile
+++ b/packages/www/Dockerfile
@@ -1,0 +1,11 @@
+# To be run from the root of the repository so that we can pick up design-system too
+
+FROM node:12
+
+WORKDIR /app
+ADD package.json package.json
+ADD lerna.json lerna.json
+ADD . .
+RUN yarn install
+WORKDIR /app/packages/www
+CMD yarn run start

--- a/packages/www/Dockerfile.dockerignore
+++ b/packages/www/Dockerfile.dockerignore
@@ -23,4 +23,4 @@ packages/*
 */*/out
 
 # So you can change this without forcing a rebuild
-Dockerfile
+**/Dockerfile

--- a/packages/www/Dockerfile.dockerignore
+++ b/packages/www/Dockerfile.dockerignore
@@ -1,0 +1,26 @@
+# Package to build
+packages/*
+!packages/api
+!packages/design-system
+!packages/www
+
+# General git and node frameworks files
+.git
+.github
+.cache
+**/node_modules
+**/coverage
+**/yarn-error.log
+**/.next
+
+# API-specific
+*/*/minio
+*/*/dist
+*/*/docs
+
+# WWW-specific
+*/*/.next
+*/*/out
+
+# So you can change this without forcing a rebuild
+Dockerfile

--- a/packages/www/package.json
+++ b/packages/www/package.json
@@ -6,10 +6,12 @@
     "prepare": "cd ../api && yarn run prepare",
     "dev": "next",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p 3012",
     "postbuild": "next-sitemap",
     "type-check": "tsc --pretty --noEmit",
-    "docs-positions": "node ./generate-docs-positions.js"
+    "docs-positions": "node ./generate-docs-positions.js",
+    "docker:build": "cd ../.. && DOCKER_BUILDKIT=1 docker build -t livepeerci/www:${DOCKER_TAG:-master} -f packages/www/Dockerfile .",
+    "docker:push": "docker push livepeerci/www:${DOCKER_TAG:-master}"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Second attempt at adding a Dockerized version of `@livepeer.com/www` for livepeer-in-a-box. This one is less hacky than https://github.com/livepeer/livepeer-com/pull/423 but a bit heavier; it packages up the entire monorepo so it can run an actual Next.js server with `next start`.

Because it's a big build I added a separate Github Actions workflow that builds the WWW container in parallel; hopefully it won't slow down the overall time to completion of the GH actions that way.