### PR TITLE
workflow: Create release only if action runs on a tag.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    name: Build binary packages
     runs-on: macos-latest
 
     steps:
@@ -72,6 +73,8 @@ jobs:
           path: releases/
 
   release:
+    name: Release new version artifacts to github
+    if: ${{ github.ref_type == "tag" }}
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -90,10 +93,11 @@ jobs:
         uses: livepeer/action-gh-checksum-and-gpg-sign@latest
         with:
           artifacts-dir: releases
+          release-name: ${{ github.ref_name }}
           gpg-key: ${{ secrets.CI_GPG_SIGNING_KEY }}
           gpg-key-passphrase: ${{ secrets.CI_GPG_SIGNING_PASSPHRASE }}
 
-      - name: Create Release
+      - name: Create release
         if: startsWith(github.ref, 'refs/tags/')
         id: create_release
         uses: actions/create-release@v1


### PR DESCRIPTION
Use tag value as the release name when generating checksums.