### PR TITLE
www: show kilobits rather than kilobytes per second

### DIFF
--- a/packages/www/pages/dashboard/streams/[id]/health.tsx
+++ b/packages/www/pages/dashboard/streams/[id]/health.tsx
@@ -73,7 +73,7 @@ const Health = () => {
           ...prev,
           {
             name: lastItem ? lastItem.name + interval / 1000 : 0,
-            kbps: Math.round(newInfo.session.ingestRate / 1000),
+            kbps: Math.round((newInfo.session.ingestRate / 1000) * 8), // kilobits rather than bytes here
           },
         ].slice(Math.max(prev.length - maxItems, 0));
       });


### PR DESCRIPTION
All credit to @victorges for finding the right line, I just typed the `* 8` into GitHub 🤷 