### PR TITLE
api: Simpler AMQP logic for delayed events

### DIFF
--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -922,7 +922,7 @@ app.put(
           const ingest = ((await req.getIngest()) ?? [])[0]?.base;
           const recordingUrl = getRecordingUrl(ingest, session);
           const mp4Url = getRecordingUrl(ingest, session, true);
-          await req.queue.delayedPublish(
+          await req.queue.delayedPublishWebhook(
             "events.recording.ready",
             {
               type: "webhook_event",

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -135,7 +135,7 @@ async function triggerManyIdleStreamsWebhook(ids: string[], queue: Queue) {
     ids.map(async (id) => {
       const stream = await db.stream.get(id);
       const user = await db.user.get(stream.userId);
-      await queue.publish("events.stream.idle", {
+      await queue.publishWebhook("events.stream.idle", {
         type: "webhook_event",
         id: uuid(),
         timestamp: Date.now(),
@@ -898,7 +898,7 @@ app.put(
     // trigger the webhooks, reference https://github.com/livepeer/livepeerjs/issues/791#issuecomment-658424388
     // this could be used instead of /webhook/:id/trigger (althoughs /trigger requires admin access )
     const event = req.body.active === true ? "stream.started" : "stream.idle";
-    await req.queue.publish(`events.${event}`, {
+    await req.queue.publishWebhook(`events.${event}`, {
       type: "webhook_event",
       id: uuid(),
       timestamp: Date.now(),
@@ -954,7 +954,7 @@ app.put(
         }
       }
       if (shouldEmit) {
-        await req.queue.publish("events.recording.started", {
+        await req.queue.publishWebhook("events.recording.started", {
           type: "webhook_event",
           id: uuid(),
           timestamp: Date.now(),
@@ -1505,7 +1505,7 @@ app.post(
       },
     };
 
-    await req.queue.publish("events.stream.detection", msg);
+    await req.queue.publishWebhook("events.stream.detection", msg);
     return res.status(204).end();
   }
 );

--- a/packages/api/src/store/messages.ts
+++ b/packages/api/src/store/messages.ts
@@ -4,7 +4,8 @@ import { WithID } from "./types";
 import { DBWebhook, EventKey } from "./webhook-table";
 
 namespace messages {
-  export type Any = WebhookEvent | WebhookTrigger;
+  export type Any = Webhooks;
+  export type Webhooks = WebhookEvent | WebhookTrigger;
   export type Types = Any["type"];
 
   // This is a global format followed by all messages sent by Livepeer services

--- a/packages/api/src/store/queue.test.ts
+++ b/packages/api/src/store/queue.test.ts
@@ -20,7 +20,7 @@ describe("Queue", () => {
 
   it("should be able to emit events and catch it via default consumer", async () => {
     await queue.consume("events", queue.handleMessage.bind(queue));
-    await queue.publish("events.stream.started", {
+    await queue.publishWebhook("events.stream.started", {
       type: "webhook_event",
       id: "abc123",
       timestamp: Date.now(),
@@ -45,7 +45,7 @@ describe("Queue", () => {
 
     await queue.consume("events", onMsg);
 
-    await queue.publish("events.stream.started", {
+    await queue.publishWebhook("events.stream.started", {
       type: "webhook_event",
       id: "custom_msg",
       timestamp: Date.now(),

--- a/packages/api/src/store/queue.test.ts
+++ b/packages/api/src/store/queue.test.ts
@@ -71,6 +71,7 @@ describe("Queue", () => {
 
     await queue.consume("events", onMsg);
 
+    emittedAt = Date.now();
     await queue.delayedPublishWebhook(
       "events.recording.ready",
       {
@@ -83,7 +84,6 @@ describe("Queue", () => {
       },
       2000
     );
-    emittedAt = Date.now();
     await sem.wait(4000);
     let duration = consumedAt - emittedAt;
     console.log("duration: ", duration);
@@ -105,6 +105,7 @@ describe("Queue", () => {
 
     await queue.consume("events", onMsg);
 
+    emittedAt = Date.now();
     await queue.delayedPublishWebhook(
       "events.recording.ready",
       {
@@ -117,7 +118,6 @@ describe("Queue", () => {
       },
       1000
     );
-    emittedAt = Date.now();
     await sem.wait(3000);
     let duration = consumedAt - emittedAt;
     console.log("duration: ", duration);

--- a/packages/api/src/store/queue.test.ts
+++ b/packages/api/src/store/queue.test.ts
@@ -71,7 +71,7 @@ describe("Queue", () => {
 
     await queue.consume("events", onMsg);
 
-    await queue.delayedPublish(
+    await queue.delayedPublishWebhook(
       "events.recording.ready",
       {
         type: "webhook_event",
@@ -105,7 +105,7 @@ describe("Queue", () => {
 
     await queue.consume("events", onMsg);
 
-    await queue.delayedPublish(
+    await queue.delayedPublishWebhook(
       "events.recording.ready",
       {
         type: "webhook_event",

--- a/packages/api/src/store/queue.ts
+++ b/packages/api/src/store/queue.ts
@@ -19,7 +19,7 @@ type RoutingKey = `events.${EventKey}` | `webhooks.${string}`;
 
 export default interface Queue {
   publishWebhook(key: RoutingKey, msg: messages.Webhooks): Promise<void>;
-  delayedPublish(
+  delayedPublishWebhook(
     key: RoutingKey,
     msg: messages.Any,
     delay: number
@@ -40,7 +40,11 @@ export class NoopQueue implements Queue {
     );
   }
 
-  async delayedPublish(key: RoutingKey, msg: messages.Any, delay: number) {
+  async delayedPublishWebhook(
+    key: RoutingKey,
+    msg: messages.Any,
+    delay: number
+  ) {
     console.warn(
       `WARN: Delayed publish event to noop queue. key=${key} delay=${delay} message=`,
       msg
@@ -165,7 +169,7 @@ export class RabbitQueue implements Queue {
     });
   }
 
-  public async delayedPublish(
+  public async delayedPublishWebhook(
     routingKey: RoutingKey,
     msg: messages.Any,
     delay: number

--- a/packages/api/src/store/queue.ts
+++ b/packages/api/src/store/queue.ts
@@ -91,6 +91,7 @@ export class RabbitQueue implements Queue {
           channel.bindQueue(QUEUES.webhooks, EXCHANGES.webhooks, "webhooks.#"),
           channel
             .assertQueue(QUEUES.delayed, {
+              arguments: { "x-queue-type": "quorum" },
               deadLetterExchange: EXCHANGES.webhooks,
               durable: true,
             })

--- a/packages/api/src/store/queue.ts
+++ b/packages/api/src/store/queue.ts
@@ -169,6 +169,10 @@ export class RabbitQueue implements Queue {
     });
   }
 
+  // This function publishes a message to an alternate exchange/queue used only
+  // for delayed messages. Messages are published with an expiration equal to
+  // the desired `delay` parameter, and after they expire are sent to the main
+  // exchange through the delayed queue deadletterExchange configuration.
   public async delayedPublishWebhook(
     routingKey: RoutingKey,
     msg: messages.Any,

--- a/packages/api/src/store/queue.ts
+++ b/packages/api/src/store/queue.ts
@@ -91,7 +91,6 @@ export class RabbitQueue implements Queue {
           channel.bindQueue(QUEUES.webhooks, EXCHANGES.webhooks, "webhooks.#"),
           channel
             .assertQueue(QUEUES.delayed, {
-              arguments: { "x-queue-type": "quorum" },
               deadLetterExchange: EXCHANGES.webhooks,
               durable: true,
             })

--- a/packages/api/src/webhooks/cannon.test.ts
+++ b/packages/api/src/webhooks/cannon.test.ts
@@ -206,7 +206,7 @@ describe("webhook cannon", () => {
         sem.release();
       };
 
-      await server.queue.publish("events.stream.started", {
+      await server.queue.publishWebhook("events.stream.started", {
         type: "webhook_event",
         id: "webhook_test_12",
         timestamp: Date.now(),
@@ -243,7 +243,7 @@ describe("webhook cannon", () => {
         sems[1].release();
       };
 
-      await server.queue.publish("events.stream.started", {
+      await server.queue.publishWebhook("events.stream.started", {
         type: "webhook_event",
         id: "webhook_test_12",
         timestamp: Date.now(),
@@ -273,7 +273,7 @@ describe("webhook cannon", () => {
         sem.release();
       };
 
-      await server.queue.publish("events.stream.started", {
+      await server.queue.publishWebhook("events.stream.started", {
         type: "webhook_event",
         id: "webhook_test_12",
         timestamp: Date.now(),
@@ -287,7 +287,7 @@ describe("webhook cannon", () => {
       expect(receivedEvent).toBe("stream.started");
 
       sem = semaphore();
-      await server.queue.publish("events.stream.idle", {
+      await server.queue.publishWebhook("events.stream.idle", {
         type: "webhook_event",
         id: "webhook_test_42",
         timestamp: Date.now(),
@@ -302,7 +302,7 @@ describe("webhook cannon", () => {
 
       // does not receive some random event
       sem = semaphore();
-      await server.queue.publish("events.stream.unknown" as any, {
+      await server.queue.publishWebhook("events.stream.unknown" as any, {
         type: "webhook_event",
         id: "webhook_test_93",
         timestamp: Date.now(),
@@ -342,7 +342,7 @@ describe("webhook cannon", () => {
       };
       server.webhook.calcBackoff = () => 100;
 
-      await server.queue.publish("events.stream.started", {
+      await server.queue.publishWebhook("events.stream.started", {
         type: "webhook_event",
         id: "webhook_test_12",
         timestamp: Date.now(),

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -138,7 +138,7 @@ export default class WebhookCannon {
       };
       await Promise.all(
         webhooks.map((webhook) =>
-          this.queue.publish("webhooks.triggers", {
+          this.queue.publishWebhook("webhooks.triggers", {
             ...baseTrigger,
             id: uuid(),
             webhook,

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -215,7 +215,7 @@ export default class WebhookCannon {
       lastInterval: this.calcBackoff(trigger.lastInterval),
       retries: trigger.retries ? trigger.retries + 1 : 1,
     };
-    return this.queue.delayedPublish(
+    return this.queue.delayedPublishWebhook(
       "webhooks.delayedEmits",
       trigger,
       trigger.lastInterval


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This is to simplify the logic for delaying messages on AMQP, also avoiding the
creation and destruction of multiple queues in runtime, as well as the dynamic
management of setup functions on the AMQP connection manager. 

Not the biggest priority, but I was bored while monitoring some incidents over
the weekend and decided to hack this out, seems to have worked nicely.
Sponsored by all the RabbitMQ learnings for stream health :D

**Specific updates (required)**
 - Create a separate exchange E for publishing delayed messages (necessary for separate routing keys for each message)
 - Create a delayed queue Q, bound to everything on that exchange, with a dead-letter exchange set to the (other) main webhooks exchange
( - Publish messages on the exchange E, with the desired routing key and with an `expiration` set to desired delay. Message expires on the queue and is sent to the webhook's main exchange with the same routing key.)

## -

- **How did you test each of these updates (required)**
`yarn test`, we have plenty of tests on that part of the code :)
(at least for the basic retry/delay logic)

**Does this pull request close any open issues?**
Not really, was an on-call bonus.
Edit: Created one. Now this implements #812

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
