### PR TITLE
www/multistream: Fix react hooks and some final touches

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -81,6 +81,7 @@ export default async function makeApp(params: CliArgs) {
     "https://livepeer.monster",
     "https://explorer.livepeer.org",
     "http://localhost:3000",
+    /livepeer.vercel\.app$/,
     /livepeerorg.vercel\.app$/,
     /\.livepeerorg.now\.sh$/,
   ];

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -481,6 +481,11 @@ components:
         multistream:
           $ref: "#/components/schemas/stream/properties/multistream"
 
+    multistream-target-patch-payload:
+      $ref: "#/components/schemas/multistream-target"
+      required: []
+      table: null
+
     session:
       type: object
       table: session
@@ -1315,11 +1320,7 @@ paths:
         content:
           application/json:
             schema:
-              required: [disabled]
-              additionalProperties: false
-              properties:
-                disabled:
-                  $ref: "#/components/schemas/multistream-target/properties/disabled"
+              $ref: "#/components/schemas/multistream-target-patch-payload"
       responses:
         204:
           description: Success

--- a/packages/api/src/store/db.ts
+++ b/packages/api/src/store/db.ts
@@ -141,7 +141,7 @@ export class DB {
     this.session = makeTable<Session>({ db: this, schema: schemas["session"] });
 
     const tables = Object.entries(schema.components.schemas).filter(
-      ([name, schema]) => "table" in schema
+      ([name, schema]) => "table" in schema && schema.table
     );
     await Promise.all(
       tables.map(([name, schema]) => {

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/SaveTargetDialog.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/SaveTargetDialog.tsx
@@ -94,16 +94,16 @@ const updateTarget = async (
   targetId: string,
   state: State,
   parsedUrl: url.UrlWithParsedQuery,
-  initialState: State
+  initState: State
 ) => {
   const patch = {
-    name: state.name !== initialState.name ? state.name : undefined,
+    name: state.name !== initState.name ? state.name : undefined,
     url: parsedUrl ? url.format(parsedUrl) : undefined,
   };
   if (patch.name || patch.url) {
     await api.patchMultistreamTarget(targetId, patch);
   }
-  if (state.profile !== initialState.profile) {
+  if (state.profile !== initState.profile) {
     const targets: CreateTargetSpec[] = stream.multistream?.targets?.map(
       (t) => ({
         ...t,
@@ -135,7 +135,7 @@ const SaveTargetDialog = ({
   const [openSnackbar] = useSnackbar();
   const [saving, setSaving] = useState(false);
 
-  const initialState = useMemo(
+  const initState = useMemo(
     () => ({
       name: action === Action.Create ? "" : target?.name,
       ingestUrl: "",
@@ -144,10 +144,10 @@ const SaveTargetDialog = ({
     }),
     [action, target?.name, initialProfile]
   );
-  const [state, setState] = useState(initialState);
+  const [state, setState] = useState(initState);
   useEffect(() => {
-    setState(initialState);
-  }, [isOpen, initialState]);
+    setState(initState);
+  }, [isOpen, initState]);
 
   const setStateProp = (prop: keyof typeof state, value: string) => {
     setState({ ...state, [prop]: value });
@@ -166,7 +166,7 @@ const SaveTargetDialog = ({
         await createTarget(api, stream, state, parsedUrl);
       } else {
         const tId = target?.id;
-        await updateTarget(api, stream, tId, state, parsedUrl, initialState);
+        await updateTarget(api, stream, tId, state, parsedUrl, initState);
       }
       await invalidate();
       onOpenChange(false);
@@ -221,7 +221,9 @@ const SaveTargetDialog = ({
               type="text"
               id="targetName"
               value={state.name}
-              placeholder={parsedUrl?.host || "e.g. streaming.tv"}
+              placeholder={
+                initState.name || parsedUrl?.host || "e.g. streaming.tv"
+              }
               onChange={(e) => setStateProp("name", e.target.value)}
             />
 
@@ -249,6 +251,7 @@ const SaveTargetDialog = ({
             <TextField
               size="2"
               type="text"
+              autoComplete="off"
               id="streamKey"
               value={state.streamKey}
               onChange={(e) => setStateProp("streamKey", e.target.value)}

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/SaveTargetDialog.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/SaveTargetDialog.tsx
@@ -145,9 +145,7 @@ const SaveTargetDialog = ({
     [action, target?.name, initialProfile]
   );
   const [state, setState] = useState(initState);
-  useEffect(() => {
-    setState(initState);
-  }, [isOpen, initState]);
+  useEffect(() => setState(initState), [isOpen]);
 
   const setStateProp = (prop: keyof typeof state, value: string) => {
     setState({ ...state, [prop]: value });

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/SaveTargetDialog.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/SaveTargetDialog.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import url from "url";
 
 import {
@@ -22,77 +22,159 @@ import {
 
 import Spinner from "components/Dashboard/Spinner";
 import { useApi } from "hooks";
-import { Stream, StreamPatchPayload } from "../../../../api/src/schema/types";
+import {
+  MultistreamTarget,
+  MultistreamTargetPatchPayload,
+  Stream,
+  StreamPatchPayload,
+} from "../../../../api/src/schema/types";
 import { pathJoin2 } from "@lib/utils";
 
 type CreateTargetSpec = StreamPatchPayload["multistream"]["targets"][number];
 
-const CreateTargetDialog = ({
+export enum Action {
+  Create = "Create",
+  Update = "Update",
+}
+
+type State = {
+  name: string;
+  ingestUrl: string;
+  streamKey: string;
+  profile: string;
+};
+
+type Api = ReturnType<typeof useApi>;
+
+const parseUrl = (ingestUrl: string, streamKey: string) => {
+  let parsed: url.UrlWithParsedQuery;
+  try {
+    if (ingestUrl) {
+      parsed = url.parse(ingestUrl, true);
+    }
+  } catch (err) {}
+  if (!streamKey || !parsed) {
+    return parsed;
+  }
+
+  switch (parsed.protocol) {
+    case "rtmp:":
+    case "rtmps:":
+      parsed.pathname = pathJoin2(parsed.pathname, streamKey);
+      break;
+    case "srt:":
+      parsed.query.streamId = streamKey;
+      break;
+  }
+  return parsed;
+};
+
+const createTarget = (
+  api: Api,
+  stream: Stream,
+  state: State,
+  parsedUrl: url.UrlWithParsedQuery
+) => {
+  const targets: CreateTargetSpec[] = [
+    ...(stream.multistream?.targets ?? []),
+    {
+      profile: state.profile,
+      spec: {
+        name: state.name || parsedUrl?.host,
+        url: url.format(parsedUrl),
+      },
+    },
+  ];
+  return api.patchStream(stream.id, { multistream: { targets } });
+};
+
+const updateTarget = async (
+  api: Api,
+  stream: Stream,
+  targetId: string,
+  state: State,
+  parsedUrl: url.UrlWithParsedQuery,
+  initialState: State
+) => {
+  const patch = {
+    name: state.name !== initialState.name ? state.name : undefined,
+    url: parsedUrl ? url.format(parsedUrl) : undefined,
+  };
+  if (patch.name || patch.url) {
+    await api.patchMultistreamTarget(targetId, patch);
+  }
+  if (state.profile !== initialState.profile) {
+    const targets: CreateTargetSpec[] = stream.multistream?.targets?.map(
+      (t) => ({
+        ...t,
+        profile: t.id === targetId ? state.profile : t.profile,
+      })
+    );
+    await api.patchStream(stream.id, { multistream: { targets } });
+  }
+};
+
+const SaveTargetDialog = ({
+  action,
   isOpen,
   onOpenChange,
   stream,
-  invalidateStream,
+  target,
+  initialProfile,
+  invalidate,
 }: {
+  action: Action;
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
   stream: Stream;
-  invalidateStream: () => Promise<void>;
+  target?: MultistreamTarget;
+  initialProfile?: string;
+  invalidate: () => Promise<void>;
 }) => {
-  const { patchStream } = useApi();
+  const api = useApi();
   const [openSnackbar] = useSnackbar();
   const [saving, setSaving] = useState(false);
 
-  const [name, setName] = useState("");
-  const [ingestUrl, setIngestUrl] = useState("");
-  const [streamKey, setStreamKey] = useState("");
-  const [profile, setProfile] = useState("source");
-  const resetState = () => {
-    setName("");
-    setIngestUrl("");
-    setStreamKey("");
-    setProfile("source");
+  const initialState = useMemo(
+    () => ({
+      name: action === Action.Create ? "" : target?.name,
+      ingestUrl: "",
+      streamKey: "",
+      profile: action === Action.Create ? "source" : initialProfile,
+    }),
+    [action, target?.name, initialProfile]
+  );
+  const [state, setState] = useState(initialState);
+  useEffect(() => {
+    setState(initialState);
+  }, [isOpen, initialState]);
+
+  const setStateProp = (prop: keyof typeof state, value: string) => {
+    setState({ ...state, [prop]: value });
   };
 
-  const parsedUrl = useMemo(() => {
-    let parsed: url.UrlWithParsedQuery;
-    try {
-      parsed = url.parse(ingestUrl, true);
-    } catch (err) {}
-    if (!streamKey || !parsed) {
-      return parsed;
-    }
-
-    switch (parsed.protocol) {
-      case "rtmp:":
-      case "rtmps:":
-        parsed.pathname = pathJoin2(parsed.pathname, streamKey);
-        break;
-      case "srt:":
-        parsed.query.streamId = streamKey;
-        break;
-    }
-    return parsed;
-  }, [ingestUrl, streamKey]);
+  const parsedUrl = useMemo(
+    () => parseUrl(state.ingestUrl, state.streamKey),
+    [state.ingestUrl, state.streamKey]
+  );
 
   const saveMultistreamTarget = async () => {
     if (saving) return;
     setSaving(true);
     try {
-      const targets: CreateTargetSpec[] = [
-        ...(stream.multistream?.targets ?? []),
-        {
-          profile,
-          spec: {
-            name: name || parsedUrl?.host,
-            url: url.format(parsedUrl),
-          },
-        },
-      ];
-      await patchStream(stream.id, { multistream: { targets } });
-      await invalidateStream();
+      if (action === Action.Create) {
+        await createTarget(api, stream, state, parsedUrl);
+      } else {
+        const tId = target?.id;
+        await updateTarget(api, stream, tId, state, parsedUrl, initialState);
+      }
+      await invalidate();
       onOpenChange(false);
-      openSnackbar(`Successfully created multistream target ${name}`);
-      resetState();
+      openSnackbar(
+        `Successfully ${
+          action === Action.Create ? "created" : "updated"
+        } multistream target ${name}`
+      );
     } catch (error) {
       console.error(error);
     } finally {
@@ -120,7 +202,9 @@ const CreateTargetDialog = ({
         css={{ maxWidth: 450, px: "$5", pt: "$4", pb: "$4" }}
         onOpenAutoFocus={(e) => e.preventDefault()}>
         <AlertDialogTitle as={Heading} size="1">
-          Create a new multistream target
+          {action === Action.Create
+            ? "Create a new multistream target"
+            : "Update multistream target"}
         </AlertDialogTitle>
 
         <Box
@@ -136,22 +220,26 @@ const CreateTargetDialog = ({
               size="2"
               type="text"
               id="targetName"
-              value={name}
+              value={state.name}
               placeholder={parsedUrl?.host || "e.g. streaming.tv"}
-              onChange={(e) => setName(e.target.value)}
+              onChange={(e) => setStateProp("name", e.target.value)}
             />
 
             <Label htmlFor="ingestUrl">Ingest URL</Label>
             <TextField
-              required
+              required={action === Action.Create || !!state.streamKey}
               autoFocus
               size="2"
               type="url"
               pattern="^(srt|rtmps?)://.+"
               id="ingestUrl"
-              value={ingestUrl}
-              onChange={(e) => setIngestUrl(e.target.value)}
-              placeholder="e.g. rtmp://streaming.tv/live"
+              value={state.ingestUrl}
+              onChange={(e) => setStateProp("ingestUrl", e.target.value)}
+              placeholder={
+                action === Action.Create || !!state.streamKey
+                  ? "e.g. rtmp://streaming.tv/live"
+                  : "(redacted)"
+              }
             />
             <Text size="1" css={{ fontWeight: 500, color: "$gray9" }}>
               Supported protocols: RTMP(S) and SRT
@@ -162,9 +250,13 @@ const CreateTargetDialog = ({
               size="2"
               type="text"
               id="streamKey"
-              value={streamKey}
-              onChange={(e) => setStreamKey(e.target.value)}
-              placeholder="e.g. a1b2-4d3c-e5f6-8h7g"
+              value={state.streamKey}
+              onChange={(e) => setStateProp("streamKey", e.target.value)}
+              placeholder={
+                action === Action.Create || state.ingestUrl
+                  ? "e.g. a1b2-4d3c-e5f6-8h7g"
+                  : "(redacted)"
+              }
             />
             <Text size="1" css={{ fontWeight: 500, color: "$gray9" }}>
               Stream key should be included if not already present in the URL.
@@ -180,14 +272,15 @@ const CreateTargetDialog = ({
                 justifyContent: "flex-start",
                 margin: "0px",
               }}>
-              <RadioGroup onValueChange={(e) => setProfile(e.target.value)}>
+              <RadioGroup
+                onValueChange={(e) => setStateProp("profile", e.target.value)}>
                 <Box css={{ display: "flex", flexDirection: "column" }}>
                   {profileOpts.map((p) => (
                     <Box key={p.name} css={{ display: "flex", mb: "$2" }}>
                       <Radio
                         value={p.name}
                         id={`profile-${p.name}`}
-                        checked={profile === p.name}
+                        checked={state.profile === p.name}
                       />
                       <Tooltip multiline content={p.tooltip}>
                         <Label
@@ -196,7 +289,6 @@ const CreateTargetDialog = ({
                           {p.displayName || p.name}
                         </Label>
                       </Tooltip>
-                      {/* <Label htmlFor="profile-source">source</Label> */}
                     </Box>
                   ))}
                 </Box>
@@ -208,8 +300,11 @@ const CreateTargetDialog = ({
             size="3"
             variant="gray"
             css={{ mt: "$2", fontSize: "$2", mb: "$4" }}>
-            Addition of new multistream targets will take effect when the next
-            stream session is started.
+            {`${
+              action === Action.Create
+                ? "Addition of new multistream targets"
+                : "Updating a multistream target"
+            } will take effect when the next stream session is started.`}
           </AlertDialogDescription>
 
           <Flex css={{ jc: "flex-end", gap: "$3", mt: "$4" }}>
@@ -220,7 +315,7 @@ const CreateTargetDialog = ({
               css={{ display: "flex", ai: "center" }}
               type="submit"
               size="2"
-              disabled={saving}
+              disabled={saving || (action === Action.Update && !target)}
               variant="violet">
               {saving && (
                 <Spinner
@@ -232,7 +327,7 @@ const CreateTargetDialog = ({
                   }}
                 />
               )}
-              Create target
+              {`${action} target`}
             </Button>
           </Flex>
         </Box>
@@ -241,4 +336,4 @@ const CreateTargetDialog = ({
   );
 };
 
-export default CreateTargetDialog;
+export default SaveTargetDialog;

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/TargetStatusBadge.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/TargetStatusBadge.tsx
@@ -1,0 +1,75 @@
+import moment from "moment";
+
+import { Box, Badge, Status, Tooltip } from "@livepeer.com/design-system";
+import { MultistreamTarget, Stream } from "@livepeer.com/api";
+
+import { MultistreamStatus } from "hooks/use-analyzer";
+import { useMemo } from "react";
+
+enum TargetStatus {
+  Idle = "Idle",
+  Pending = "Pending",
+  Offline = "Offline",
+  Online = "Online",
+}
+
+type StatusBadgeStyle = {
+  color: Parameters<typeof Badge>[0]["variant"];
+  dotColor?: Parameters<typeof Status>[0]["variant"];
+  noTooltip?: boolean;
+};
+
+const styleByStatus: Record<TargetStatus, StatusBadgeStyle> = {
+  Idle: { color: "gray", noTooltip: true },
+  Pending: { color: "lime", dotColor: "yellow" },
+  Offline: { color: "red" },
+  Online: { color: "green" },
+};
+
+const computeStatus = (
+  stream: Stream,
+  target: MultistreamTarget,
+  status: MultistreamStatus
+): TargetStatus => {
+  if (!stream?.isActive || (!status?.connected.status && target?.disabled)) {
+    return TargetStatus.Idle;
+  } else if (!status) {
+    return TargetStatus.Pending;
+  }
+  const isConnected = status.connected.status;
+  return isConnected ? TargetStatus.Online : TargetStatus.Offline;
+};
+
+const TargetStatusBadge = ({
+  stream,
+  target,
+  status: msStatus,
+}: {
+  stream: Stream;
+  target: MultistreamTarget;
+  status: MultistreamStatus;
+}) => {
+  const status = useMemo(
+    () => computeStatus(stream, target, msStatus),
+    [stream, target, msStatus]
+  );
+  const style = styleByStatus[status];
+  const badge = (
+    <Badge size="2" variant={style.color}>
+      <Box css={{ mr: 5 }}>
+        <Status size="1" variant={style.dotColor ?? (style.color as any)} />
+      </Box>
+      {status}
+    </Badge>
+  );
+  const timeAgo = useMemo(() => {
+    const lastProbe = Date.parse(msStatus?.connected.lastProbeTime);
+    return moment.unix(lastProbe / 1000);
+  }, [msStatus?.connected.lastProbeTime]);
+  if (!timeAgo.isValid() || style.noTooltip) {
+    return badge;
+  }
+  return <Tooltip content={timeAgo.fromNow()}>{badge}</Tooltip>;
+};
+
+export default TargetStatusBadge;

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/Toolbox.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/Toolbox.tsx
@@ -1,8 +1,5 @@
-import { useState } from "react";
-import {
-  DotsHorizontalIcon as Overflow,
-  QuestionMarkCircledIcon as Help,
-} from "@radix-ui/react-icons";
+import { useCallback, useMemo, useState } from "react";
+import { DotsHorizontalIcon as Overflow } from "@radix-ui/react-icons";
 
 import {
   Box,
@@ -201,14 +198,18 @@ const Delete = ({
 const Toolbox = ({
   target,
   stream,
-  invalidateTarget,
+  invalidateTargetId,
   invalidateStream,
 }: {
   target?: MultistreamTarget;
   stream: Stream;
-  invalidateTarget: () => Promise<void>;
+  invalidateTargetId: (id: string) => Promise<void>;
   invalidateStream: (optm: Stream) => Promise<void>;
 }) => {
+  const invalidateTarget = useCallback(
+    () => invalidateTargetId(target?.id),
+    [invalidateTargetId, target?.id]
+  );
   return (
     <Flex align="center" gap="2" justify="end">
       <Toggle target={target} invalidate={invalidateTarget} />

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo } from "react";
-import moment from "moment";
 import Link from "next/link";
 import { Column } from "react-table";
 import { ArrowRightIcon, PlusIcon } from "@radix-ui/react-icons";
@@ -11,8 +10,6 @@ import {
   Heading,
   Text,
   Link as A,
-  Badge,
-  Status,
   Tooltip,
   Label,
 } from "@livepeer.com/design-system";
@@ -28,10 +25,11 @@ import { stringSort } from "components/Dashboard/Table/sorts";
 import { SortTypeArgs } from "components/Dashboard/Table/types";
 import { useToggleState } from "hooks/use-toggle-state";
 import { useApi } from "hooks";
-import { HealthStatus, MultistreamStatus } from "hooks/use-analyzer";
+import { HealthStatus } from "hooks/use-analyzer";
 
 import Toolbox from "./Toolbox";
 import SaveTargetDialog, { Action } from "./SaveTargetDialog";
+import TargetStatusBadge from "./TargetStatusBadge";
 
 type TargetsTableData = {
   id: string;
@@ -62,39 +60,6 @@ const defaultEmptyState = (
     </Link>
   </Flex>
 );
-
-const TargetStatusBadge = ({
-  stream,
-  target,
-  status,
-}: {
-  stream: Stream;
-  target: MultistreamTarget;
-  status: MultistreamStatus;
-}) => {
-  const props =
-    !stream?.isActive || (!status?.connected.status && target?.disabled)
-      ? { color: "gray", text: "Idle", noTooltip: true }
-      : !status
-      ? { color: "lime", text: "Pending", dotColor: "yellow" }
-      : !status.connected.status
-      ? { color: "red", text: "Offline" }
-      : { color: "green", text: "Online" };
-  const badge = (
-    <Badge size="2" variant={props.color as any}>
-      <Box css={{ mr: 5 }}>
-        <Status size="1" variant={props.dotColor ?? (props.color as any)} />
-      </Box>
-      {props.text}
-    </Badge>
-  );
-  const lastProbe = Date.parse(status?.connected.lastProbeTime);
-  const timeAgo = moment.unix(lastProbe / 1000);
-  if (!timeAgo.isValid() || props.noTooltip) {
-    return badge;
-  }
-  return <Tooltip content={timeAgo.fromNow()}>{badge}</Tooltip>;
-};
 
 const MultistreamTargetsTable = ({
   title = "Multistream Targets",

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
@@ -3,7 +3,7 @@ import moment from "moment";
 import Link from "next/link";
 import { Column } from "react-table";
 import { ArrowRightIcon, PlusIcon } from "@radix-ui/react-icons";
-import { useQueries, useQuery, useQueryClient } from "react-query";
+import { useQueries, useQueryClient } from "react-query";
 
 import {
   Box,
@@ -31,7 +31,7 @@ import { useApi } from "hooks";
 import { HealthStatus, MultistreamStatus } from "hooks/use-analyzer";
 
 import Toolbox from "./Toolbox";
-import CreateTargetDialog from "./CreateTargetDialog";
+import SaveTargetDialog, { Action } from "./SaveTargetDialog";
 
 type TargetsTableData = {
   id: string;
@@ -119,7 +119,7 @@ const MultistreamTargetsTable = ({
   const { state, stateSetter } = useTableState<TargetsTableData>({
     tableId: "multistreamTargetsTable",
   });
-  const createDialogState = useToggleState();
+  const saveDialogState = useToggleState();
 
   const columns: Column<TargetsTableData>[] = useMemo(
     () => [
@@ -233,7 +233,7 @@ const MultistreamTargetsTable = ({
         emptyState={emptyState}
         tableLayout={tableLayout}
         createAction={{
-          onClick: createDialogState.onOn,
+          onClick: saveDialogState.onOn,
           css: { display: "flex", alignItems: "center", ml: "$1" },
           children: (
             <>
@@ -246,11 +246,12 @@ const MultistreamTargetsTable = ({
         }}
       />
 
-      <CreateTargetDialog
-        isOpen={createDialogState.on}
-        onOpenChange={createDialogState.onToggle}
+      <SaveTargetDialog
+        action={Action.Create}
+        isOpen={saveDialogState.on}
+        onOpenChange={saveDialogState.onToggle}
         stream={stream}
-        invalidateStream={invalidateStream}
+        invalidate={invalidateStream}
       />
     </Box>
   );

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
@@ -140,7 +140,7 @@ const MultistreamTargetsTable = ({
         rows: targets.map((target, idx) => {
           const ref = targetRefs[idx];
           const status = streamHealth?.multistream?.find(
-            (m) => m.target.id === ref.id
+            (m) => m.target.id === ref.id && m.target.profile === ref.profile
           );
           return {
             id: ref.id,

--- a/packages/www/hooks/use-api.tsx
+++ b/packages/www/hooks/use-api.tsx
@@ -10,6 +10,7 @@ import {
   StreamPatchPayload,
   ObjectStore,
   MultistreamTargetPatchPayload,
+  Session,
 } from "@livepeer.com/api";
 import qs from "qs";
 import { isStaging, isDevelopment, HttpError } from "../lib/utils";
@@ -633,7 +634,7 @@ const makeContext = (state: ApiState, setState) => {
       limit: number = 20,
       filters?: Array<{ id: string; value: string | object }>,
       count?: boolean
-    ): Promise<[Array<Stream>, string, number]> {
+    ): Promise<[Session[], string, number]> {
       const stringifiedFilters = filters ? JSON.stringify(filters) : undefined;
       const uri = `/session?${qs.stringify({
         limit,

--- a/packages/www/hooks/use-api.tsx
+++ b/packages/www/hooks/use-api.tsx
@@ -10,7 +10,6 @@ import {
   StreamPatchPayload,
   ObjectStore,
   MultistreamTargetPatchPayload,
-  Session,
 } from "@livepeer.com/api";
 import qs from "qs";
 import { isStaging, isDevelopment, HttpError } from "../lib/utils";
@@ -634,7 +633,7 @@ const makeContext = (state: ApiState, setState) => {
       limit: number = 20,
       filters?: Array<{ id: string; value: string | object }>,
       count?: boolean
-    ): Promise<[Session[], string, number]> {
+    ): Promise<[Array<Stream>, string, number]> {
       const stringifiedFilters = filters ? JSON.stringify(filters) : undefined;
       const uri = `/session?${qs.stringify({
         limit,

--- a/packages/www/hooks/use-api.tsx
+++ b/packages/www/hooks/use-api.tsx
@@ -9,6 +9,7 @@ import {
   Webhook,
   StreamPatchPayload,
   ObjectStore,
+  MultistreamTargetPatchPayload,
 } from "@livepeer.com/api";
 import qs from "qs";
 import { isStaging, isDevelopment, HttpError } from "../lib/utils";
@@ -678,7 +679,7 @@ const makeContext = (state: ApiState, setState) => {
 
     async patchMultistreamTarget(
       id: string,
-      patch: { disabled: boolean }
+      patch: MultistreamTargetPatchPayload
     ): Promise<void> {
       const [res, body] = await context.fetch(`/multistream/target/${id}`, {
         method: "PATCH",

--- a/packages/www/lib/utils/index.tsx
+++ b/packages/www/lib/utils/index.tsx
@@ -263,6 +263,7 @@ export const CARD_OPTIONS = {
 export function isStaging(): boolean {
   return (
     window.location.hostname.includes("livepeer.monster") ||
+    window.location.hostname.includes("livepeer.vercel.app") ||
     window.location.hostname.includes("livepeerorg.vercel.app") ||
     window.location.hostname.includes("livepeerorg.now.sh")
   );


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This is to fix a couple bugs that went through to production on the multistream launch.

**Specific updates (required)**
Fixed bugs:
 - Menus/dialogs closing when the stream is active, on every stream/health refetch
 - Delete dialog bug that steals the window focus after closed

Implemented:
 - Edit target dialog (not a bug, but implemented it too!)
 - Also tried to consider stream session information on the status badge, but we actually
 expose no reliable API for that as of now. Still committed&reverted the POC just for 
 historical reasons, may want to pick it up again in the future.

## -

- **How did you test each of these updates (required)**
`yarn dev` and do all the multistream target flows:
 - Create a target
 - Enabled/disable
 - Edit target
 - Delete target
 - Start and stop an actual stream in between those steps and ensure UI is still usable and
 updates (like to name, source, url, etc) happen as expected.

**Does this pull request close any open issues?**
Closes https://github.com/livepeer/livepeer-com/issues/585

**Screenshots (optional):**
<img width="1487" alt="Screen Shot 2021-09-01 at 10 39 14" src="https://user-images.githubusercontent.com/1613383/131681596-4783f242-ca67-40bc-bef1-cc03e69275e8.png">
(the bugs can only really be tested)

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
