### PR TITLE
Broken link (404) on /docs page "Application Development"

### DIFF
--- a/packages/www/docs/guides/application-development/live-streaming-from-your-app.mdx
+++ b/packages/www/docs/guides/application-development/live-streaming-from-your-app.mdx
@@ -19,4 +19,5 @@ You can also use any RTMP library, for example
 [Streamaxia](https://www.streamaxia.com/) in iOS.
 
 Livepeer.com is currently working on additional recommendations for mobile SDKs.
-Fill out a [contact form](https://livepeer.com/contact) if you have more urgent needs.
+Fill out a [contact form](https://livepeer.com/contact) if you have more urgent
+needs.

--- a/packages/www/docs/guides/application-development/live-streaming-from-your-app.mdx
+++ b/packages/www/docs/guides/application-development/live-streaming-from-your-app.mdx
@@ -19,4 +19,4 @@ You can also use any RTMP library, for example
 [Streamaxia](https://www.streamaxia.com/) in iOS.
 
 Livepeer.com is currently working on additional recommendations for mobile SDKs.
-Fill out a [contact form](contact) if you have more urgent needs.
+Fill out a [contact form](https://livepeer.com/contact) if you have more urgent needs.


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

<!-- A clear and concise description of what this pull request does. -->

Broken links found on this page: https://livepeer.com/docs/guides/application-development/live-streaming-from-your-app anchor that goes to https://livepeer.com/docs/guides/application-development/contact which currently 404s.

Should instead go to https://livepeer.com/contact.

To Reproduce (required) Steps to reproduce the behavior:

1. Go to https://livepeer.com/docs/guides/application-development/live-streaming-from-your-app
2. Click on contact form
3. See error

<!--- List out all significant updates your code introduces -->

No significant update, only a minor markdown change.

- **How did you test each of these updates (required)**

By clicking on the updated markdown change, the appropriate link worked!

**Does this pull request close any open issues?**

Yes, it fixes this open issue I created https://github.com/livepeer/livepeer-com/issues/718

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
