### PR TITLE
api: downgrade rabbitmq to one that works

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
         ports:
           - 5432:5432
       rabbitmq:
-        image: rabbitmq
+        image: rabbitmq@sha256:f0be9e47ec42081a36593dfc6604274a623caed074fc043e0a927fbd1533dc20
         env:
           RABBITMQ_DEFAULT_VHOST: "livepeer"
         ports:

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -17,7 +17,7 @@
     "docker": "run-s docker:build docker:push",
     "postgres:start": "docker run --rm -d --name postgres -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 -v \"$(pwd)/data/postgres:/var/lib/postgresql/data\" postgres",
     "postgres:stop": "docker rm -f postgres",
-    "rabbitmq:start": "docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 -e RABBITMQ_DEFAULT_VHOST=livepeer rabbitmq:3-management",
+    "rabbitmq:start": "docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 -e RABBITMQ_DEFAULT_VHOST=livepeer rabbitmq@sha256:f0be9e47ec42081a36593dfc6604274a623caed074fc043e0a927fbd1533dc20",
     "rabbitmq:stop": "docker rm -f rabbitmq",
     "prepare:babel": "babel --extensions '.ts,.js' --ignore '**/*.test.js,**/*.test-data.js' --out-dir=dist --source-maps=true src",
     "prepare:redoc": "redoc-cli bundle --cdn -o docs/index.html src/schema/schema.yaml",


### PR DESCRIPTION
RabbitMQ deprecated `RABBIT_DEFAULT_VHOST` or whatever it's called. Rolling back to a version that has that until we can figure out something more elegant.