### PR TITLE
api: Make auth header parsing insensitive to case and whitespace

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -68,7 +68,6 @@
     "email-validator": "^2.0.4",
     "express": "^4.16.4",
     "express-async-errors": "^3.1.1",
-    "express-bearer-token": "^2.4.0",
     "express-mung": "^0.5.1",
     "fs-extra": "^7.0.1",
     "google-auth-library": "^5.2.2",

--- a/packages/api/src/app-router.ts
+++ b/packages/api/src/app-router.ts
@@ -1,6 +1,5 @@
 // import 'express-async-errors' // it monkeypatches, i guess
 import Router from "express/lib/router";
-import bearerToken from "express-bearer-token";
 import makeStore from "./store";
 import {
   errorHandler,
@@ -139,7 +138,6 @@ export default async function makeApp(params: CliArgs) {
     }
     app.use(`/${insecureTestToken}`, insecureTest());
   }
-  app.use(bearerToken());
 
   // Populate Kubernetes getOrchestrators and getBroadcasters is provided
   if (kubeNamespace) {

--- a/packages/api/src/controllers/api-token.test.js
+++ b/packages/api/src/controllers/api-token.test.js
@@ -290,7 +290,9 @@ describe("controllers/api-token", () => {
         const res = await client.fetch(path, { method });
         expect(res.status).toBe(403);
         const body = await res.json();
-        expect(body.errors[0]).toEqual("unsupported authorization type Bearer");
+        expect(body.errors[0]).toEqual(
+          "unsupported authorization header scheme: Bearer"
+        );
       };
       const expectAll403s = async () => {
         await expect403("post", `/api-token`);

--- a/packages/api/src/controllers/multistream.test.ts
+++ b/packages/api/src/controllers/multistream.test.ts
@@ -367,7 +367,7 @@ describe("controllers/multistream-target", () => {
       expect(res.status).toBe(500);
       const errJson = await res.json();
       expect(errJson.errors[0]).toEqual(
-        `no user found for token Bearer ${tokenId}`
+        `no user found from authorization header: Bearer ${tokenId}`
       );
     });
   });

--- a/packages/api/src/controllers/object-store.test.js
+++ b/packages/api/src/controllers/object-store.test.js
@@ -308,7 +308,7 @@ describe("controllers/object-stores", () => {
       const objStore = await res.json();
       expect(res.status).toBe(500);
       expect(objStore.errors[0]).toBe(
-        `no user found for token Bearer ${tokenId}`
+        `no user found from authorization header: Bearer ${tokenId}`
       );
     });
   });

--- a/packages/api/src/middleware/auth.test.ts
+++ b/packages/api/src/middleware/auth.test.ts
@@ -119,11 +119,11 @@ describe("auth middleware", () => {
     });
 
     it("should be case and whitespace insensitive", async () => {
-      await expectStatus(`   beAReR ${nonAdminApiKey}`).toBe(204);
+      await expectStatus(`   beAReR\t ${nonAdminApiKey}`).toBe(204);
       await expectStatus(`  BEARER ${nonAdminApiKey}`).toBe(204);
       await expectStatus(` baSIc  ${basicAuth64}`).toBe(204);
-      await expectStatus(`   Jwt    ${nonAdminToken}`).toBe(204);
-      await expectStatus(` JWT  ${nonAdminToken}   `).toBe(204);
+      await expectStatus(`\tJwt    ${nonAdminToken}`).toBe(204);
+      await expectStatus(`JWT \t${nonAdminToken}   `).toBe(204);
     });
   });
 

--- a/packages/api/src/middleware/auth.test.ts
+++ b/packages/api/src/middleware/auth.test.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import bearerToken from "express-bearer-token";
 import { authMiddleware } from ".";
 
 import { ApiToken, User } from "../schema/types";
@@ -35,7 +34,6 @@ beforeAll(async () => {
   };
 
   const { app } = (testServer = await startAuxTestServer());
-  app.use(bearerToken());
   app.use((req, res, next) => {
     req.config = {
       httpPrefix,

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -99,7 +99,9 @@ function authFactory(params: AuthParams): RequestHandler {
 
     user = await db.user.get(userId);
     if (!user) {
-      throw new InternalServerError(`no user found from auth: ${authHeader}`);
+      throw new InternalServerError(
+        `no user found from authorization header: ${authHeader}`
+      );
     }
     if (user.suspended) {
       throw new ForbiddenError(`user is suspended`);

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -14,7 +14,7 @@ import tracking from "./tracking";
 type AuthScheme = "jwt" | "bearer" | "basic";
 
 function parseAuthHeader(authHeader: string) {
-  const match = authHeader?.match(/^ *(\w+) +(.+)$/);
+  const match = authHeader?.match(/^\s*(\w+)\s+(.+)$/);
   if (!match) return {};
   return {
     rawAuthScheme: match[1],

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -14,7 +14,7 @@ import tracking from "./tracking";
 type AuthScheme = "jwt" | "bearer" | "basic";
 
 function parseAuthHeader(authHeader: string) {
-  const match = authHeader?.match(/^\s*(\w+)\s+(.+)$/);
+  const match = authHeader?.match(/^ *(\w+) +(.+)$/);
   if (!match) return {};
   return {
     rawAuthScheme: match[1],
@@ -68,7 +68,7 @@ function authFactory(params: AuthParams): RequestHandler {
       throw new ForbiddenError(`no authorization header provided`);
     } else if (["bearer", "basic"].includes(authScheme) && !params.noApiToken) {
       const isBasic = authScheme === "basic";
-      const tokenId = isBasic ? basicUser?.pass : req.token;
+      const tokenId = isBasic ? basicUser?.pass : authToken;
       if (!tokenId) {
         throw new ForbiddenError(`no authorization token provided`);
       }

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -14,7 +14,7 @@ import tracking from "./tracking";
 type AuthScheme = "jwt" | "bearer" | "basic";
 
 function parseAuthHeader(authHeader: string) {
-  const match = authHeader?.match(/^\s+(\w+)\s+(.+)$/);
+  const match = authHeader?.match(/^\s*(\w+)\s+(.+)$/);
   if (!match) return {};
   return {
     rawAuthScheme: match[1],

--- a/packages/api/src/test-helpers.ts
+++ b/packages/api/src/test-helpers.ts
@@ -91,21 +91,21 @@ export class TestClient {
     let headers = args.headers || {};
     if (this.apiKey) {
       headers = {
-        ...headers,
         authorization: `Bearer ${this.apiKey}`,
+        ...headers,
       };
     }
     if (this.jwtAuth) {
       headers = {
-        ...headers,
         authorization: `JWT ${this.jwtAuth}`,
+        ...headers,
       };
     }
     if (this.basicAuth) {
       const basic64 = Buffer.from(this.basicAuth).toString("base64");
       headers = {
-        ...headers,
         authorization: `Basic ${basic64}`,
+        ...headers,
       };
     }
     const res = await fetch(

--- a/packages/api/src/types/common.d.ts
+++ b/packages/api/src/types/common.d.ts
@@ -13,12 +13,6 @@ export interface OrchestratorNodeAddress extends NodeAddress {
   score: number;
 }
 
-export enum AuthTokenType {
-  JWT = "JWT",
-  Bearer = "Bearer",
-  Basic = "Basic",
-}
-
 declare global {
   namespace Express {
     // add custom properties to Request object
@@ -30,7 +24,6 @@ declare global {
       frontendDomain: string;
 
       user?: User;
-      authTokenType?: AuthTokenType;
       isUIAdmin?: boolean;
       tokenName?: string;
       tokenId?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9076,14 +9076,6 @@ convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.0,
   dependencies:
     safe-buffer "~5.1.1"
 
-cookie-parser@^1.4.4:
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.5.tgz#3e572d4b7c0c80f9c61daf604e4336831b5d1d49"
-  integrity sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==
-  dependencies:
-    cookie "0.4.0"
-    cookie-signature "1.0.6"
-
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
@@ -9093,11 +9085,6 @@ cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
-
-cookie@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
-  integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -11414,14 +11401,6 @@ express-async-errors@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/express-async-errors/-/express-async-errors-3.1.1.tgz#6053236d61d21ddef4892d6bd1d736889fc9da41"
   integrity sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==
-
-express-bearer-token@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/express-bearer-token/-/express-bearer-token-2.4.0.tgz#f4d9d5a1e318953445e7f0d2bde00bb96d21c95a"
-  integrity sha512-2+kRZT2xo+pmmvSY7Ma5FzxTJpO3kGaPCEXPbAm3GaoZ/z6FE4K6L7cvs1AUZwY2xkk15PcQw7t4dWjsl5rdJw==
-  dependencies:
-    cookie "^0.3.1"
-    cookie-parser "^1.4.4"
 
 express-mung@^0.5.1:
   version "0.5.1"


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This is to improve the developer experience by not requiring that they specify their authorization
headers with perfect casing. [The "specs"](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization) also state that the auth scheme should be case-insensitive.

Also made it a little more whitespace insensitive while on it, since it should not affect our ability to
process those anyway.

**Specific updates (required)**
 - whitespace-trim any value read from the auth header
 - toLowerCase the auth scheme and compare with lower case constants
 - Rename some vars and helpers for consistency with spec

## -

- **How did you test each of these updates (required)**
Make some requests and ensure authorization still work.

**Does this pull request close any open issues?**
No. Just an invisible one that's been annoying me in my head.

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
