### PR TITLE
api: Use repatcha secret key as feature toggle

### DIFF
--- a/packages/api/src/controllers/user.js
+++ b/packages/api/src/controllers/user.js
@@ -102,7 +102,7 @@ app.post("/", validatePost("user"), async (req, res) => {
 
   const { selectedPlan } = req.query;
 
-  if (!req.config.disableRecaptcha) {
+  if (req.config.recaptchaSecretKey) {
     if (!recaptchaToken) {
       res.status(422);
       res.json({

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -237,12 +237,6 @@ export default function parseCli(argv?: string | readonly string[]) {
         describe: "google recaptcha secret key",
         type: "string",
       },
-      disableRecaptcha: {
-        describe:
-          "whether to validate user registrations with google recaptcha",
-        type: "boolean",
-        default: false,
-      },
     })
     .help()
     .parse(argv);

--- a/packages/api/src/test-server.ts
+++ b/packages/api/src/test-server.ts
@@ -19,7 +19,6 @@ const jwtSecret = "secret";
 const supportAddr = "Livepeer Team/angie@livepeer.org";
 const sendgridTemplateId = "iamanid";
 const sendgridApiKey = "SG. iamanapikey";
-const disableRecaptcha = true;
 
 fs.ensureDirSync(dbPath);
 
@@ -45,7 +44,6 @@ if (!params.insecureTestToken) {
   params.insecureTestToken = uuid();
 }
 params.listen = true;
-params.disableRecaptcha = disableRecaptcha;
 let server: AppServer & { host?: string };
 
 console.log(`test run parameters: ${JSON.stringify(params)}`);


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Use existing recaptcha secret key flag as the toggle for using recaptcha at all.

**Specific updates (required)**

Remove separate disableRecaptcha flag and use secret key existence as toggle.

## -

- **How did you test each of these updates (required)**

`yarn test`

**Does this pull request close any open issues?**

No.

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
