### PR TITLE
vod: Add clip parameters to vod transcode task

### DIFF
--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -80,6 +80,26 @@ components:
             - hevc
             - vp8
             - vp9
+    ffmpeg-trim:
+      type: object
+      description: ffmpeg cut/trim parameters
+      additionalProperties: false
+      required:
+        - start
+      properties:
+        start:
+          type: number
+          description: start time in seconds
+          minimum: 0
+        time:
+          type: number
+          description: length of clip in seconds
+          minimum: 0
+        to:
+          type: number
+          description:
+            end time in seconds (if time is specified, only -t is used)
+          minimum: 0
     cdn-data-row:
       type: object
       description:
@@ -1070,6 +1090,8 @@ components:
           example: filename.mp4
         profile:
           $ref: "#/components/schemas/ffmpeg-profile"
+        clip:
+          $ref: "#/components/schemas/ffmpeg-trim"
 
     task:
       type: object


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Adds clip (trim) ffmpeg parameters to the transcode task.
To evaluate if ffmpeg-trim and ffmpeg-profile can belong to the same object, and if it's possible to create a clip in keyframes without re-encode the asset.

**Specific updates (required)**

- Added parameters

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
