### PR TITLE
api/auth: Allow access to deleted streams

### DIFF
--- a/packages/api/src/controllers/auth.ts
+++ b/packages/api/src/controllers/auth.ts
@@ -14,12 +14,10 @@ app.all(
   async (req, res) => {
     const streamId = req.headers["x-livepeer-stream-id"];
     const stream = await db.stream.get(streamId?.toString() ?? "");
-
-    const exists = stream && !stream.deleted;
-    if (!exists) {
+    if (!stream) {
       return res.status(404).json({ errors: ["stream not found"] });
     }
-    const hasAccess = stream?.userId === req.user.id || req.user.admin;
+    const hasAccess = stream.userId === req.user.id || req.user.admin;
     if (!hasAccess) {
       return res.status(403).json({ errors: ["access forbidden"] });
     }


### PR DESCRIPTION
We currently can't get health or events about
streams that have been deleted. This prohibits
from investigating a bad stream after it has been
deleted, like from record-tester, and could create
similar problems to end-users as well. Don't see why
we shouldn't allow that access anyway, so skipping the
check for the stream.deleted in the auth controller logic.

**Does this pull request close any open issues?**

Stream not found error grabbing stream health from a deleted stream.

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
