### PR TITLE
.github: Create separate api CI workflow

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -35,12 +35,10 @@ jobs:
 
       - name: yarn install
         run: |
-          cd packages/api
           yarn install --frozen-lockfile
 
       - name: yarn test
         run: |
-          cd packages/api
           yarn test
 
       - name: docker login
@@ -60,7 +58,6 @@ jobs:
           CF_EMAIL: ${{ secrets.CF_EMAIL }}
           DOCKER_BUILDKIT: 1
         run: |
-          cd packages/api
           yarn run docker:build
           yarn run docker:push
 

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -6,6 +6,23 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-18.04
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_HOST_AUTH_METHOD: "trust"
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+      rabbitmq:
+        image: rabbitmq@sha256:f0be9e47ec42081a36593dfc6604274a623caed074fc043e0a927fbd1533dc20
+        env:
+          RABBITMQ_DEFAULT_VHOST: "livepeer"
+        ports:
+          - 5672:5672
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -38,6 +38,14 @@ jobs:
         id: tags
         uses: livepeer/action-gh-release-tags@v0
 
+      - name: yarn install
+        run: |
+          yarn install --frozen-lockfile
+
+      - name: yarn test
+        run: |
+          yarn test
+
       - name: docker login
         env:
           DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
@@ -47,7 +55,7 @@ jobs:
           docker version
           docker login -u $DOCKER_USER -p $DOCKER_PASS
 
-      - name: test & docker build
+      - name: docker build & push
         env:
           DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
           VERSION: ${{ steps.tags.outputs.version }}
@@ -55,30 +63,7 @@ jobs:
           CF_EMAIL: ${{ secrets.CF_EMAIL }}
           DOCKER_BUILDKIT: 1
         run: |
-          sub_step() {
-            local cmd_name=$1
-            shift
-            (time sh -c "$@" || echo $cmd_name >> fail.txt) 2>&1 > $cmd_name.txt
-          }
-
-          sub_step test 'yarn install --frozen-lockfile && yarn test' &
-          sub_step docker-build 'yarn docker:build' &
-
-          wait
-          cat test.txt
-          cat docker-build.txt
-          if [ -f fail.txt ]; then
-            cat fail.txt
-            exit 1
-          fi
-
-      - name: docker push
-        env:
-          DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
-          VERSION: ${{ steps.tags.outputs.version }}
-          CF_API_KEY: ${{ secrets.CF_API_KEY }}
-          CF_EMAIL: ${{ secrets.CF_EMAIL }}
-        run: |
+          yarn run docker:build
           yarn run docker:push
 
       - name: notify livepeer-infra

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -35,10 +35,12 @@ jobs:
 
       - name: yarn install
         run: |
+          cd packages/api
           yarn install --frozen-lockfile
 
       - name: yarn test
         run: |
+          cd packages/api
           yarn test
 
       - name: docker login
@@ -58,6 +60,7 @@ jobs:
           CF_EMAIL: ${{ secrets.CF_EMAIL }}
           DOCKER_BUILDKIT: 1
         run: |
+          cd packages/api
           yarn run docker:build
           yarn run docker:push
 

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -31,8 +31,8 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '16'
-          cache: 'yarn'
+          node-version: "16"
+          cache: "yarn"
 
       - name: Tags
         id: tags

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,9 +1,8 @@
-name: www
+name: api
 on: push
 jobs:
   build:
     runs-on: ubuntu-18.04
-
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -31,7 +30,7 @@ jobs:
           CF_EMAIL: ${{ secrets.CF_EMAIL }}
           DOCKER_BUILDKIT: 1
         run: |
-          cd packages/www
+          cd packages/api
           yarn run docker:build
           yarn run docker:push
 

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -38,14 +38,6 @@ jobs:
         id: tags
         uses: livepeer/action-gh-release-tags@v0
 
-      - name: yarn install
-        run: |
-          yarn install --frozen-lockfile
-
-      - name: yarn test
-        run: |
-          yarn test
-
       - name: docker login
         env:
           DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
@@ -55,7 +47,7 @@ jobs:
           docker version
           docker login -u $DOCKER_USER -p $DOCKER_PASS
 
-      - name: docker build & push
+      - name: test & docker build
         env:
           DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
           VERSION: ${{ steps.tags.outputs.version }}
@@ -63,7 +55,30 @@ jobs:
           CF_EMAIL: ${{ secrets.CF_EMAIL }}
           DOCKER_BUILDKIT: 1
         run: |
-          yarn run docker:build
+          sub_step() {
+            local cmd_name=$1
+            shift
+            (time sh -c "$@" || echo $cmd_name >> fail.txt) 2>&1 > $cmd_name.txt
+          }
+
+          sub_step test 'yarn install --frozen-lockfile && yarn test' &
+          sub_step docker-build 'yarn docker:build' &
+
+          wait
+          cat test.txt
+          cat docker-build.txt
+          if [ -f fail.txt ]; then
+            cat fail.txt
+            exit 1
+          fi
+
+      - name: docker push
+        env:
+          DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
+          VERSION: ${{ steps.tags.outputs.version }}
+          CF_API_KEY: ${{ secrets.CF_API_KEY }}
+          CF_EMAIL: ${{ secrets.CF_EMAIL }}
+        run: |
           yarn run docker:push
 
       - name: notify livepeer-infra

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,5 +1,8 @@
 name: api
-on: push
+on:
+  push:
+    branches-ignore:
+      - latest
 defaults:
   run:
     working-directory: packages/api

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,5 +1,8 @@
 name: api
 on: push
+defaults:
+  run:
+    working-directory: packages/api
 jobs:
   build:
     runs-on: ubuntu-18.04
@@ -12,6 +15,14 @@ jobs:
       - name: Tags
         id: tags
         uses: livepeer/action-gh-release-tags@v0
+
+      - name: yarn install
+        run: |
+          yarn install --frozen-lockfile
+
+      - name: yarn test
+        run: |
+          yarn test
 
       - name: docker login
         env:
@@ -30,7 +41,6 @@ jobs:
           CF_EMAIL: ${{ secrets.CF_EMAIL }}
           DOCKER_BUILDKIT: 1
         run: |
-          cd packages/api
           yarn run docker:build
           yarn run docker:push
 

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: 'yarn'
+
       - name: Tags
         id: tags
         uses: livepeer/action-gh-release-tags@v0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,4 @@
+name: main
 on: push
 jobs:
   build:
@@ -25,19 +26,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Tags
-        id: tags
-        uses: livepeer/action-gh-release-tags@v0
-
-      - name: docker login
-        env:
-          DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
-          DOCKER_USER: ${{ secrets.DOCKER_USER }}
-        run: |
-          # docker login
-          docker version
-          docker login -u $DOCKER_USER -p $DOCKER_PASS
-
       - name: yarn install
         run: |
           yarn install --frozen-lockfile
@@ -45,17 +33,3 @@ jobs:
       - name: yarn test
         run: |
           yarn test
-
-      - name: docker build
-        env:
-          DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
-          VERSION: ${{ steps.tags.outputs.version }}
-          CF_API_KEY: ${{ secrets.CF_API_KEY }}
-          CF_EMAIL: ${{ secrets.CF_EMAIL }}
-          DOCKER_BUILDKIT: 1
-        run: |
-          yarn run lerna-run docker:build --scope=@livepeer.com/api
-          yarn run lerna-run docker:push --scope=@livepeer.com/api
-
-          # Livepeer internal build alerting
-          curl -X POST https://holy-bread-207a.livepeer.workers.dev

--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -15,14 +15,14 @@ WORKDIR /app
 
 ENV NODE_ENV production
 
+ADD packages/api/package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+COPY --from=builder /app/dist dist
+
 ARG VERSION
 ENV VERSION ${VERSION}
 ARG GITHUB_SHA
 ENV GITHUB_SHA ${GITHUB_SHA}
-
-ADD packages/api/package.json yarn.lock ./
-RUN yarn install --frozen-lockfile
-COPY --from=builder /app/dist dist
 
 RUN node dist/cli.js --help
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "cloud-dev": "npm run docker && kubectl delete pod -l app.kubernetes.io/name=livepeer-api-server --wait && sleep 1 && kubectl logs -f --pod-running-timeout=30s $(kubectl get pods -o name -l app.kubernetes.io/name=livepeer-api-server)",
     "cloud-dev:server": "nodemon -w src -x node -r esm src/cli.js --port 3040 --kubeBroadcasterService broadcaster --kubeOrchestratorService orchestrator --kubeNamespace default --kubeBroadcasterTemplate 'https://{{nodeName}}.livepeer-staging.live' --kubeOrchestratorTemplate 'https://{{nodeName}}.livepeer-staging.live:8935'",
-    "docker:build": "docker pull livepeerci/api:master && docker build --cache-from=livepeerci/api:master $(printf ' -t livepeerci/api:%s' ${DOCKER_TAGS:-master}) --build-arg GITHUB_SHA --build-arg VERSION -f Dockerfile ../..",
+    "docker:build": "docker build $(printf ' -t livepeerci/api:%s' ${DOCKER_TAGS:-master}) --build-arg GITHUB_SHA --build-arg VERSION -f Dockerfile ../..",
     "docker:push": "for TAG in ${DOCKER_TAGS:-dev}; do docker push livepeerci/api:${TAG}; done",
     "docker": "run-s docker:build docker:push",
     "postgres:start": "docker run --rm -d --name postgres -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 -v \"$(pwd)/data/postgres:/var/lib/postgresql/data\" postgres",


### PR DESCRIPTION
Building the API image takes a looong time today
because we build all the WWW stuff before it.

This separates the API docker image build so that
we can have it in a few minutes, not in 10 minutes.

Added an `install` & `test` steps on the root just so
that we don't end up publishing a docker image that
does not pass the repo tests. That doubles the build
time to 5 minutes instead of 2 tho, so happy to remove
if someone thinks we can deal with the potential unsafe
docker images.
