### PR TITLE
www: Fix health progression on beginning of stream

### DIFF
--- a/packages/www/components/Dashboard/MultistreamTargetsTable/TargetStatusBadge.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/TargetStatusBadge.tsx
@@ -32,7 +32,7 @@ const TargetStatusBadge = ({
   stream: Stream;
   target: MultistreamTarget;
   status: MultistreamStatus;
-  streamActiveSince?: number;
+  streamActiveSince: number | undefined;
 }) => {
   const status = useMemo(
     () => computeStatus(stream, target, msStatus, streamActiveSince),

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/TargetStatusBadge.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/TargetStatusBadge.tsx
@@ -13,7 +13,8 @@ const computeStatus = (
   if (
     !stream?.isActive ||
     status?.connected.lastProbeTime < streamActiveSince ||
-    target.createdAt > streamActiveSince
+    target.createdAt > streamActiveSince ||
+    target.disabled
   ) {
     return Status.Idle;
   } else if (!status) {

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/TargetStatusBadge.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/TargetStatusBadge.tsx
@@ -7,9 +7,14 @@ import StatusBadge, { Variant as Status } from "../StatusBadge";
 const computeStatus = (
   stream: Stream,
   target: MultistreamTarget,
-  status: MultistreamStatus
+  status: MultistreamStatus,
+  streamActiveSince: number | undefined
 ): Status => {
-  if (!stream?.isActive || (!status?.connected.status && target?.disabled)) {
+  if (
+    !stream?.isActive ||
+    status?.connected.lastProbeTime < streamActiveSince ||
+    target.createdAt < streamActiveSince
+  ) {
     return Status.Idle;
   } else if (!status) {
     return Status.Pending;
@@ -22,13 +27,15 @@ const TargetStatusBadge = ({
   stream,
   target,
   status: msStatus,
+  streamActiveSince,
 }: {
   stream: Stream;
   target: MultistreamTarget;
   status: MultistreamStatus;
+  streamActiveSince?: number;
 }) => {
   const status = useMemo(
-    () => computeStatus(stream, target, msStatus),
+    () => computeStatus(stream, target, msStatus, streamActiveSince),
     [stream, target, msStatus]
   );
   const timestamp = msStatus?.connected.lastProbeTime;

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/TargetStatusBadge.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/TargetStatusBadge.tsx
@@ -10,17 +10,19 @@ const computeStatus = (
   status: MultistreamStatus,
   streamActiveSince: number | undefined
 ): Status => {
+  if (status?.connected.lastProbeTime < streamActiveSince) {
+    status = null;
+  }
+  const isConnected = status?.connected.status;
   if (
     !stream?.isActive ||
-    status?.connected.lastProbeTime < streamActiveSince ||
     target?.createdAt > streamActiveSince ||
-    target?.disabled
+    (target?.disabled && !isConnected)
   ) {
     return Status.Idle;
   } else if (!status) {
     return Status.Pending;
   }
-  const isConnected = status.connected.status;
   return isConnected ? Status.Online : Status.Offline;
 };
 

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/TargetStatusBadge.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/TargetStatusBadge.tsx
@@ -13,8 +13,8 @@ const computeStatus = (
   if (
     !stream?.isActive ||
     status?.connected.lastProbeTime < streamActiveSince ||
-    target.createdAt > streamActiveSince ||
-    target.disabled
+    target?.createdAt > streamActiveSince ||
+    target?.disabled
   ) {
     return Status.Idle;
   } else if (!status) {

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/TargetStatusBadge.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/TargetStatusBadge.tsx
@@ -10,7 +10,10 @@ const computeStatus = (
   status: MultistreamStatus,
   streamActiveSince: number | undefined
 ): Status => {
-  if (status?.connected.lastProbeTime < streamActiveSince) {
+  if (
+    status?.connected.lastProbeTime < streamActiveSince ||
+    !streamActiveSince
+  ) {
     status = null;
   }
   const isConnected = status?.connected.status;
@@ -39,7 +42,7 @@ const TargetStatusBadge = ({
 }) => {
   const status = useMemo(
     () => computeStatus(stream, target, msStatus, streamActiveSince),
-    [stream, target, msStatus]
+    [stream, target, msStatus, streamActiveSince]
   );
   const timestamp = msStatus?.connected.lastProbeTime;
   return <StatusBadge variant={status} timestamp={timestamp} />;

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/TargetStatusBadge.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/TargetStatusBadge.tsx
@@ -13,7 +13,7 @@ const computeStatus = (
   if (
     !stream?.isActive ||
     status?.connected.lastProbeTime < streamActiveSince ||
-    target.createdAt < streamActiveSince
+    target.createdAt > streamActiveSince
   ) {
     return Status.Idle;
   } else if (!status) {

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
@@ -134,7 +134,7 @@ const MultistreamTargetsTable = ({
     const activeCondition = streamHealth?.conditions.find(
       (c) => c.type === "Active"
     );
-    return activeCondition.status ? activeCondition.lastTransitionTime : null;
+    return activeCondition?.status ? activeCondition.lastTransitionTime : null;
   }, [streamHealth?.conditions]);
 
   const tableData: TableData<TargetsTableData> = useMemo(() => {

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
@@ -130,6 +130,12 @@ const MultistreamTargetsTable = ({
       queryFn: () => getMultistreamTarget(ref.id),
     }))
   ).map((res) => res.data as MultistreamTarget);
+  const streamActiveSince = useMemo(() => {
+    const activeCondition = streamHealth?.conditions.find(
+      (c) => c.type === "Active"
+    );
+    return activeCondition.status && activeCondition.lastTransitionTime;
+  }, [streamHealth]);
 
   const tableData: TableData<TargetsTableData> = useMemo(() => {
     return {
@@ -160,6 +166,7 @@ const MultistreamTargetsTable = ({
                   stream={stream}
                   target={target}
                   status={status}
+                  streamActiveSince={streamActiveSince}
                 />
               ),
             },

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
@@ -134,8 +134,8 @@ const MultistreamTargetsTable = ({
     const activeCondition = streamHealth?.conditions.find(
       (c) => c.type === "Active"
     );
-    return activeCondition.status && activeCondition.lastTransitionTime;
-  }, [streamHealth]);
+    return activeCondition.status ? activeCondition.lastTransitionTime : null;
+  }, [streamHealth?.conditions]);
 
   const tableData: TableData<TargetsTableData> = useMemo(() => {
     return {

--- a/packages/www/hooks/use-analyzer.tsx
+++ b/packages/www/hooks/use-analyzer.tsx
@@ -26,7 +26,7 @@ export interface Condition {
   status: boolean | null;
   frequency?: Record<string, number>;
   lastProbeTime?: number;
-  lastTransitionsTime?: number;
+  lastTransitionTime?: number;
 }
 
 export interface HealthStatus {

--- a/packages/www/hooks/use-analyzer.tsx
+++ b/packages/www/hooks/use-analyzer.tsx
@@ -25,8 +25,8 @@ export interface Condition {
     | "Multistreaming";
   status: boolean | null;
   frequency?: Record<string, number>;
-  lastProbeTime?: string;
-  lastTransitionsTime?: string;
+  lastProbeTime?: number;
+  lastTransitionsTime?: number;
 }
 
 export interface HealthStatus {

--- a/packages/www/layouts/streamDetail.tsx
+++ b/packages/www/layouts/streamDetail.tsx
@@ -39,6 +39,9 @@ import Terminate from "components/Dashboard/StreamDetails/Terminate";
 import Suspend from "components/Dashboard/StreamDetails/Suspend";
 import Delete from "components/Dashboard/StreamDetails/Delete";
 import Link from "next/link";
+import StatusBadge, {
+  Variant as StatusVariant,
+} from "@components/Dashboard/StatusBadge";
 
 type ShowURLProps = {
   url: string;
@@ -307,29 +310,16 @@ const StreamDetail = ({
                         }}>
                         {stream.name}
                       </Box>
-                      {isHealthy == null ? null : isHealthy ? (
-                        <Badge
-                          size="2"
-                          variant="green"
-                          css={{ mt: "$1", letterSpacing: 0 }}>
-                          <Box css={{ mr: "$1" }}>
-                            <Status size="1" variant="green" />
-                          </Box>
-                          Healthy
-                        </Badge>
-                      ) : (
-                        <Badge
-                          size="2"
-                          variant="red"
-                          css={{
-                            mt: "$1",
-                            letterSpacing: 0,
-                          }}>
-                          <Box css={{ mr: "$1" }}>
-                            <Status size="1" variant="red" />
-                          </Box>
-                          Unhealthy
-                        </Badge>
+                      {isHealthy == null ? null : (
+                        <StatusBadge
+                          variant={
+                            isHealthy
+                              ? StatusVariant.Healthy
+                              : StatusVariant.Unhealthy
+                          }
+                          timestamp={streamHealth?.healthy?.lastProbeTime}
+                          css={{ mt: "$1", letterSpacing: 0 }}
+                        />
                       )}
                       {stream.suspended && (
                         <Badge

--- a/packages/www/layouts/streamDetail.tsx
+++ b/packages/www/layouts/streamDetail.tsx
@@ -254,6 +254,17 @@ const StreamDetail = ({
       .catch((err) => console.error(err)); // todo: surface this
   }, [id]);
 
+  const isHealthy = useMemo(() => {
+    if (!stream?.isActive || !streamHealth) return null;
+    const activeCond = streamHealth?.conditions.find(
+      (c) => c.type === "Active"
+    );
+    return !activeCond?.status ||
+      streamHealth.healthy.lastProbeTime < activeCond.lastTransitionTime
+      ? null
+      : streamHealth.healthy.status;
+  }, [stream?.isActive, streamHealth]);
+
   if (!user) {
     return <Layout />;
   }
@@ -270,16 +281,6 @@ const StreamDetail = ({
   const domain = isStaging() ? "monster" : "com";
   const globalIngestUrl = `rtmp://rtmp.livepeer.${domain}/live`;
   const globalPlaybackUrl = `https://cdn.livepeer.${domain}/hls/${playbackId}/index.m3u8`;
-  const isHealthy = useMemo(() => {
-    if (!stream?.isActive || !streamHealth) return null;
-    const activeCond = streamHealth?.conditions.find(
-      (c) => c.type === "Active"
-    );
-    return !activeCond?.status ||
-      streamHealth.healthy.lastProbeTime < activeCond.lastTransitionTime
-      ? null
-      : streamHealth.healthy.status;
-  }, [stream?.isActive, streamHealth]);
 
   return (
     <Layout id="streams" breadcrumbs={breadcrumbs}>

--- a/packages/www/layouts/streamDetail.tsx
+++ b/packages/www/layouts/streamDetail.tsx
@@ -23,7 +23,7 @@ import Layout from "layouts/dashboard";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import { useRouter } from "next/router";
 import { useApi, useLoggedIn } from "hooks";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useMemo } from "react";
 import { isStaging } from "lib/utils";
 import RelativeTime from "components/Dashboard/RelativeTime";
 import {
@@ -267,6 +267,16 @@ const StreamDetail = ({
   const domain = isStaging() ? "monster" : "com";
   const globalIngestUrl = `rtmp://rtmp.livepeer.${domain}/live`;
   const globalPlaybackUrl = `https://cdn.livepeer.${domain}/hls/${playbackId}/index.m3u8`;
+  const isHealthy = useMemo(() => {
+    if (!stream?.isActive || !streamHealth) return null;
+    const activeCond = streamHealth?.conditions.find(
+      (c) => c.type === "Active"
+    );
+    return !activeCond?.status ||
+      streamHealth.healthy.lastProbeTime < activeCond.lastTransitionTime
+      ? null
+      : streamHealth.healthy.status;
+  }, [stream?.isActive, streamHealth]);
 
   return (
     <Layout id="streams" breadcrumbs={breadcrumbs}>
@@ -297,8 +307,7 @@ const StreamDetail = ({
                         }}>
                         {stream.name}
                       </Box>
-                      {!streamHealth || !stream.isActive ? null : streamHealth
-                          .healthy.status ? (
+                      {isHealthy == null ? null : isHealthy ? (
                         <Badge
                           size="2"
                           variant="green"


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This fixes a couple of glitches that happen with the current stream health UI, in which we
might both display health information about previous stream sessions, as well as display
invalid health information when the stream config has changed after the stream had already
been started (e.g. displaying "pending" for a multistream target only created after the stream
was active).

**Specific updates (required)**
 - Start processing and using the "stream active since" information, which can now be obtained from
 the stream health payload via the `Active` condition!
 - Ignore conditions and multistream status from before the stream was active
 - Also ignore multistream targets created after the stream was active

## -

- **How did you test each of these updates (required)**
TODO:
1
 - [ ] Start a stream 
 - [ ] Make sure stream health statuses still works
 - [ ] Change multistream configuration
 - [ ] Make sure any target created after stream started is displayed as "Idle" instead of "Pending"
2
 - [ ] Stop the stream, restart it
 - [ ] Make sure all stream health stuff restarts as "-" instead of "Healthy" right from the start
 - [ ] Make sure multistream status still works (from the target created above)
3
 - [ ] Stop the stream, restart it
 - [ ] Make sure multistream target status starts as "Pending" instead of "Offine" (from previous stream event)

**Does this pull request close any open issues?**
Now yeah! Fixes https://github.com/livepeer/livepeer-com/issues/770

**Screenshots (optional):**
<pending>

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
