### PR TITLE
api: add status to Webhooks

### DIFF
--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -170,37 +170,31 @@ components:
         status:
           type: object
           description: status of webhook
-          default: null
           readOnly: true
           properties:
             lastFailure:
               type: object
               description: failure timestamp and error message with status code
-              default: null
               readOnly: true
               properties:
                 timestamp:
                   type: number
                   readOnly: true
-                  default: null
                   example: 1587667174725
                   description:
                     Timestamp (in milliseconds) at which the webhook last failed
                 error:
                   type: string
                   readOnly: true
-                  default: null
                   description: Webhook failure error message
                   example: "Error message"
                 statusCode:
                   type: number
                   readOnly: true
-                  default: null
                   description: Webhook failure status code
                   example: 500
             lastTriggerTime:
               type: number
-              default: null
               readyOnly: true
               description:
                 Timestamp (in milliseconds) at which the webhook last was

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -193,7 +193,7 @@ components:
                   readOnly: true
                   description: Webhook failure status code
                   example: 500
-            lastTriggerTime:
+            lastTriggeredAt:
               type: number
               readyOnly: true
               description:

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -188,6 +188,11 @@ components:
                   readOnly: true
                   description: Webhook failure error message
                   example: "Error message"
+                response:
+                  type: string
+                  readOnly: true
+                  description: Webhook failure response
+                  example: "Response body"
                 statusCode:
                   type: number
                   readOnly: true

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -167,6 +167,45 @@ components:
           type: string
           writeOnly: true
           description: shared secret used to sign the webhook payload
+        status:
+          type: object
+          description: status of webhook
+          default: null
+          readOnly: true
+          properties:
+            lastFailure:
+              type: object
+              description: failure timestamp and error message with status code
+              default: null
+              readOnly: true
+              properties:
+                timestamp:
+                  type: number
+                  readOnly: true
+                  default: null
+                  example: 1587667174725
+                  description:
+                    Timestamp (in milliseconds) at which the webhook last failed
+                error:
+                  type: string
+                  readOnly: true
+                  default: null
+                  description: Webhook failure error message
+                  example: "Error message"
+                statusCode:
+                  type: number
+                  readOnly: true
+                  default: null
+                  description: Webhook failure status code
+                  example: 500
+            lastTriggerTime:
+              type: number
+              default: null
+              readyOnly: true
+              description:
+                Timestamp (in milliseconds) at which the webhook last was
+                triggered
+              example: 1587667174725
 
     webhook-response:
       type: object

--- a/packages/api/src/store/webhook-table.ts
+++ b/packages/api/src/store/webhook-table.ts
@@ -45,7 +45,7 @@ export default class WebhookTable extends Table<DBWebhook> {
       `UPDATE ${
         this.name
       } SET data = jsonb_set(data, '{status}', case when data->'status' is null then '{}' else data->'status' end || '${JSON.stringify(
-        status.status
+        status
       )}') WHERE id = '${id}'`
     );
 

--- a/packages/api/src/util.ts
+++ b/packages/api/src/util.ts
@@ -1,6 +1,4 @@
 import fetch, { RequestInit, Response } from "node-fetch";
-
-// extend requestinit with timeout parameter
 export interface RequestInitWithTimeout extends RequestInit {
   timeout?: number;
 }

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -387,8 +387,7 @@ export default class WebhookCannon {
         logger.info(`webhook ${webhook.id} firing`);
         const startTime = process.hrtime();
         resp = await fetchWithTimeout(webhook.url, params);
-        // getting the response text here to avoid the overhead of reading the body twice
-        let responseBody = await resp.text();
+        const responseBody = await resp.text();
         await this.storeResponse(webhook, event, resp, startTime, responseBody);
         statusCode = resp.status;
 

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -303,7 +303,7 @@ export default class WebhookCannon {
     });
 
     console.log(
-      `Webhook Cannon| Email sent to user, id: ${trigger.id}, streamId: ${trigger.stream?.id}`
+      `Webhook Cannon| Email sent to user ${trigger.user.email}, id: ${trigger.id}, streamId: ${trigger.stream?.id}`
     );
   }
 
@@ -379,13 +379,13 @@ export default class WebhookCannon {
       }
       const triggerTime = Date.now();
       let resp: Response;
-      let errorMessage;
-      let statusCode;
+      let errorMessage: string;
+      let statusCode: number;
       try {
         logger.info(`webhook ${webhook.id} firing`);
         const startTime = process.hrtime();
         resp = await fetchWithTimeout(webhook.url, params);
-        const responseBody = await resp.text();
+        const responseBody = (errorMessage = await resp.text());
         await this.storeResponse(webhook, event, resp, startTime, responseBody);
         statusCode = resp.status;
 
@@ -394,7 +394,6 @@ export default class WebhookCannon {
           logger.info(`webhook ${webhook.id} fired successfully`);
           return true;
         }
-        errorMessage = responseBody;
         if (resp.status >= 500) {
           await this.retry(
             trigger,

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -274,7 +274,7 @@ export default class WebhookCannon {
 
     let signatureHeader = "";
     if (params.headers[SIGNATURE_HEADER]) {
-      signatureHeader = `-H  "${SIGNATURE_HEADER}: ${params.headers["Livepeer-Signature"]}"`;
+      signatureHeader = `-H  "${SIGNATURE_HEADER}: ${params.headers[SIGNATURE_HEADER]}"`;
     }
 
     let payload = params.body;

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -442,7 +442,7 @@ export default class WebhookCannon {
   async storeTriggerTime(webhook: DBWebhook) {
     await this.db.webhook.update(webhook.id, {
       status: {
-        lastTriggerTime: Date.now(),
+        lastTriggeredAt: Date.now(),
         lastFailure: webhook.status?.lastFailure,
       },
     });
@@ -455,7 +455,7 @@ export default class WebhookCannon {
   ) {
     await this.db.webhook.update(webhook.id, {
       status: {
-        lastTriggerTime: webhook.status?.lastTriggerTime,
+        lastTriggeredAt: webhook.status?.lastTriggeredAt,
         lastFailure: {
           timestamp: Date.now(),
           statusCode: statusCode,

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -377,7 +377,8 @@ export default class WebhookCannon {
         let signature = sign(params.body, webhook.sharedSecret);
         params.headers[SIGNATURE_HEADER] = `t=${timestamp},v1=${signature}`;
       }
-      await this.storeTriggerTime(webhook);
+      const triggerTime = Date.now();
+      await this.storeTriggerTime(webhook, triggerTime);
       let resp: Response;
       let errorMessage;
       let statusCode;
@@ -417,6 +418,7 @@ export default class WebhookCannon {
         if (statusCode >= 300 || !statusCode) {
           await this.storeWebhookFailure(
             trigger.webhook,
+            triggerTime,
             statusCode,
             errorMessage
           );
@@ -426,11 +428,11 @@ export default class WebhookCannon {
     }
   }
 
-  async storeTriggerTime(webhook: DBWebhook) {
+  async storeTriggerTime(webhook: DBWebhook, triggerTime: number) {
     try {
       await this.db.webhook.update(webhook.id, {
         status: {
-          lastTriggeredAt: Date.now(),
+          lastTriggeredAt: triggerTime,
           lastFailure: webhook.status?.lastFailure,
         },
       });
@@ -443,6 +445,7 @@ export default class WebhookCannon {
 
   async storeWebhookFailure(
     webhook: DBWebhook,
+    triggerTime: number,
     statusCode?: number,
     errorMessage?: string
   ) {
@@ -451,7 +454,7 @@ export default class WebhookCannon {
         status: {
           lastTriggeredAt: webhook.status?.lastTriggeredAt,
           lastFailure: {
-            timestamp: Date.now(),
+            timestamp: triggerTime,
             statusCode: statusCode,
             errorMessage: errorMessage,
           },

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -290,7 +290,7 @@ export default class WebhookCannon {
       buttonUrl: `https://${this.frontendDomain}/dashboard/developers/webhooks`,
       unsubscribe: `https://${this.frontendDomain}/contact`,
       text: [
-        `Your webhook ${trigger.webhook.url} failed to receive our payload in the last 24 hours`,
+        `Your webhook ${trigger.webhook.name} with url ${trigger.webhook.url} failed to receive our payload in the last 24 hours`,
         //`<code>${payload}</code>`,
         `This is the error we are receiving:`,
         `${err}`,


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Extends [#838](https://github.com/livepeer/livepeer-com/pull/838) to add a status object on the api webhooks.
Now the lastTriggerTime and the lastFailure timestamps are added on _fireHook, making possible a notification of unhealthy or healthy state on the dashboard in a future step, as discussed [here](https://github.com/livepeer/livepeer-com/issues/818#issuecomment-1007765675).

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

* Added webhook status schema  
* Store failure and trigger time on webhook status  
  

**How did you test each of these updates (required)**

CI

**Does this pull request close any open issues?**

Extends [#838](https://github.com/livepeer/livepeer-com/pull/838) on issue [#818](https://github.com/livepeer/livepeer-com/compare/gioele/webhooks-lastfailure)

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
