### PR TITLE
api/queue: Create webhook queues as quorum type

### DIFF
--- a/packages/api/src/store/queue.ts
+++ b/packages/api/src/store/queue.ts
@@ -81,11 +81,9 @@ export class RabbitQueue implements Queue {
         await Promise.all([
           channel.assertQueue(QUEUES.events, {
             arguments: { "x-queue-type": "quorum" },
-            durable: true,
           }),
           channel.assertQueue(QUEUES.webhooks, {
             arguments: { "x-queue-type": "quorum" },
-            durable: true,
           }),
           channel.assertExchange(EXCHANGES.webhooks, "topic", {
             durable: true,

--- a/packages/api/src/store/queue.ts
+++ b/packages/api/src/store/queue.ts
@@ -9,8 +9,10 @@ const EXCHANGES = {
   delayed: "webhook_delayed_exchange",
 } as const;
 const QUEUES = {
-  events: "webhook_events_queue",
-  webhooks: "webhook_cannon_single_url",
+  events: "webhook_events_queue_v1",
+  webhooks: "webhook_cannon_single_url_v1",
+  events_old: "webhook_events_queue",
+  webhooks_old: "webhook_cannon_single_url",
   delayed: "webhook_delayed_queue",
 } as const;
 
@@ -77,8 +79,14 @@ export class RabbitQueue implements Queue {
       json: true,
       setup: async (channel: Channel) => {
         await Promise.all([
-          channel.assertQueue(QUEUES.events, { durable: true }),
-          channel.assertQueue(QUEUES.webhooks, { durable: true }),
+          channel.assertQueue(QUEUES.events, {
+            arguments: { "x-queue-type": "quorum" },
+            durable: true,
+          }),
+          channel.assertQueue(QUEUES.webhooks, {
+            arguments: { "x-queue-type": "quorum" },
+            durable: true,
+          }),
           channel.assertExchange(EXCHANGES.webhooks, "topic", {
             durable: true,
           }),
@@ -91,6 +99,8 @@ export class RabbitQueue implements Queue {
           channel.bindQueue(QUEUES.webhooks, EXCHANGES.webhooks, "webhooks.#"),
           channel
             .assertQueue(QUEUES.delayed, {
+              // Quorum queues do not support message expiration, so this has to
+              // be a Classic Mirrored Queue configured by a policy on RabbitMQ.
               deadLetterExchange: EXCHANGES.webhooks,
               durable: true,
             })
@@ -98,6 +108,27 @@ export class RabbitQueue implements Queue {
               channel.bindQueue(QUEUES.delayed, EXCHANGES.delayed, "#")
             ),
           channel.prefetch(2),
+        ]);
+        // TODO: Remove this once all old queues have been deleted.
+        await Promise.all([
+          channel.unbindQueue(
+            QUEUES.events_old,
+            EXCHANGES.webhooks,
+            "events.#"
+          ),
+          channel.unbindQueue(
+            QUEUES.webhooks_old,
+            EXCHANGES.webhooks,
+            "webhooks.#"
+          ),
+          channel.deleteQueue(QUEUES.events_old, {
+            ifUnused: true,
+            ifEmpty: true,
+          }),
+          channel.deleteQueue(QUEUES.webhooks_old, {
+            ifUnused: true,
+            ifEmpty: true,
+          }),
         ]);
       },
     });


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This is to guarantee some higher availability for the webhook queues by making them of quorum type instead.

**Specific updates (required)**
 - Create new queues, appending a `_v1` to their previous names
 - Create logic to unbind the old queues from the exchanges and delete them once they are empty+unused

## -

- **How did you test each of these updates (required)**
 - Ran api locally and ensure it creates the new queues and delete the old ones.
 - Ran it again to ensure that neither the `unbind` nor the `delete` explode when the queue is not 
 - `yarn test`

**Does this pull request close any open issues?**
Implements #823 

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have run tests to cover my changes.
