### PR TITLE
api: Fix admin queries table scans

### DIFF
--- a/packages/api/src/controllers/api-token.js
+++ b/packages/api/src/controllers/api-token.js
@@ -45,10 +45,10 @@ app.delete("/:id", async (req, res) => {
 
 const fieldsMap = {
   id: `api_token.ID`,
-  name: `api_token.data->>'name'`,
+  name: { val: `api_token.data->>'name'`, type: "full-text" },
   lastSeen: `api_token.data->'lastSeen'`,
   userId: `api_token.data->>'userId'`,
-  "user.email": `users.data->>'email'`,
+  "user.email": { val: `users.data->>'email'`, type: "full-text" },
 };
 
 app.get("/", async (req, res) => {

--- a/packages/api/src/controllers/helpers.js
+++ b/packages/api/src/controllers/helpers.js
@@ -293,41 +293,37 @@ export function parseFilters(fieldsMap, val) {
               } `
             )
           );
-        } else {
+        } else if (isObject(filter.value)) {
           // if value is a dictionary
-          if (isObject(filter.value)) {
-            Object.keys(filter.value).map(function (key, _index) {
-              let comparison = "";
-              switch (key) {
-                case "gt":
-                  comparison = ">";
-                  break;
-                case "gte":
-                  comparison = ">=";
-                  break;
-                case "lt":
-                  comparison = "<";
-                  break;
-                case "lte":
-                  comparison = "<=";
-                  break;
-                default:
-                  comparison = "=";
-              }
-              q.push(
-                sql``
-                  .append(fv.val)
-                  .append(comparison)
-                  .append(sql` ${filter.value[key]}`)
-              );
-            });
-          } else {
+          Object.keys(filter.value).forEach(function (key, _index) {
+            let comparison = "";
+            switch (key) {
+              case "gt":
+                comparison = ">";
+                break;
+              case "gte":
+                comparison = ">=";
+                break;
+              case "lt":
+                comparison = "<";
+                break;
+              case "lte":
+                comparison = "<=";
+                break;
+              default:
+                comparison = "=";
+            }
             q.push(
               sql``
                 .append(fv.val)
-                .append(sql` LIKE ${"%" + filter.value + "%"}`)
+                .append(comparison)
+                .append(sql` ${filter.value[key]}`)
             );
-          }
+          });
+        } else {
+          q.push(
+            sql``.append(fv.val).append(sql` LIKE ${"%" + filter.value + "%"}`)
+          );
         }
       }
     }

--- a/packages/api/src/controllers/helpers.js
+++ b/packages/api/src/controllers/helpers.js
@@ -293,6 +293,10 @@ export function parseFilters(fieldsMap, val) {
               } `
             )
           );
+        } else if (fv.type === "full-text") {
+          q.push(
+            sql``.append(fv.val).append(sql` LIKE ${"%" + filter.value + "%"}`)
+          );
         } else if (isObject(filter.value)) {
           // if value is a dictionary
           Object.keys(filter.value).forEach(function (key, _index) {

--- a/packages/api/src/controllers/helpers.js
+++ b/packages/api/src/controllers/helpers.js
@@ -283,7 +283,7 @@ export function parseFilters(fieldsMap, val) {
     const fv = fieldsMap[filter.id];
     if (fv) {
       if (typeof fv === "string") {
-        q.push(sql``.append(fv).append(sql` LIKE ${"%" + filter.value + "%"}`));
+        q.push(sql``.append(fv).append(sql` = ${filter.value}`));
       } else if (fv.val) {
         if (fv.type === "boolean") {
           q.push(
@@ -321,9 +321,7 @@ export function parseFilters(fieldsMap, val) {
             );
           });
         } else {
-          q.push(
-            sql``.append(fv.val).append(sql` LIKE ${"%" + filter.value + "%"}`)
-          );
+          q.push(sql``.append(fv.val).append(sql` = ${filter.value}`));
         }
       }
     }

--- a/packages/api/src/controllers/multistream.ts
+++ b/packages/api/src/controllers/multistream.ts
@@ -15,12 +15,12 @@ import { DBMultistreamTarget } from "../store/multistream-table";
 
 const fieldsMap = {
   id: `multistream_target.ID`,
-  name: `multistream_target.data->>'name'`,
+  name: { val: `multistream_target.data->>'name'`, type: "full-text" },
   url: `multistream_target.data->>'url'`,
   disabled: { val: `multistream_target.data->'disabled'`, type: "boolean" },
   createdAt: { val: `multistream_target.data->'createdAt'`, type: "int" },
   userId: `multistream_target.data->>'userId'`,
-  "user.email": `users.data->>'email'`,
+  "user.email": { val: `users.data->>'email'`, type: "full-text" },
 };
 
 function adminListQuery(

--- a/packages/api/src/controllers/object-store.js
+++ b/packages/api/src/controllers/object-store.js
@@ -9,13 +9,13 @@ const app = Router();
 
 const fieldsMap = {
   id: `object_store.ID`,
-  name: `object_store.data->>'name'`,
+  name: { val: `object_store.data->>'name'`, type: "full-text" },
   url: `object_store.data->>'url'`,
   publicUrl: `object_store.data->>'publicUrl'`,
   disabled: `object_store.data->'disabled'`,
   createdAt: `object_store.data->'createdAt'`,
   userId: `object_store.data->>'userId'`,
-  "user.email": `users.data->>'email'`,
+  "user.email": { val: `users.data->>'email'`, type: "full-text" },
 };
 
 app.get("/", authMiddleware({}), async (req, res) => {

--- a/packages/api/src/controllers/session.ts
+++ b/packages/api/src/controllers/session.ts
@@ -18,11 +18,11 @@ const app = Router();
 
 const fieldsMap = {
   id: `session.ID`,
-  name: `session.data->>'name'`,
+  name: { val: `session.data->>'name'`, type: "full-text" },
   lastSeen: { val: `session.data->'lastSeen'`, type: "int" },
   createdAt: { val: `session.data->'createdAt'`, type: "int" },
   userId: `session.data->>'userId'`,
-  "user.email": `users.data->>'email'`,
+  "user.email": { val: `users.data->>'email'`, type: "full-text" },
   parentId: `session.data->>'parentId'`,
   record: { val: `session.data->'record'`, type: "boolean" },
   sourceSegments: `session.data->'sourceSegments'`,

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -186,13 +186,13 @@ function activeCleanup(streams: DBStream[], activeOnly = false) {
 
 const fieldsMap = {
   id: `stream.ID`,
-  name: `stream.data->>'name'`,
+  name: { val: `stream.data->>'name'`, type: "full-text" },
   sourceSegments: `stream.data->'sourceSegments'`,
   lastSeen: { val: `stream.data->'lastSeen'`, type: "int" },
   createdAt: { val: `stream.data->'createdAt'`, type: "int" },
   userId: `stream.data->>'userId'`,
   isActive: { val: `stream.data->'isActive'`, type: "boolean" },
-  "user.email": `users.data->>'email'`,
+  "user.email": { val: `users.data->>'email'`, type: "full-text" },
   parentId: `stream.data->>'parentId'`,
   record: { val: `stream.data->'record'`, type: "boolean" },
   suspended: { val: `stream.data->'suspended'`, type: "boolean" },

--- a/packages/api/src/controllers/user.js
+++ b/packages/api/src/controllers/user.js
@@ -40,7 +40,7 @@ app.get("/usage", authMiddleware({}), async (req, res) => {
 
 const fieldsMap = {
   id: `users.ID`,
-  email: `data->>'email'`,
+  email: { val: `data->>'email'`, type: "full-text" },
   emailValid: { val: `data->'emailValid'`, type: "boolean" },
   admin: { val: `data->'admin'`, type: "boolean" },
   stripeProductId: `data->>'stripeProductId'`,

--- a/packages/api/src/controllers/webhook.js
+++ b/packages/api/src/controllers/webhook.js
@@ -39,13 +39,13 @@ const app = Router();
 
 const fieldsMap = {
   id: `webhook.ID`,
-  name: `webhook.data->>'name'`,
+  name: { val: `webhook.data->>'name'`, type: "full-text" },
   url: `webhook.data->>'url'`,
   blocking: `webhook.data->'blocking'`,
   deleted: `webhook.data->'deleted'`,
   createdAt: `webhook.data->'createdAt'`,
   userId: `webhook.data->>'userId'`,
-  "user.email": `users.data->>'email'`,
+  "user.email": { val: `users.data->>'email'`, type: "full-text" },
   sharedSecret: `webhook.data->>'sharedSecret'`,
 };
 

--- a/packages/www/hooks/use-api.tsx
+++ b/packages/www/hooks/use-api.tsx
@@ -551,6 +551,7 @@ const makeContext = (state: ApiState, setState) => {
     async getAdminStreams({
       active,
       nonLivepeerOnly,
+      userId,
       order,
       filters,
       limit,
@@ -559,6 +560,7 @@ const makeContext = (state: ApiState, setState) => {
     }: {
       active?: boolean;
       nonLivepeerOnly?: boolean;
+      userId?: string;
       order?: string;
       filters?: Array<{ id: string; value: string }>;
       limit?: number;
@@ -576,6 +578,7 @@ const makeContext = (state: ApiState, setState) => {
           cursor,
           filters: f,
           nonLivepeerOnly,
+          userId,
           sessionsonly,
         })}`
       );

--- a/packages/www/layouts/streamDetail.tsx
+++ b/packages/www/layouts/streamDetail.tsx
@@ -222,6 +222,7 @@ const StreamDetail = ({
         limit: 1,
         order: "createdAt-true",
         filters: [{ id: "parentId", value: stream.id }],
+        userId: stream.userId,
       })
         .then((res) => {
           const [streamsOrError] = res;

--- a/packages/www/pages/app/stream/[id].tsx
+++ b/packages/www/pages/app/stream/[id].tsx
@@ -201,6 +201,7 @@ const ID = () => {
         limit: 1,
         order: "createdAt-true",
         filters: [{ id: "parentId", value: stream.id }],
+        userId: stream.userId,
       })
         .then((res) => {
           const [streamsOrError] = res;


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This fixes some queries that have been performing table scans on the streams due to a
`LIKE %x%` filter on a field with only a B-TREE index.

**Specific updates (required)**
Fixed it 2-fold:
 - Started using an `=` filter for most of the fields we allow user-defined filters on;
 - Specify a `userId` on that specific query, so on the worst case we still don't do a full table scan.

## -

- **How did you test each of these updates (required)**
Open `pages/app/stream/[id]` page (old dashboard) and make sure query still works (and is cheaper)

**Does this pull request close any open issues?**
Fixes [this issue](https://eu-metrics-monitoring.livepeer.live/grafana/explore?orgId=1&left=%5B%22now-7d%22,%22now%22,%22Loki%22,%7B%22exemplar%22:true,%22expr%22:%22%7Bregion%3D~%5C%22.%2B%5C%22,%20app%3D%5C%22prod-livepeer-api%5C%22%7D%20%7C%3D%20%5C%22runQuery%20phase%3Dsuccess%5C%22%20%7C%3D%20%5C%22SELECT%5C%22%20%7C%20pattern%20%5C%22%3C_%3Eelapsed%3D%3Celapsed%3E%20%3C_%3E%5C%22%20%7C%20elapsed%20%3E%2015s%22%7D%5D)

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
