### PR TITLE
Allow video-only multistream sessions

### DIFF
--- a/packages/api/src/controllers/stream.test.ts
+++ b/packages/api/src/controllers/stream.test.ts
@@ -424,7 +424,13 @@ describe("controllers/stream", () => {
         const res = await client.post("/stream", {
           ...postMockStream,
           multistream: {
-            targets: [{ profile: "test_stream_360p", spec: mockTarget }],
+            targets: [
+              {
+                profile: "test_stream_360p",
+                videoOnly: true,
+                spec: mockTarget,
+              },
+            ],
           },
         });
         expect(res.status).toBe(201);
@@ -434,6 +440,7 @@ describe("controllers/stream", () => {
         expect(resultMst.spec).toBeUndefined();
         expect(resultMst.id).toBeDefined();
         expect(resultMst.id).not.toEqual(msTarget.id);
+        expect(resultMst.videoOnly).toBe(true);
 
         const saved = await server.db.multistreamTarget.get(resultMst.id);
         expect(saved).toBeDefined();

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -93,7 +93,8 @@ async function validateMultistreamTarget(
     url: spec.url,
     userId,
   });
-  return { profile, id: created.id };
+  const { spec: _, ...specless } = target;
+  return { ...specless, id: created.id };
 }
 
 async function validateMultistreamOpts(

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -362,6 +362,12 @@ components:
                     minLength: 1
                     maxLength: 500
                     example: 720p
+                  mute:
+                    type: boolean
+                    description:
+                      If true, the profile audio will be silenced and only video
+                      will be pushed to the target.
+                    default: false
                   id:
                     type: string
                     description:

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -362,11 +362,11 @@ components:
                     minLength: 1
                     maxLength: 500
                     example: 720p
-                  mute:
+                  videoOnly:
                     type: boolean
                     description:
-                      If true, the profile audio will be silenced and only video
-                      will be pushed to the target.
+                      If true, the stream audio will be muted and only silent
+                      video will be pushed to the target.
                     default: false
                   id:
                     type: string

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/SaveTargetDialog.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/SaveTargetDialog.tsx
@@ -107,7 +107,10 @@ const updateTarget = async (
   if (patch.name || patch.url) {
     await api.patchMultistreamTarget(targetId, patch);
   }
-  if (state.profile !== initState.profile) {
+  if (
+    state.profile !== initState.profile ||
+    state.videoOnly !== initState.videoOnly
+  ) {
     const targets: MultistreamTargetRef[] = stream.multistream?.targets?.map(
       (t) =>
         t.id !== targetId

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/Toolbox.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/Toolbox.tsx
@@ -196,9 +196,8 @@ const Toolbox = ({
   const invalidateAll = useCallback(async () => {
     await Promise.all([invalidateStream(), invalidateTargetId(target?.id)]);
   }, [invalidateStream, invalidateTargetId, target?.id]);
-  const currProfile = useMemo(() => {
-    const ref = stream?.multistream?.targets?.find((t) => t.id == target?.id);
-    return ref?.profile;
+  const targetRef = useMemo(() => {
+    return stream?.multistream?.targets?.find((t) => t.id == target?.id);
   }, [stream?.multistream?.targets, target?.id]);
 
   return (
@@ -259,7 +258,7 @@ const Toolbox = ({
         onOpenChange={setSaveDialogOpen}
         stream={stream}
         target={target}
-        initialProfile={currProfile}
+        targetRef={targetRef}
         invalidate={invalidateAll}
       />
       <DeleteDialog

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
@@ -152,7 +152,7 @@ const MultistreamTargetsTable = ({
               ),
             },
             profile: {
-              children: ref.profile,
+              children: ref.profile + (ref.videoOnly ? " (video-only)" : ""),
             },
             status: {
               children: (

--- a/packages/www/docs/api-reference/stream/overview.mdx
+++ b/packages/www/docs/api-reference/stream/overview.mdx
@@ -139,6 +139,16 @@ ingested `sourceSegments` and duration data, among others.
       ),
     },
     {
+      parameter: <code>multistream.targets.videoOnly</code>,
+      type: <code>boolean</code>,
+      description: (
+        <>
+          If <code>true</code>, the stream audio will be muted and only silent
+          video will be pushed to the target.
+        </>
+      ),
+    },
+    {
       parameter: <code>multistream.targets.id</code>,
       type: <code>string</code>,
       description:

--- a/packages/www/docs/api-reference/stream/update-stream.mdx
+++ b/packages/www/docs/api-reference/stream/update-stream.mdx
@@ -50,7 +50,7 @@ curl -X PATCH 'https://livepeer.com/api/stream/{id}' \
      "multistream": {
         "targets":  [
           { "id" :"0bf161f3-95bd-4971-a7b1-4dcb5d39e78a", "profile": "source" },
-          { "id" :"95bd0bf1-61f3-a7b1-4971-39e78a4dcb5d", "profile": "720p" }
+          { "id" :"95bd0bf1-61f3-a7b1-4971-39e78a4dcb5d", "profile": "720p", "videoOnly": true }
         ]
       }
     }'

--- a/packages/www/docs/guides/start-live-streaming/multistream.mdx
+++ b/packages/www/docs/guides/start-live-streaming/multistream.mdx
@@ -182,7 +182,8 @@ multistreamed and the `id` of the corresponding `Multistream Target`.
 The `profile` field must reference an existing transcoding profile on the same
 stream, or `"source"` to multistream the same original video as ingested. The
 same profile can be mulsitreamed to several `Multistream Targets`, but there can
-be only 1 multistream to a given URL.
+be only 1 multistream to a given URL. You can also set the `videoOnly` field to
+`true` to mute the stream audio and stream only a silent video to the target.
 
 To avoid managing separate `Multistream Target` objects, you can also create
 targets inlined in the `Stream` object on the same mutation request (create or
@@ -240,6 +241,7 @@ curl -X POST 'https://livepeer.com/api/stream' \
       "targets": [
         {
           "profile": "720p",
+          "videoOnly": true,
           "spec": {
             "name": "Eli\'s Twitch",
             "url": "rtmp://rtmp.twitch.tv/live/SECRET"


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This is to enable multistreaming only a stream video, to allow streaming to a platform
where there might be strong copyright enforcement. Needed by PlayDJ.

**Specific updates (required)**
 - Add proper field and handling in the API
 - Add UI components for toggling mutestream for a given target
 - Update the docs

## -

- **How did you test each of these updates (required)**
Create, view and update multistream targets video-only fields.

**Does this pull request close any open issues?**
Implements https://github.com/livepeer/livepeer-com/issues/595

**Screenshots (optional):**
![Screen Shot 2021-09-28 at 19 33 34](https://user-images.githubusercontent.com/1613383/135174801-a30aaf74-b8af-4042-ab3e-e7195ecae04e.png)
![Screen Shot 2021-09-28 at 19 33 53](https://user-images.githubusercontent.com/1613383/135174824-dc6960e9-37dd-486f-a171-d065da87acc1.png)

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
