### PR TITLE
api: Implement common protocol for RabbitMQ messages

### DIFF
--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -139,7 +139,6 @@ async function triggerManyIdleStreamsWebhook(
         type: "webhook_event",
         id: uuid(),
         timestamp: Date.now(),
-        manifestId: stream.playbackId,
         event: "stream.idle",
         streamId: stream.id,
         userId: user.id,
@@ -903,9 +902,8 @@ app.put(
       type: "webhook_event",
       id: uuid(),
       timestamp: Date.now(),
-      manifestId: stream.playbackId,
-      event: event,
       streamId: id,
+      event: event,
       userId: user.id,
     });
 
@@ -930,10 +928,9 @@ app.put(
               type: "webhook_event",
               id: uuid(),
               timestamp: Date.now(),
-              manifestId: session.playbackId,
+              streamId: id,
               event: "recording.ready",
               userId: user.id,
-              streamId: id,
               sessionId: session.id,
               payload: {
                 recordingUrl,
@@ -961,9 +958,8 @@ app.put(
           type: "webhook_event",
           id: uuid(),
           timestamp: Date.now(),
-          manifestId: stream.playbackId,
-          event: "recording.started",
           streamId: id,
+          event: "recording.started",
           userId: user.id,
         });
       }
@@ -1470,6 +1466,8 @@ app.post("/hook", authMiddleware({ anyAdmin: true }), async (req, res) => {
 
   res.json({
     manifestID,
+    streamID: stream.parentId ?? streamId,
+    sessionID: streamId,
     presets: stream.presets,
     profiles: stream.profiles,
     objectStore,
@@ -1497,9 +1495,8 @@ app.post(
       type: "webhook_event",
       id: uuid(),
       timestamp: Date.now(),
-      manifestId: stream.playbackId,
-      event: "stream.detection",
       streamId: stream.id,
+      event: "stream.detection",
       userId: stream.userId,
       payload: {
         seqNo,

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1487,6 +1487,7 @@ app.post(
     console.log(`DetectionWebhookPayload: ${JSON.stringify(req.body)}`);
 
     const msg: messages.WebhookEvent = {
+      type: "webhook_event",
       id: uuid(),
       event: "stream.detection",
       createdAt: Date.now(),

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -20,7 +20,7 @@ import { BadRequestError } from "../store/errors";
 import { DBStream, StreamStats } from "../store/stream-table";
 import { WithID } from "../store/types";
 import { IStore } from "../types/common";
-import { WebhookMessage } from "../webhooks/cannon";
+import messages from "../store/messages";
 import { getBroadcasterHandler } from "./broadcaster";
 import { generateStreamKey } from "./generate-stream-key";
 import {
@@ -1486,7 +1486,7 @@ app.post(
     }
     console.log(`DetectionWebhookPayload: ${JSON.stringify(req.body)}`);
 
-    const msg: WebhookMessage = {
+    const msg: messages.WebhookEvent = {
       id: uuid(),
       event: "stream.detection",
       createdAt: Date.now(),

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -932,13 +932,12 @@ app.put(
               timestamp: Date.now(),
               manifestId: session.playbackId,
               event: "recording.ready",
-              streamId: id,
               userId: user.id,
+              streamId: id,
+              sessionId: session.id,
               payload: {
                 recordingUrl,
                 mp4Url,
-                // this info is for cannon
-                sessionId: session.id,
               },
             },
             USER_SESSION_TIMEOUT + HTTP_PUSH_TIMEOUT

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -96,6 +96,7 @@ components:
         - webhookId
         - eventId
         - statusCode
+      additionalProperties: false
       properties:
         id:
           type: string
@@ -117,16 +118,29 @@ components:
           type: number
           readOnly: true
           description:
-            Timestamp (in milliseconds) at which stream object was created
+            Timestamp (in milliseconds) at which webhook response object was
+            created
           example: 1587667174725
         statusCode:
           type: number
           default: 0
-        responseObject:
+        response:
           type: object
-          additionalProperties: true
+          additionalProperties: false
           properties:
             body:
+              type: string
+            headers:
+              type: object
+              additionalProperties:
+                type: array
+                items:
+                  type: string
+            redirected:
+              type: boolean
+            status:
+              type: number
+            statusText:
               type: string
 
     detection-webhook-payload:

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -121,6 +121,8 @@ components:
             Timestamp (in milliseconds) at which webhook response object was
             created
           example: 1587667174725
+        duration:
+          type: number
         statusCode:
           type: number
           default: 0

--- a/packages/api/src/store/messages.ts
+++ b/packages/api/src/store/messages.ts
@@ -4,6 +4,9 @@ import { WithID } from "./types";
 import { DBWebhook, EventKey } from "./webhook-table";
 
 namespace messages {
+  export type Any = WebhookEvent | WebhookTrigger;
+  export type Types = Any["type"];
+
   interface TPayload {
     [key: string]: any;
   }
@@ -16,9 +19,6 @@ namespace messages {
     userId: string;
     streamId: string;
     payload?: TPayload;
-    retries?: number;
-    lastInterval?: number;
-    status?: string;
   }
 
   export interface WebhookTrigger {

--- a/packages/api/src/store/messages.ts
+++ b/packages/api/src/store/messages.ts
@@ -7,25 +7,36 @@ namespace messages {
   export type Any = WebhookEvent | WebhookTrigger;
   export type Types = Any["type"];
 
+  // This is a global format followed by all messages sent by Livepeer services
+  // to the message broker (RabbitMQ as of writing this).
+  export interface Base {
+    // Type should be unique for each message schema, indicating what object
+    // type to parse and interpret the message data into.
+    type: Types;
+    // ID is generally a randomly generated UUID.
+    id: string;
+    // Unix timestamp in milliseconds.
+    timestamp: number;
+    // Manifest ID of the stream, which is known in the API as the playback ID.
+    manifestId: string;
+  }
+
   interface TPayload {
     [key: string]: any;
   }
 
-  export interface WebhookEvent {
+  export interface WebhookEvent extends Base {
     type: "webhook_event";
-    id: string;
     event: EventKey;
-    createdAt: number;
     userId: string;
     streamId: string;
     payload?: TPayload;
   }
 
-  export interface WebhookTrigger {
+  export interface WebhookTrigger extends Base {
     type: "webhook_trigger";
-    id: string;
-    user: WithID<User>;
     event: WebhookEvent;
+    user: WithID<User>;
     webhook: DBWebhook;
     stream: DBStream;
     retries?: number;

--- a/packages/api/src/store/messages.ts
+++ b/packages/api/src/store/messages.ts
@@ -1,4 +1,7 @@
-import { EventKey } from "./webhook-table";
+import { User } from "../schema/types";
+import { DBStream } from "./stream-table";
+import { WithID } from "./types";
+import { DBWebhook, EventKey } from "./webhook-table";
 
 namespace messages {
   interface TPayload {
@@ -6,6 +9,7 @@ namespace messages {
   }
 
   export interface WebhookEvent {
+    type: "webhook_event";
     id: string;
     event: EventKey;
     createdAt: number;
@@ -15,6 +19,17 @@ namespace messages {
     retries?: number;
     lastInterval?: number;
     status?: string;
+  }
+
+  export interface WebhookTrigger {
+    type: "webhook_trigger";
+    id: string;
+    user: WithID<User>;
+    event: WebhookEvent;
+    webhook: DBWebhook;
+    stream: DBStream;
+    retries?: number;
+    lastInterval?: number;
   }
 }
 

--- a/packages/api/src/store/messages.ts
+++ b/packages/api/src/store/messages.ts
@@ -17,8 +17,8 @@ namespace messages {
     id: string;
     // Unix timestamp in milliseconds.
     timestamp: number;
-    // Manifest ID of the stream, which is known in the API as the playback ID.
-    manifestId: string;
+    // ID of the stream as defined by the API in the authWebhook (ID from DB).
+    streamId: string;
   }
 
   type TPayload = {
@@ -29,7 +29,6 @@ namespace messages {
     type: "webhook_event";
     event: EventKey;
     userId: string;
-    streamId: string;
     sessionId?: string;
     // Additional information about the event to be sent to the user on the
     // webhook request.

--- a/packages/api/src/store/messages.ts
+++ b/packages/api/src/store/messages.ts
@@ -1,0 +1,21 @@
+import { EventKey } from "./webhook-table";
+
+namespace messages {
+  interface TPayload {
+    [key: string]: any;
+  }
+
+  export interface WebhookEvent {
+    id: string;
+    event: EventKey;
+    createdAt: number;
+    userId: string;
+    streamId: string;
+    payload?: TPayload;
+    retries?: number;
+    lastInterval?: number;
+    status?: string;
+  }
+}
+
+export default messages;

--- a/packages/api/src/store/messages.ts
+++ b/packages/api/src/store/messages.ts
@@ -21,15 +21,18 @@ namespace messages {
     manifestId: string;
   }
 
-  interface TPayload {
-    [key: string]: any;
-  }
+  type TPayload = {
+    readonly [key: string]: any;
+  };
 
   export interface WebhookEvent extends Base {
     type: "webhook_event";
     event: EventKey;
     userId: string;
     streamId: string;
+    sessionId?: string;
+    // Additional information about the event to be sent to the user on the
+    // webhook request.
     payload?: TPayload;
   }
 

--- a/packages/api/src/store/rabbit-queue.test.ts
+++ b/packages/api/src/store/rabbit-queue.test.ts
@@ -25,7 +25,8 @@ describe("Queue", () => {
     await queue.publish("events.stream.started", {
       type: "webhook_event",
       id: "abc123",
-      createdAt: Date.now(),
+      timestamp: Date.now(),
+      manifestId: "manifestId",
       event: "stream.started",
       streamId: "asdf",
       userId: "fdsa",
@@ -50,7 +51,8 @@ describe("Queue", () => {
     await queue.publish("events.stream.started", {
       type: "webhook_event",
       id: "custom_msg",
-      createdAt: Date.now(),
+      timestamp: Date.now(),
+      manifestId: "manifestId",
       event: "stream.started",
       streamId: "asdf",
       userId: "fdsa",
@@ -78,7 +80,8 @@ describe("Queue", () => {
       {
         type: "webhook_event",
         id: "delayedMsg",
-        createdAt: Date.now(),
+        timestamp: Date.now(),
+        manifestId: "manifestId",
         event: "recording.ready",
         streamId: "asdf",
         userId: "fdsa",
@@ -112,7 +115,8 @@ describe("Queue", () => {
       {
         type: "webhook_event",
         id: "delayedMsg2",
-        createdAt: Date.now(),
+        timestamp: Date.now(),
+        manifestId: "manifestId",
         event: "recording.ready",
         streamId: "asdf",
         userId: "fdsa",

--- a/packages/api/src/store/rabbit-queue.test.ts
+++ b/packages/api/src/store/rabbit-queue.test.ts
@@ -26,9 +26,8 @@ describe("Queue", () => {
       type: "webhook_event",
       id: "abc123",
       timestamp: Date.now(),
-      manifestId: "manifestId",
-      event: "stream.started",
       streamId: "asdf",
+      event: "stream.started",
       userId: "fdsa",
     });
     await sleep(500);
@@ -52,9 +51,8 @@ describe("Queue", () => {
       type: "webhook_event",
       id: "custom_msg",
       timestamp: Date.now(),
-      manifestId: "manifestId",
-      event: "stream.started",
       streamId: "asdf",
+      event: "stream.started",
       userId: "fdsa",
     });
     await sem.wait(2000);
@@ -81,9 +79,8 @@ describe("Queue", () => {
         type: "webhook_event",
         id: "delayedMsg",
         timestamp: Date.now(),
-        manifestId: "manifestId",
-        event: "recording.ready",
         streamId: "asdf",
+        event: "recording.ready",
         userId: "fdsa",
       },
       2000
@@ -116,9 +113,8 @@ describe("Queue", () => {
         type: "webhook_event",
         id: "delayedMsg2",
         timestamp: Date.now(),
-        manifestId: "manifestId",
-        event: "recording.ready",
         streamId: "asdf",
+        event: "recording.ready",
         userId: "fdsa",
       },
       1000

--- a/packages/api/src/store/rabbit-queue.test.ts
+++ b/packages/api/src/store/rabbit-queue.test.ts
@@ -22,14 +22,13 @@ describe("Queue", () => {
 
   it("should be able to emit events and catch it via default consumer", async () => {
     await queue.consume("events", queue.handleMessage.bind(queue));
-    await queue.publish("events.test", {
+    await queue.publish("events.stream.started", {
+      type: "webhook_event",
       id: "abc123",
       createdAt: Date.now(),
-      channel: "test.channel",
-      event: "teststarted",
+      event: "stream.started",
       streamId: "asdf",
       userId: "fdsa",
-      isConsumed: false,
     });
     await sleep(500);
     console.log("done");
@@ -48,14 +47,13 @@ describe("Queue", () => {
 
     await queue.consume("events", onMsg);
 
-    await queue.publish("events.test", {
+    await queue.publish("events.stream.started", {
+      type: "webhook_event",
       id: "custom_msg",
       createdAt: Date.now(),
-      channel: "test.channel",
-      event: "teststarted",
+      event: "stream.started",
       streamId: "asdf",
       userId: "fdsa",
-      isConsumed: false,
     });
     await sem.wait(2000);
     expect(resp.id).toBe("custom_msg");
@@ -76,15 +74,14 @@ describe("Queue", () => {
     await queue.consume("events", onMsg);
 
     await queue.delayedPublish(
-      "events.recording",
+      "events.recording.ready",
       {
+        type: "webhook_event",
         id: "delayedMsg",
         createdAt: Date.now(),
-        channel: "test.channel",
-        event: "teststarted",
+        event: "recording.ready",
         streamId: "asdf",
         userId: "fdsa",
-        isConsumed: false,
       },
       2000
     );
@@ -111,15 +108,14 @@ describe("Queue", () => {
     await queue.consume("events", onMsg);
 
     await queue.delayedPublish(
-      "events.recording",
+      "events.recording.ready",
       {
+        type: "webhook_event",
         id: "delayedMsg2",
         createdAt: Date.now(),
-        channel: "test.channel",
-        event: "teststarted",
+        event: "recording.ready",
         streamId: "asdf",
         userId: "fdsa",
-        isConsumed: false,
       },
       1000
     );

--- a/packages/api/src/store/rabbit-queue.ts
+++ b/packages/api/src/store/rabbit-queue.ts
@@ -1,22 +1,23 @@
 import amqp from "amqp-connection-manager";
 import { ChannelWrapper, AmqpConnectionManager } from "amqp-connection-manager";
-import { Channel, ConsumeMessage, Options } from "amqplib";
+import { Channel, ConsumeMessage } from "amqplib";
+import messages from "./messages";
+import { EventKey } from "./webhook-table";
 
-const QUEUE_NAME = "webhook_default_queue";
 const EXCHANGE_NAME = "webhook_default_exchange";
-const WEBHOOK_CANNON_SINGLE_URL = "webhook_cannon_single_url";
+const QUEUES = {
+  events: "webhook_default_queue",
+  webhooks: "webhook_cannon_single_url",
+} as const;
+
+type QueueName = keyof typeof QUEUES;
+type RoutingKey = `events.${EventKey}` | `webhooks.${string}`;
 
 export default class MessageQueue {
   private channel: ChannelWrapper;
   private connection: AmqpConnectionManager;
-  private queues: Record<string, string>;
 
-  constructor() {
-    this.queues = {
-      events: QUEUE_NAME,
-      webhooks: WEBHOOK_CANNON_SINGLE_URL,
-    };
-  }
+  constructor() {}
 
   public connect(url: string): Promise<void> {
     // Create a new connection manager
@@ -25,11 +26,11 @@ export default class MessageQueue {
       json: true,
       setup: async (channel: Channel) => {
         await Promise.all([
-          channel.assertQueue(this.queues.events, { durable: true }),
-          channel.assertQueue(this.queues.webhooks, { durable: true }),
+          channel.assertQueue(QUEUES.events, { durable: true }),
+          channel.assertQueue(QUEUES.webhooks, { durable: true }),
           channel.assertExchange(EXCHANGE_NAME, "topic", { durable: true }),
-          channel.bindQueue(this.queues.events, EXCHANGE_NAME, "events.#"),
-          channel.bindQueue(this.queues.webhooks, EXCHANGE_NAME, "webhooks.#"),
+          channel.bindQueue(QUEUES.events, EXCHANGE_NAME, "events.#"),
+          channel.bindQueue(QUEUES.webhooks, EXCHANGE_NAME, "webhooks.#"),
           channel.prefetch(1),
         ]);
       },
@@ -69,7 +70,7 @@ export default class MessageQueue {
   }
 
   public async consume(
-    queueName: string,
+    queueName: QueueName,
     func: (msg: ConsumeMessage) => void
   ): Promise<void> {
     if (!func) {
@@ -77,7 +78,7 @@ export default class MessageQueue {
     }
     console.log("adding consumer");
     await this.channel.addSetup((channel: Channel) => {
-      return channel.consume(this.queues[queueName], func);
+      return channel.consume(QUEUES[queueName], func);
     });
   }
 
@@ -87,19 +88,19 @@ export default class MessageQueue {
     this.ack(data);
   }
 
-  public async sendToQueue(msg: Object): Promise<void> {
+  public async sendToQueue(msg: messages.Any): Promise<void> {
     console.log("emitting ", msg);
-    await this.channel.sendToQueue(QUEUE_NAME, msg);
+    await this.channel.sendToQueue(QUEUES.events, msg);
   }
 
-  public async publish(route: string, msg: object): Promise<void> {
+  public async publish(route: RoutingKey, msg: messages.Any): Promise<void> {
     console.log(`publishing to ${route} : ${JSON.stringify(msg)}`);
     await this.channel.publish(EXCHANGE_NAME, route, msg, { persistent: true });
   }
 
   public async delayedPublish(
-    routingKey: string,
-    msg: Object,
+    routingKey: RoutingKey,
+    msg: messages.Any,
     delay: number
   ): Promise<void> {
     await this.channel.addSetup((channel: Channel) => {

--- a/packages/api/src/test-server.ts
+++ b/packages/api/src/test-server.ts
@@ -67,7 +67,7 @@ async function setupServer() {
 
 afterAll(async () => {
   if (server) {
-    await server.webhook.stop();
+    server.webhook.stop();
     await server.queue.close();
     await server.close();
     server = null;

--- a/packages/api/src/webhooks/cannon.test.ts
+++ b/packages/api/src/webhooks/cannon.test.ts
@@ -233,15 +233,15 @@ describe("webhook cannon", () => {
       });
       expect(res.status).toBe(201);
 
-      const semaphs = [semaphore(), semaphore()];
+      const sems = [semaphore(), semaphore()];
       let calledFlags = [false, false];
       webhookCallback = () => {
         calledFlags[0] = true;
-        semaphs[0].release();
+        sems[0].release();
       };
       webhook2Callback = () => {
         calledFlags[1] = true;
-        semaphs[1].release();
+        sems[1].release();
       };
 
       await server.queue.publish("events.stream.started", {
@@ -254,7 +254,7 @@ describe("webhook cannon", () => {
         userId: nonAdminUser.id,
       });
 
-      await Promise.all(semaphs.map((s) => s.wait(3000)));
+      await Promise.all(sems.map((s) => s.wait(3000)));
       expect(calledFlags).toEqual([true, true]);
     });
 
@@ -333,17 +333,17 @@ describe("webhook cannon", () => {
       });
       expect(res.status).toBe(201);
 
-      const semaphs = [semaphore(), semaphore()];
+      const sems = [semaphore(), semaphore()];
       let calledCounts = [0, 0];
       webhookCallback = () => {
         const attempt = ++calledCounts[0];
         if (attempt < 4) throw new Error("backoff! im busy 😡");
-        semaphs[0].release();
+        sems[0].release();
       };
       webhook2Callback = () => {
         const attempt = ++calledCounts[1];
         if (attempt < 2) throw new Error("could you please try later? 😇");
-        semaphs[1].release();
+        sems[1].release();
       };
       server.webhook.calcBackoff = () => 100;
 
@@ -357,7 +357,7 @@ describe("webhook cannon", () => {
         userId: nonAdminUser.id,
       });
 
-      await Promise.all(semaphs.map((s) => s.wait(3000)));
+      await Promise.all(sems.map((s) => s.wait(3000)));
       expect(calledCounts).toEqual([4, 2]);
     });
   });

--- a/packages/api/src/webhooks/cannon.test.ts
+++ b/packages/api/src/webhooks/cannon.test.ts
@@ -210,9 +210,8 @@ describe("webhook cannon", () => {
         type: "webhook_event",
         id: "webhook_test_12",
         timestamp: Date.now(),
-        manifestId: "manifestId",
-        event: "stream.started",
         streamId: "streamid",
+        event: "stream.started",
         userId: nonAdminUser.id,
       });
 
@@ -248,9 +247,8 @@ describe("webhook cannon", () => {
         type: "webhook_event",
         id: "webhook_test_12",
         timestamp: Date.now(),
-        manifestId: "manifestId",
-        event: "stream.started",
         streamId: "streamid",
+        event: "stream.started",
         userId: nonAdminUser.id,
       });
 
@@ -279,9 +277,8 @@ describe("webhook cannon", () => {
         type: "webhook_event",
         id: "webhook_test_12",
         timestamp: Date.now(),
-        manifestId: "manifestId",
-        event: "stream.started",
         streamId: "streamid",
+        event: "stream.started",
         userId: nonAdminUser.id,
       });
 
@@ -294,9 +291,8 @@ describe("webhook cannon", () => {
         type: "webhook_event",
         id: "webhook_test_42",
         timestamp: Date.now(),
-        manifestId: "manifestId",
-        event: "stream.idle",
         streamId: "streamid",
+        event: "stream.idle",
         userId: nonAdminUser.id,
       });
 
@@ -310,9 +306,8 @@ describe("webhook cannon", () => {
         type: "webhook_event",
         id: "webhook_test_93",
         timestamp: Date.now(),
-        manifestId: "manifestId",
-        event: "stream.unknown" as any,
         streamId: "streamid",
+        event: "stream.unknown" as any,
         userId: nonAdminUser.id,
       });
 
@@ -351,9 +346,8 @@ describe("webhook cannon", () => {
         type: "webhook_event",
         id: "webhook_test_12",
         timestamp: Date.now(),
-        manifestId: "manifestId",
-        event: "stream.started",
         streamId: "streamid",
+        event: "stream.started",
         userId: nonAdminUser.id,
       });
 

--- a/packages/api/src/webhooks/cannon.test.ts
+++ b/packages/api/src/webhooks/cannon.test.ts
@@ -200,7 +200,8 @@ describe("webhook cannon", () => {
       await server.queue.publish("events.stream.started", {
         type: "webhook_event",
         id: "webhook_test_12",
-        createdAt: Date.now(),
+        timestamp: Date.now(),
+        manifestId: "manifestId",
         event: "stream.started",
         streamId: "streamid",
         userId: nonAdminUser.id,
@@ -232,7 +233,8 @@ describe("webhook cannon", () => {
       await server.queue.publish("events.stream.started", {
         type: "webhook_event",
         id: "webhook_test_12",
-        createdAt: Date.now(),
+        timestamp: Date.now(),
+        manifestId: "manifestId",
         event: "stream.started",
         streamId: "streamid",
         userId: nonAdminUser.id,
@@ -262,7 +264,8 @@ describe("webhook cannon", () => {
       await server.queue.publish("events.stream.started", {
         type: "webhook_event",
         id: "webhook_test_12",
-        createdAt: Date.now(),
+        timestamp: Date.now(),
+        manifestId: "manifestId",
         event: "stream.started",
         streamId: "streamid",
         userId: nonAdminUser.id,
@@ -276,7 +279,8 @@ describe("webhook cannon", () => {
       await server.queue.publish("events.stream.idle", {
         type: "webhook_event",
         id: "webhook_test_42",
-        createdAt: Date.now(),
+        timestamp: Date.now(),
+        manifestId: "manifestId",
         event: "stream.idle",
         streamId: "streamid",
         userId: nonAdminUser.id,
@@ -291,7 +295,8 @@ describe("webhook cannon", () => {
       await server.queue.publish("events.stream.unknown" as any, {
         type: "webhook_event",
         id: "webhook_test_93",
-        createdAt: Date.now(),
+        timestamp: Date.now(),
+        manifestId: "manifestId",
         event: "stream.unknown" as any,
         streamId: "streamid",
         userId: nonAdminUser.id,

--- a/packages/api/src/webhooks/cannon.test.ts
+++ b/packages/api/src/webhooks/cannon.test.ts
@@ -197,14 +197,13 @@ describe("webhook cannon", () => {
         sem.release();
       };
 
-      await server.queue.publish("events.stream", {
+      await server.queue.publish("events.stream.started", {
+        type: "webhook_event",
         id: "webhook_test_12",
-        time: Date.now(),
-        channel: "test.channel",
+        createdAt: Date.now(),
         event: "stream.started",
         streamId: "streamid",
         userId: nonAdminUser.id,
-        isConsumed: false,
       });
 
       await sem.wait(3000);
@@ -230,14 +229,13 @@ describe("webhook cannon", () => {
         if (callCount === 2) sem.release();
       };
 
-      await server.queue.publish("events.stream", {
+      await server.queue.publish("events.stream.started", {
+        type: "webhook_event",
         id: "webhook_test_12",
-        time: Date.now(),
-        channel: "test.channel",
+        createdAt: Date.now(),
         event: "stream.started",
         streamId: "streamid",
         userId: nonAdminUser.id,
-        isConsumed: false,
       });
 
       await sem.wait(3000);
@@ -261,14 +259,13 @@ describe("webhook cannon", () => {
         sem.release();
       };
 
-      await server.queue.publish("events.stream", {
+      await server.queue.publish("events.stream.started", {
+        type: "webhook_event",
         id: "webhook_test_12",
-        time: Date.now(),
-        channel: "test.channel",
+        createdAt: Date.now(),
         event: "stream.started",
         streamId: "streamid",
         userId: nonAdminUser.id,
-        isConsumed: false,
       });
 
       await sem.wait(3000);
@@ -276,14 +273,13 @@ describe("webhook cannon", () => {
       expect(receivedEvent).toBe("stream.started");
 
       sem = semaphore();
-      await server.queue.publish("events.stream", {
+      await server.queue.publish("events.stream.idle", {
+        type: "webhook_event",
         id: "webhook_test_42",
-        time: Date.now(),
-        channel: "test.channel",
+        createdAt: Date.now(),
         event: "stream.idle",
         streamId: "streamid",
         userId: nonAdminUser.id,
-        isConsumed: false,
       });
 
       await sem.wait(3000);
@@ -292,14 +288,13 @@ describe("webhook cannon", () => {
 
       // does not receive some random event
       sem = semaphore();
-      await server.queue.publish("events.stream", {
+      await server.queue.publish("events.stream.unknown" as any, {
+        type: "webhook_event",
         id: "webhook_test_93",
-        time: Date.now(),
-        channel: "test.channel",
-        event: "stream.unknown",
+        createdAt: Date.now(),
+        event: "stream.unknown" as any,
         streamId: "streamid",
         userId: nonAdminUser.id,
-        isConsumed: false,
       });
 
       await sem.wait(1000);

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -149,6 +149,7 @@ export default class WebhookCannon {
       console.log("Error publish webhook trigger message: ", error);
       return false; // nack to retry processing the event
     }
+    return true;
   }
 
   async handleWebhookQueue(data: ConsumeMessage) {

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -131,7 +131,7 @@ export default class WebhookCannon {
       const baseTrigger = {
         type: "webhook_trigger" as const,
         timestamp: Date.now(),
-        manifestId: event.manifestId,
+        streamId: event.streamId,
         event,
         stream: sanitized,
         user,

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -54,11 +54,17 @@ export default class WebhookCannon {
     }
 
     if (event.event === "recording.ready") {
-      if (!event.payload.sessionId) {
+      if (event.payload.sessionId) {
+        // TODO: Remove this. Backward compat only during deploy
+        event.sessionId = event.payload.sessionId;
+        event.payload = { ...event.payload, sessionId: undefined };
+      }
+      const sessionId = event.sessionId;
+      if (!sessionId) {
         this.queue.ack(data);
         return;
       }
-      const session = await this.db.stream.get(event.payload.sessionId, {
+      const session = await this.db.stream.get(sessionId, {
         useReplica: false,
       });
       if (!session) {
@@ -70,7 +76,6 @@ export default class WebhookCannon {
         this.queue.ack(data);
         return;
       }
-      delete event.payload.sessionId;
     }
 
     try {

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -225,9 +225,11 @@ export default class WebhookCannon {
   async _fireHook(trigger: messages.WebhookTrigger, verifyUrl = true) {
     const { event, webhook, stream: sanitized, user } = trigger;
     if (!event || !webhook || !sanitized || !user) {
-      throw new Error(
-        `_firehook Error: event, webhook, sanitized and user are required`
+      console.error(
+        `invalid webhook trigger message received. type=${trigger.type} message=`,
+        trigger
       );
+      return;
     }
     console.log(`trying webhook ${webhook.name}: ${webhook.url}`);
     let ips, urlObj, isLocal;

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -336,7 +336,13 @@ export default class WebhookCannon {
       webhookId: webhook.id,
       eventId: event.id,
       statusCode: resp.status,
-      response: resp,
+      response: {
+        body: await resp.text(),
+        headers: resp.headers.raw(),
+        redirected: resp.redirected,
+        status: resp.status,
+        statusText: resp.statusText,
+      },
     });
   }
 }

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -9,11 +9,10 @@ import { DB } from "../store/db";
 import messages from "../store/messages";
 import MessageQueue from "../store/rabbit-queue";
 import Model from "../store/model";
-import { DBWebhook, EventKey } from "../store/webhook-table";
+import { DBWebhook } from "../store/webhook-table";
 import { fetchWithTimeout } from "../util";
 import logger from "../logger";
 import { sign } from "../controllers/helpers";
-// const resolver = new Resolver();
 
 const WEBHOOK_TIMEOUT = 5 * 1000;
 const MAX_BACKOFF = 10 * 60 * 1000;

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -180,7 +180,7 @@ export default class WebhookCannon {
     this.verifyUrls = false;
   }
 
-  calcBackoff(lastInterval?: number): number {
+  public calcBackoff = (lastInterval?: number): number => {
     if (!lastInterval || lastInterval < 1000) {
       lastInterval = 5000;
     }
@@ -190,7 +190,7 @@ export default class WebhookCannon {
     }
     // RabbitMQ expects integer
     return newInterval | 0;
-  }
+  };
 
   retry(trigger: messages.WebhookTrigger) {
     if (trigger?.retries >= MAX_RETRIES) {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This is to implement the common protocol proposed with the `data/analyzer` logic for 
events sent from our services into RabbitMQ. The main reason for this protocol is that
we need all events to be serialized on the **same** data stream (~a queue), while still being
able to process them correctly according to their corresponding type. In the low-level, this
meant:
 - a `type` field which specifies what is the type of the message. This field should be parsed
 first to determine how to parse the rest of the event (in [data/analyzer](https://github.com/livepeer/livepeer-data/blob/5b75a623cbb307520e42001663532c1572f6b46b/pkg/data/parse.go#L13))
 - a `timestamp` field instead of a `createdAt`, which is how I had followed for `data/analyzer`
 and I think it makes sense for events/messages. 
 - a required `id` field because why not, should be helpful
 - a required `manifestId`, since not all Livepeer services understand stream IDs so that's the global stream identifier

2 things here that I intend to update `livepeer-data` for consistency (and functionality):
 - Timestamps should be in milliseconds instead of nanoseconds. Nano required `int64` and that's just
 not portable. JSON is not defined that way, and node doesn't even know how to serialize `bigint`s. This
 is a backward-incompatible change on `analyzer`, but I intend to do anyway since we're only in `staging` yet.
 - Will rename "events" to "messages" instead, which is what they actually are. In the API we already
 had the higher-level user-facing "events", so we should better keep those separate. This is just nomenclature
 in the code, so lower-pri and should have no incompatibilities.

**Specific updates (required)**
 - Improve data stored in `webhook_response` table, for more debuggability
 - Create separate types for the 2 cannon RabbitMQ messages (event and trigger)
 - Fix webhook retries (I think either the N*N bug was back or retries were broken)
 - Implement that common message protocol described above
 - Move `sessionId` field of `recording.ready` event out of the user-facing `payload`

## -

- **How did you test each of these updates (required)**
`yarn test` 
Mostly some structural changes on code very well exercised in the tests, so I believe
this is enough. Also added a test for webhook retries to make sure they keep working. 

**Does this pull request close any open issues?**
This is part of the movement to get `multistream`s in prod, with connectivity data available
in stream health/`data/anlyzer`.

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
