### PR TITLE
api: Improve Webhook Retry Logic and Notification

### DIFF
--- a/packages/api/src/app-router.ts
+++ b/packages/api/src/app-router.ts
@@ -86,6 +86,10 @@ export default async function makeApp(params: CliArgs) {
   const webhookCannon = new WebhookCannon({
     db,
     store,
+    frontendDomain,
+    sendgridTemplateId,
+    sendgridApiKey,
+    supportAddr,
     verifyUrls: true,
     queue,
   });

--- a/packages/api/src/controllers/user.js
+++ b/packages/api/src/controllers/user.js
@@ -190,7 +190,7 @@ app.post("/", validatePost("user"), async (req, res) => {
   const verificationUrl = `${protocol}://${
     req.frontendDomain
   }/verify?${qs.stringify({ email, emailValidToken, selectedPlan })}`;
-  const unsubscribeUrl = `${protocol}://${req.frontendDomain}/#contactSection`;
+  const unsubscribeUrl = `${protocol}://${req.frontendDomain}/contact`;
 
   if (!validUser && user) {
     const { supportAddr, sendgridTemplateId, sendgridApiKey } = req.config;
@@ -310,7 +310,7 @@ app.post("/verify", validatePost("user-verification"), async (req, res) => {
     const protocol =
       req.headers["x-forwarded-proto"] === "https" ? "https" : "http";
     const buttonUrl = `${protocol}://${req.frontendDomain}/login`;
-    const unsubscribeUrl = `${protocol}://${req.frontendDomain}/#contactSection`;
+    const unsubscribeUrl = `${protocol}://${req.frontendDomain}/contact`;
     const salesEmail = "sales@livepeer.org";
 
     if (req.headers.host.includes("livepeer.com")) {
@@ -463,7 +463,7 @@ app.post(
       const verificationUrl = `${protocol}://${
         req.frontendDomain
       }/reset-password?${qs.stringify({ email, resetToken })}`;
-      const unsubscribeUrl = `${protocol}://${req.frontendDomain}/#contactSection`;
+      const unsubscribeUrl = `${protocol}://${req.frontendDomain}/contact`;
 
       await sendgridEmail({
         email,

--- a/packages/api/src/util.ts
+++ b/packages/api/src/util.ts
@@ -1,5 +1,10 @@
 import fetch, { RequestInit, Response } from "node-fetch";
 
+// extend requestinit with timeout parameter
+export interface RequestInitWithTimeout extends RequestInit {
+  timeout?: number;
+}
+
 export const timeout = <T>(ms: number, fn: () => Promise<T>) => {
   return new Promise<T>((resolve, reject) => {
     const handle = setTimeout(() => {
@@ -54,7 +59,7 @@ export const shuffle = <T>(arr: T[]) => {
 
 export const fetchWithTimeout = (
   url: string,
-  options: RequestInit & { timeout?: number }
+  options: RequestInitWithTimeout
 ) =>
   new Promise<Response>((resolve, reject) => {
     let timeout = setTimeout(() => {

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -270,7 +270,7 @@ export default class WebhookCannon {
 
     let signature_header = "";
     if (params.headers[SIGNATURE_HEADER]) {
-      signature_header = `-H  ${SIGNATURE_HEADER}: ${params.headers["Livepeer-Signature"]}`;
+      signature_header = `-H  "${SIGNATURE_HEADER}: ${params.headers["Livepeer-Signature"]}"`;
     }
 
     let payload = params.body;

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -24,13 +24,30 @@ export default class WebhookCannon {
   store: Model;
   running: boolean;
   verifyUrls: boolean;
+  frontendDomain: string;
+  sendgridTemplateId: string;
+  sendgridApiKey: string;
+  supportAddr: string;
   resolver: any;
   queue: Queue;
-  constructor({ db, store, verifyUrls, queue }) {
+  constructor({
+    db,
+    store,
+    frontendDomain,
+    sendgridTemplateId,
+    sendgridApiKey,
+    supportAddr,
+    verifyUrls,
+    queue,
+  }) {
     this.db = db;
     this.store = store;
     this.running = true;
     this.verifyUrls = verifyUrls;
+    this.frontendDomain = frontendDomain;
+    this.sendgridTemplateId = sendgridTemplateId;
+    this.sendgridApiKey = sendgridApiKey;
+    this.supportAddr = supportAddr;
     this.resolver = new dns.Resolver();
     this.queue = queue;
     // this.start();

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -16,7 +16,7 @@ import { sign, sendgridEmail } from "../controllers/helpers";
 const WEBHOOK_TIMEOUT = 5 * 1000;
 const MAX_BACKOFF = 10 * 60 * 1000 * 6;
 const BACKOFF_COEF = 2;
-const MAX_RETRIES = 20;
+const MAX_RETRIES = 33;
 
 export default class WebhookCannon {
   db: DB;
@@ -277,7 +277,7 @@ export default class WebhookCannon {
           buttonUrl: `https://${this.frontendDomain}/dashboard/developers/webhooks`,
           unsubscribe: `https://${this.frontendDomain}/contact`,
           text: [
-            `Your webhook failed to receive this payload: `,
+            `Your webhook failed to receive this payload in the last 24 hours: `,
             `<code>${payload}</code>`,
             `This is the error we are receiving:`,
             `${err}`,

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -286,13 +286,13 @@ export default class WebhookCannon {
       buttonUrl: `https://${this.frontendDomain}/dashboard/developers/webhooks`,
       unsubscribe: `https://${this.frontendDomain}/contact`,
       text: [
-        `Your webhook failed to receive this payload in the last 24 hours: `,
-        `<code>${payload}</code>`,
-        `This is the error we are receiving:`,
-        `${err}`,
-        `We disabled your webhook, please check your configuration and try again.`,
-        `If you want to try yourself the call we are making, here is a curl command for that:`,
-        `<code>curl -X POST -H "Content-Type: application/json" -H "user-agent: livepeer.com" ${signature_header} -d '${payload}' ${trigger.webhook.url}</code>`,
+        `Your webhook ${trigger.webhook.url} failed to receive our payload in the last 24 hours`,
+        //`<code>${payload}</code>`,
+        //`This is the error we are receiving:`,
+        //`${err}`,
+        //`We disabled your webhook, please check your configuration and try again.`,
+        //`If you want to try yourself the call we are making, here is a curl command for that:`,
+        //`<code>curl -X POST -H "Content-Type: application/json" -H "user-agent: livepeer.com" ${signature_header} -d '${payload}' ${trigger.webhook.url}</code>`,
       ].join("\n\n"),
     });
 

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -270,7 +270,7 @@ export default class WebhookCannon {
 
     let signature_header = "";
     if (params.headers[SIGNATURE_HEADER]) {
-      signature_header = `-H  : ${params.headers[SIGNATURE_HEADER]}`;
+      signature_header = `-H  ${SIGNATURE_HEADER}: ${params.headers["Livepeer-Signature"]}`;
     }
 
     let payload = params.body;


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Changes the webhook retry policy as specified at #818 and add a notification email to the user if max retries are reached

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

- Modifies the backoff coefficient to 2
- Sets the max retries attempt to 33 (24h)
- Send an email to the user before the webhook is disabled

**How did you test each of these updates (required)**

CI

**Does this pull request close any open issues?**

Fixes #818 

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
