### PR TITLE
www/multistream: Add beta badge to multistream pages

### DIFF
--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -107,6 +107,8 @@ async function validateMultistreamOpts(
       continue;
     } else if (name === "source") {
       throw new BadRequestError(`profile cannot be named "source"`);
+    } else if (profileNames.has(name)) {
+      throw new BadRequestError(`duplicate profile name "${name}"`);
     }
     profileNames.add(name);
   }

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/SaveTargetDialog.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/SaveTargetDialog.tsx
@@ -187,12 +187,17 @@ const SaveTargetDialog = ({
       displayName: "Source",
       tooltip: "Original video",
     };
-    const fromStream = stream.profiles?.map(({ name, width, height, fps }) => ({
-      name,
-      displayName: name,
-      tooltip: `${width}x${height} @ ${fps || "Source"} FPS`,
-    }));
-    return [sourceProfile, ...fromStream];
+    const fromStream = stream.profiles
+      ?.sort(
+        (p1, p2) => p1.height - p2.height || p1.name.localeCompare(p2.name)
+      )
+      .reverse()
+      .map(({ name, width, height, fps }) => ({
+        name,
+        displayName: name,
+        tooltip: `${width}x${height} @ ${fps || "Source"} FPS`,
+      }));
+    return [sourceProfile, ...(fromStream ?? [])];
   }, [stream.profiles]);
 
   return (

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/SaveTargetDialog.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/SaveTargetDialog.tsx
@@ -202,9 +202,11 @@ const SaveTargetDialog = ({
         onOpenAutoFocus={(e) => e.preventDefault()}>
         <AlertDialogTitle as={Heading} size="1">
           {`${action} multistream target`}
-          <Badge size="2" variant="violet" css={{ ml: "$2" }}>
-            Beta
-          </Badge>
+          {action === Action.Create ? (
+            <Badge size="2" variant="violet" css={{ ml: "$2" }}>
+              Beta
+            </Badge>
+          ) : null}
         </AlertDialogTitle>
 
         <Box

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/SaveTargetDialog.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/SaveTargetDialog.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import url from "url";
 
 import {
+  Badge,
   Box,
   Button,
   Flex,
@@ -200,9 +201,10 @@ const SaveTargetDialog = ({
         css={{ maxWidth: 450, px: "$5", pt: "$4", pb: "$4" }}
         onOpenAutoFocus={(e) => e.preventDefault()}>
         <AlertDialogTitle as={Heading} size="1">
-          {action === Action.Create
-            ? "Create a new multistream target"
-            : "Update multistream target"}
+          {`${action} multistream target`}
+          <Badge size="2" variant="violet" css={{ ml: "$2" }}>
+            Beta
+          </Badge>
         </AlertDialogTitle>
 
         <Box

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/TargetStatusBadge.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/TargetStatusBadge.tsx
@@ -56,7 +56,7 @@ const TargetStatusBadge = ({
   const style = styleByStatus[status];
   const badge = (
     <Badge size="2" variant={style.color}>
-      <Box css={{ mr: 5 }}>
+      <Box css={{ mr: "$1" }}>
         <Status size="1" variant={style.dotColor ?? (style.color as any)} />
       </Box>
       {status}

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
@@ -5,6 +5,7 @@ import { ArrowRightIcon, PlusIcon } from "@radix-ui/react-icons";
 import { useQueries, useQueryClient } from "react-query";
 
 import {
+  Badge,
   Box,
   Flex,
   Heading,
@@ -187,7 +188,12 @@ const MultistreamTargetsTable = ({
         stateSetter={stateSetter}
         header={
           <>
-            <Heading>{title}</Heading>
+            <Heading>
+              {title}
+              <Badge size="2" variant="violet" css={{ ml: "$2" }}>
+                Beta
+              </Badge>
+            </Heading>
           </>
         }
         border={border}

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
@@ -5,7 +5,6 @@ import { ArrowRightIcon, PlusIcon } from "@radix-ui/react-icons";
 import { useQueries, useQueryClient } from "react-query";
 
 import {
-  Badge,
   Box,
   Flex,
   Heading,
@@ -188,12 +187,7 @@ const MultistreamTargetsTable = ({
         stateSetter={stateSetter}
         header={
           <>
-            <Heading>
-              {title}
-              <Badge size="2" variant="violet" css={{ ml: "$2" }}>
-                Beta
-              </Badge>
-            </Heading>
+            <Heading>{title}</Heading>
           </>
         }
         border={border}


### PR DESCRIPTION
Mainly added `Beta` badge to multistream frontend components (only creation dialog in the end).

But then also added some improvements:
 - Sort profiles on create/update target dialogs, so it's always descending in quality starting from `Source`
 - Disallow profiles with the same name in the API. We assume uniqueness in several places and this bugs some stuff

**Screenshots:**
<img width="501" alt="Screen Shot 2021-09-03 at 16 02 52" src="https://user-images.githubusercontent.com/1613383/132054444-909fe8da-ce34-422f-9fa4-fcc5d399e88b.png">

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
