### PR TITLE
www: Prevent recording and multistream changes while stream is live

### DIFF
--- a/packages/www/components/Dashboard/ErrorDialog/index.tsx
+++ b/packages/www/components/Dashboard/ErrorDialog/index.tsx
@@ -10,10 +10,12 @@ import {
   Text,
 } from "@livepeer.com/design-system";
 
-const ErrorRecordDialog = ({
+const ErrorDialog = ({
+  description,
   isOpen,
   onOpenChange,
 }: {
+  description: string;
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
 }) => {
@@ -28,7 +30,7 @@ const ErrorRecordDialog = ({
           size="3"
           variant="gray"
           css={{ mt: "$2", lineHeight: "22px" }}>
-          You cannot change recording preferences while a session is active
+          {description}
         </AlertDialogDescription>
 
         <Flex css={{ jc: "flex-end", gap: "$3", mt: "$5" }}>
@@ -41,4 +43,4 @@ const ErrorRecordDialog = ({
   );
 };
 
-export default ErrorRecordDialog;
+export default ErrorDialog;

--- a/packages/www/components/Dashboard/ErrorRecordDialog/index.tsx
+++ b/packages/www/components/Dashboard/ErrorRecordDialog/index.tsx
@@ -1,0 +1,44 @@
+import {
+  Button,
+  Flex,
+  AlertDialog,
+  AlertDialogTitle,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogCancel,
+  Heading,
+  Text,
+} from "@livepeer.com/design-system";
+
+const ErrorRecordDialog = ({
+  isOpen,
+  onOpenChange,
+}: {
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+}) => {
+  return (
+    <AlertDialog open={isOpen} onOpenChange={onOpenChange}>
+      <AlertDialogContent css={{ maxWidth: 450, px: "$5", pt: "$4", pb: "$4" }}>
+        <AlertDialogTitle as={Heading} size="1">
+          Error
+        </AlertDialogTitle>
+        <AlertDialogDescription
+          as={Text}
+          size="3"
+          variant="gray"
+          css={{ mt: "$2", lineHeight: "22px" }}>
+          You cannot change recording preferences while a session is active
+        </AlertDialogDescription>
+
+        <Flex css={{ jc: "flex-end", gap: "$3", mt: "$5" }}>
+          <AlertDialogCancel size="2" as={Button} ghost>
+            Ok
+          </AlertDialogCancel>
+        </Flex>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+
+export default ErrorRecordDialog;

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/Toolbox.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/Toolbox.tsx
@@ -27,7 +27,7 @@ import { useApi } from "../../../hooks";
 import { useToggleState } from "hooks/use-toggle-state";
 import { MultistreamTarget, Stream } from "../../../../api/src/schema/types";
 import SaveTargetDialog, { Action } from "./SaveTargetDialog";
-import ErrorRecordDialog from "../ErrorRecordDialog";
+import ErrorDialog from "../ErrorDialog";
 
 const DisableDialog = ({
   onDialogAction,
@@ -213,12 +213,10 @@ const Toolbox = ({
         onCheckedChange={useCallback(async () => {
           if (stream.isActive) {
             errorRecordDialogState.onOn();
+          } else if (target?.disabled) {
+            await setTargetDisabled(false);
           } else {
-            if (target?.disabled) {
-              await setTargetDisabled(false);
-            } else {
-              setDisableDialogOpen(true);
-            }
+            setDisableDialogOpen(true);
           }
         }, [target?.disabled, setTargetDisabled])}
       />
@@ -259,9 +257,10 @@ const Toolbox = ({
         </DropdownMenuContent>
       </DropdownMenu>
 
-      <ErrorRecordDialog
+      <ErrorDialog
         isOpen={errorRecordDialogState.on}
         onOpenChange={errorRecordDialogState.onToggle}
+        description="You cannot change multistream preferences while a session is active"
       />
 
       <DisableDialog

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
@@ -30,7 +30,7 @@ import { HealthStatus } from "hooks/use-analyzer";
 import Toolbox from "./Toolbox";
 import SaveTargetDialog, { Action } from "./SaveTargetDialog";
 import TargetStatusBadge from "./TargetStatusBadge";
-import ErrorRecordDialog from "../ErrorRecordDialog";
+import ErrorDialog from "../ErrorDialog";
 
 type TargetsTableData = {
   id: string;
@@ -223,9 +223,10 @@ const MultistreamTargetsTable = ({
         }}
       />
 
-      <ErrorRecordDialog
+      <ErrorDialog
         isOpen={errorRecordDialogState.on}
         onOpenChange={errorRecordDialogState.onToggle}
+        description="You cannot change multistream preferences while a session is active"
       />
 
       <SaveTargetDialog

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
@@ -30,6 +30,7 @@ import { HealthStatus } from "hooks/use-analyzer";
 import Toolbox from "./Toolbox";
 import SaveTargetDialog, { Action } from "./SaveTargetDialog";
 import TargetStatusBadge from "./TargetStatusBadge";
+import ErrorRecordDialog from "../ErrorRecordDialog";
 
 type TargetsTableData = {
   id: string;
@@ -85,6 +86,7 @@ const MultistreamTargetsTable = ({
     tableId: "multistreamTargetsTable",
   });
   const saveDialogState = useToggleState();
+  const errorRecordDialogState = useToggleState();
 
   const columns: Column<TargetsTableData>[] = useMemo(
     () => [
@@ -205,7 +207,10 @@ const MultistreamTargetsTable = ({
         emptyState={emptyState}
         tableLayout={tableLayout}
         createAction={{
-          onClick: saveDialogState.onOn,
+          onClick: () =>
+            stream.isActive
+              ? errorRecordDialogState.onOn()
+              : saveDialogState.onOn(),
           css: { display: "flex", alignItems: "center", ml: "$1" },
           children: (
             <>
@@ -216,6 +221,11 @@ const MultistreamTargetsTable = ({
             </>
           ),
         }}
+      />
+
+      <ErrorRecordDialog
+        isOpen={errorRecordDialogState.on}
+        onOpenChange={errorRecordDialogState.onToggle}
       />
 
       <SaveTargetDialog

--- a/packages/www/components/Dashboard/StreamDetails/Record.tsx
+++ b/packages/www/components/Dashboard/StreamDetails/Record.tsx
@@ -1,113 +1,55 @@
 import {
   Box,
-  Button,
-  Flex,
-  AlertDialog,
-  AlertDialogTitle,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogCancel,
-  AlertDialogAction,
   DropdownMenuItem,
-  Heading,
-  Text,
   Switch,
   useSnackbar,
 } from "@livepeer.com/design-system";
-import { useState } from "react";
+import { useToggleState } from "hooks/use-toggle-state";
 import { useApi } from "../../../hooks";
-import Spinner from "components/Dashboard/Spinner";
+import ErrorRecordDialog from "../ErrorRecordDialog";
 
 const Record = ({ stream, invalidate, isSwitch = true }) => {
   const { patchStream } = useApi();
-  const [saving, setSaving] = useState(false);
-  const [open, setOpen] = useState(false);
   const [openSnackbar] = useSnackbar();
+  const errorRecordDialogState = useToggleState();
+
+  const onCheckedChange = async (e) => {
+    e.preventDefault();
+    if (stream.isActive) {
+      errorRecordDialogState.onOn();
+    } else {
+      if (!stream.record) {
+        await patchStream(stream.id, { record: true });
+        await invalidate();
+        openSnackbar("Recording has been turned on.");
+      } else {
+        await patchStream(stream.id, { record: false });
+        await invalidate();
+        openSnackbar("Recording has been turned off.");
+      }
+    }
+  };
 
   return (
-    <AlertDialog open={open} onOpenChange={() => setOpen(!open)}>
+    <Box>
       {isSwitch ? (
         <Switch
           checked={!!stream.record}
           name="record-mode"
           value={`${!!stream.record}`}
-          onCheckedChange={async () => {
-            if (!stream.record) {
-              await patchStream(stream.id, { record: true });
-              await invalidate();
-              openSnackbar("Recording has been turned on.");
-            } else {
-              setOpen(true);
-            }
-          }}
+          onCheckedChange={(e) => onCheckedChange(e)}
         />
       ) : (
-        <Box
-          as={DropdownMenuItem}
-          onSelect={async (e) => {
-            e.preventDefault();
-            if (!stream.record) {
-              await patchStream(stream.id, { record: true });
-              await invalidate();
-              openSnackbar("Recording has been turned on.");
-            } else {
-              setOpen(true);
-            }
-          }}>
+        <Box as={DropdownMenuItem} onSelect={(e) => onCheckedChange(e)}>
           <Box>{!stream.record ? "Enable recording" : "Disable recording"}</Box>
         </Box>
       )}
 
-      <AlertDialogContent css={{ maxWidth: 450, px: "$5", pt: "$4", pb: "$4" }}>
-        <AlertDialogTitle as={Heading} size="1">
-          Disable recording?
-        </AlertDialogTitle>
-        <AlertDialogDescription
-          as={Text}
-          size="3"
-          variant="gray"
-          css={{ mt: "$2", lineHeight: "22px" }}>
-          Future stream sessions will not be recorded. In progress stream
-          sessions will be recorded. Past sessions recordings will still be
-          available.
-        </AlertDialogDescription>
-
-        <Flex css={{ jc: "flex-end", gap: "$3", mt: "$5" }}>
-          <AlertDialogCancel
-            size="2"
-            onClick={() => setOpen(false)}
-            as={Button}
-            ghost>
-            Cancel
-          </AlertDialogCancel>
-          <AlertDialogAction
-            size="2"
-            as={Button}
-            disabled={saving}
-            onClick={async (e) => {
-              e.preventDefault();
-              setSaving(true);
-              await patchStream(stream.id, { record: !stream.record });
-              await invalidate();
-              openSnackbar("Recording has been turned off.");
-              setSaving(false);
-              setOpen(false);
-            }}
-            variant="red">
-            {saving && (
-              <Spinner
-                css={{
-                  width: 16,
-                  height: 16,
-                  mr: "$2",
-                }}
-              />
-            )}
-            Disable recording
-          </AlertDialogAction>
-        </Flex>
-      </AlertDialogContent>
-    </AlertDialog>
+      <ErrorRecordDialog
+        isOpen={errorRecordDialogState.on}
+        onOpenChange={errorRecordDialogState.onToggle}
+      />
+    </Box>
   );
 };
 

--- a/packages/www/components/Dashboard/StreamDetails/Record.tsx
+++ b/packages/www/components/Dashboard/StreamDetails/Record.tsx
@@ -6,7 +6,7 @@ import {
 } from "@livepeer.com/design-system";
 import { useToggleState } from "hooks/use-toggle-state";
 import { useApi } from "../../../hooks";
-import ErrorRecordDialog from "../ErrorRecordDialog";
+import ErrorDialog from "../ErrorDialog";
 
 const Record = ({ stream, invalidate, isSwitch = true }) => {
   const { patchStream } = useApi();
@@ -17,16 +17,14 @@ const Record = ({ stream, invalidate, isSwitch = true }) => {
     e.preventDefault();
     if (stream.isActive) {
       errorRecordDialogState.onOn();
+    } else if (!stream.record) {
+      await patchStream(stream.id, { record: true });
+      await invalidate();
+      openSnackbar("Recording has been turned on.");
     } else {
-      if (!stream.record) {
-        await patchStream(stream.id, { record: true });
-        await invalidate();
-        openSnackbar("Recording has been turned on.");
-      } else {
-        await patchStream(stream.id, { record: false });
-        await invalidate();
-        openSnackbar("Recording has been turned off.");
-      }
+      await patchStream(stream.id, { record: false });
+      await invalidate();
+      openSnackbar("Recording has been turned off.");
     }
   };
 
@@ -45,9 +43,10 @@ const Record = ({ stream, invalidate, isSwitch = true }) => {
         </Box>
       )}
 
-      <ErrorRecordDialog
+      <ErrorDialog
         isOpen={errorRecordDialogState.on}
         onOpenChange={errorRecordDialogState.onToggle}
+        description="You cannot change recording preferences while a session is active"
       />
     </Box>
   );


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

###  Dashboard: Prevent users from turning recording on and off while a stream is active, remove warning for disabling recording

- Handling Switch button for Record sessions on the stream details
- Apply to changing multistream targets
- Remove AlertDialog for disabling recording


<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

Fixes #797 

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
