### PR TITLE
api: Set some default profiles to streams

### DIFF
--- a/packages/api/src/controllers/stream.test.ts
+++ b/packages/api/src/controllers/stream.test.ts
@@ -1076,6 +1076,22 @@ describe("controllers/stream", () => {
       }
     });
 
+    it("should set default profiles if none provided", async () => {
+      const res = await client.post("/stream", {
+        ...stream,
+        profiles: undefined,
+      });
+      expect(res.status).toBe(201);
+      const data = (await res.json()) as DBStream;
+      expect(data.profiles).not.toEqual(stream.profiles);
+      expect(data.profiles.map((p) => p.name).sort()).toEqual([
+        "240p0",
+        "360p0",
+        "480p0",
+        "720p0",
+      ]);
+    });
+
     it("should reject profiles we do not have", async () => {
       const badStream = {
         ...profileStream,

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -42,6 +42,15 @@ export const USER_SESSION_TIMEOUT = 5 * 60 * 1000; // 5 min
 const HTTP_PUSH_TIMEOUT = 60 * 1000; // value in the go-livepeer codebase
 const ACTIVE_TIMEOUT = 90 * 1000;
 
+const DEFAULT_STREAM_FIELDS: Partial<DBStream> = {
+  profiles: [
+    { name: "240p0", fps: 0, bitrate: 250000, width: 426, height: 240 },
+    { name: "360p0", fps: 0, bitrate: 800000, width: 640, height: 360 },
+    { name: "480p0", fps: 0, bitrate: 1600000, width: 854, height: 480 },
+    { name: "720p0", fps: 0, bitrate: 3000000, width: 1280, height: 720 },
+  ],
+};
+
 const app = Router();
 const hackMistSettings = (req: Request, profiles: Profile[]): Profile[] => {
   if (
@@ -813,6 +822,7 @@ app.post("/", authMiddleware({}), validatePost("stream"), async (req, res) => {
   }
 
   const doc: DBStream = wowzaHydrate({
+    ...DEFAULT_STREAM_FIELDS,
     ...req.body,
     kind: "stream",
     userId: req.user.id,

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -389,6 +389,7 @@ components:
         profiles:
           type: array
           default:
+            # prettier-ignore
             - { name: "240p0", fps: 0, bitrate: 250000, width: 426, height: 240 }
             - { name: "360p0", fps: 0, bitrate: 800000, width: 640, height: 360 }
             - { name: "480p0", fps: 0, bitrate: 1600000, width: 854, height: 480 }

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -388,6 +388,11 @@ components:
           unique: true
         profiles:
           type: array
+          default:
+            - { name: "240p0", fps: 0, bitrate: 250000, width: 426, height: 240 }
+            - { name: "360p0", fps: 0, bitrate: 800000, width: 640, height: 360 }
+            - { name: "480p0", fps: 0, bitrate: 1600000, width: 854, height: 480 }
+            - { name: "720p0", fps: 0, bitrate: 3000000, width: 1280, height: 720 }
           items:
             type: object
             required:


### PR DESCRIPTION
It's kind of a roadblock for initial developers trying to test
Livepeer to be obliged to provide transcoding profiles for the
stream, especially when they might not even know how to configure
those.

When I went through it, I actually went on the dashboard and open
the developer network tab to find out what the dashboard was setting
when creating a stream from the UI, since from there, there is no
requirement for configuring anything.

With this change, it becomes simpler for API users as well, while
still maintaining retro-compatibility and allowing to configure the
profiles manually if desired.

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
