### PR TITLE
rename stripe migration endpoint

### DIFF
--- a/packages/api/src/controllers/stripe.js
+++ b/packages/api/src/controllers/stripe.js
@@ -80,7 +80,7 @@ async function sleep(millis) {
 }
 
 // Migrate existing users to stripe
-app.post("/migrate-users", async (req, res) => {
+app.post("/migrate-users-to-stripe", async (req, res) => {
   if (process.env.LP_STRIPE_SECRET_KEY != req.body.stripeSecretKey) {
     res.status(403);
     return res.json({ errors: ["unauthorized"] });


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
I renamed the stripe migration endpoint as a precaution so we don't accidentally invoke the old one and import thousands of duplicate users in stripe.