### PR TITLE
update stripe script to create customer accounts for users that don't have one

### DIFF
--- a/packages/api/src/controllers/stripe.js
+++ b/packages/api/src/controllers/stripe.js
@@ -89,6 +89,7 @@ app.post("/migrate-users", async (req, res) => {
   const [users] = await db.user.find(
     [sql`users.data->>'stripeCustomerId' IS NULL`],
     {
+      limit: 9999999999,
       useReplica: false,
     }
   );

--- a/packages/api/src/controllers/stripe.js
+++ b/packages/api/src/controllers/stripe.js
@@ -2,6 +2,7 @@ import Router from "express/lib/router";
 import { db } from "../store";
 import Stripe from "stripe";
 import { products } from "../config";
+import sql from "sql-template-strings";
 
 const app = Router();
 const endpointSecret = process.env.LP_STRIPE_WEBHOOK_SECRET;
@@ -86,8 +87,10 @@ app.post("/migrate-users", async (req, res) => {
   }
 
   const [users] = await db.user.find(
-    {},
-    { limit: 9999999999, useReplica: false }
+    [sql`users.data->>'stripeCustomerId' IS NULL`],
+    {
+      useReplica: false,
+    }
   );
 
   for (let index = 0; index < users.length; index++) {
@@ -127,6 +130,7 @@ app.post("/migrate-users", async (req, res) => {
       await sleep(200);
     }
   }
+
   res.json(users);
 });
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
A user reported that the dashboard was broken for them. After looking into the issue it was discovered that this user didn't have stripe customer account created upon registration. This PR updates the stripe migration script to filter by user accounts that don't have a stripe account, so we can create one for them.