### PR TITLE
Add docs link to dashboard header

### DIFF
--- a/packages/www/components/Dashboard/Header/index.tsx
+++ b/packages/www/components/Dashboard/Header/index.tsx
@@ -117,10 +117,12 @@ const Header = ({ breadcrumbs = [] }) => {
               mr: "$5",
               background: "transparent",
               appearance: "none",
-              WebkitAppearance: "none",
               border: "none",
             }}>
-            <StyledDocumentationIcon />
+            <Box
+              as={DocumentationIcon}
+              css={{ mr: "$2", color: "$hiContrast" }}
+            />
             <Link href="/docs/guides" passHref>
               <A css={{ mr: "$2" }}>
                 <Box css={{ color: "$hiContrast" }}>Documentation</Box>
@@ -136,7 +138,6 @@ const Header = ({ breadcrumbs = [] }) => {
                 mr: "$5",
                 background: "transparent",
                 appearance: "none",
-                WebkitAppearance: "none",
                 border: "none",
               }}>
               <StyledHornIcon />
@@ -287,12 +288,17 @@ const Header = ({ breadcrumbs = [] }) => {
                 HELP
               </Text>
               <Link href="/docs/guides" passHref>
-                <A>
-                  <Flex align="center" css={{ mb: "$3", cursor: "pointer" }}>
-                    <StyledDocumentationIcon />
-                    <Text css={{ margin: "0 $2" }}>Documentation</Text>
-                    <StyledHyperlinkIcon />
-                  </Flex>
+                <A
+                  css={{
+                    display: "flex",
+                    alignItems: "center",
+                    textDecoration: "none",
+                    mb: "$3",
+                    cursor: "pointer",
+                  }}>
+                  <StyledDocumentationIcon />
+                  <Text css={{ margin: "0 $2" }}>Documentation</Text>
+                  <StyledHyperlinkIcon />
                 </A>
               </Link>
               <Link href="/contact" passHref>

--- a/packages/www/components/Dashboard/Header/index.tsx
+++ b/packages/www/components/Dashboard/Header/index.tsx
@@ -119,13 +119,15 @@ const Header = ({ breadcrumbs = [] }) => {
               appearance: "none",
               border: "none",
             }}>
-            <Box
-              as={DocumentationIcon}
-              css={{ mr: "$2", color: "$hiContrast" }}
-            />
+            <StyledDocumentationIcon />
             <Link href="/docs/guides" passHref>
-              <A css={{ mr: "$2" }}>
-                <Box css={{ color: "$hiContrast" }}>Documentation</Box>
+              <A
+                css={{
+                  ml: "$2",
+                  color: "$hiContrast",
+                  textDecoration: "none",
+                }}>
+                <Box>Documentation</Box>
               </A>
             </Link>
           </Flex>

--- a/packages/www/components/Dashboard/Header/index.tsx
+++ b/packages/www/components/Dashboard/Header/index.tsx
@@ -110,6 +110,23 @@ const Header = ({ breadcrumbs = [] }) => {
           })}
         </Breadcrumbs>
         <Flex align="center" css={{ fontSize: "$3" }}>
+          <Flex
+            align="center"
+            css={{
+              cursor: "pointer",
+              mr: "$5",
+              background: "transparent",
+              appearance: "none",
+              WebkitAppearance: "none",
+              border: "none",
+            }}>
+            <StyledDocumentationIcon />
+            <Link href="/docs/guides" passHref>
+              <A css={{ mr: "$2" }}>
+                <Box css={{ color: "$hiContrast" }}>Documentation</Box>
+              </A>
+            </Link>
+          </Flex>
           <DropdownMenu>
             <Flex
               as={DropdownMenuTrigger}

--- a/packages/www/components/Dashboard/Header/index.tsx
+++ b/packages/www/components/Dashboard/Header/index.tsx
@@ -126,6 +126,9 @@ const Header = ({ breadcrumbs = [] }) => {
                   ml: "$2",
                   color: "$hiContrast",
                   textDecoration: "none",
+                  "&:hover": {
+                    textDecoration: "none",
+                  },
                 }}>
                 <Box>Documentation</Box>
               </A>
@@ -143,7 +146,7 @@ const Header = ({ breadcrumbs = [] }) => {
                 border: "none",
               }}>
               <StyledHornIcon />
-              <Box css={{ color: "$hiContrast" }}>Feedback</Box>
+              <Box css={{ fontSize: "$3", color: "$hiContrast" }}>Feedback</Box>
             </Flex>
             <DropdownMenuContent
               css={{


### PR DESCRIPTION
Closes #917

<img width="1440" alt="Screen Shot 2022-02-22 at 9 21 47 PM" src="https://user-images.githubusercontent.com/555740/155251850-726070c1-a854-4e98-94d0-2805135e8098.png">
 