### PR TITLE
api: Allow user to retrieve its informations

### DIFF
--- a/packages/api/src/controllers/user.test.ts
+++ b/packages/api/src/controllers/user.test.ts
@@ -383,6 +383,12 @@ describe("controllers/user", () => {
       client.apiKey = uuid();
     });
 
+    it("should return personal user info", async () => {
+      client.apiKey = nonAdminApiKey;
+      let res = await client.get("/user/me");
+      expect(res.status).toBe(200);
+    });
+
     it("should not get all users", async () => {
       // should return nonverified error
       client.apiKey = nonAdminApiKey;

--- a/packages/api/src/controllers/user.test.ts
+++ b/packages/api/src/controllers/user.test.ts
@@ -386,6 +386,8 @@ describe("controllers/user", () => {
     it("should return personal user info", async () => {
       client.apiKey = nonAdminApiKey;
       let res = await client.get("/user/me");
+      let resJson = await res.json();
+      expect(resJson.email).toBe(nonAdminUser.email);
       expect(res.status).toBe(200);
     });
 

--- a/packages/api/src/controllers/user.test.ts
+++ b/packages/api/src/controllers/user.test.ts
@@ -221,9 +221,7 @@ describe("controllers/user", () => {
       }
 
       let res = await client.get("/user");
-      let resJson = await res.json();
-      let condition = Array.isArray(resJson);
-      expect(condition).toBe(false);
+      expect(res.status).toBe(403);
 
       // should not be able to make users admin with non-admin user
       const resAdminChange = await client.post(`/user/make-admin/`, {
@@ -390,14 +388,11 @@ describe("controllers/user", () => {
       client.apiKey = nonAdminApiKey;
       let res = await client.get("/user");
       let resJson = await res.json();
-      let condition = Array.isArray(resJson);
       expect(res.status).toBe(403);
-      expect(condition).toBe(false);
       expect(resJson.errors[0]).toBe(
         `useremail ${nonAdminUser.email} has not been verified. Please check your inbox for verification email.`
       );
 
-      // should return nonverified error
       client.apiKey = adminApiKey;
       res = await client.get("/user");
       resJson = await res.json();
@@ -409,26 +404,29 @@ describe("controllers/user", () => {
       // adding emailValid true to user
       await db.user.update(nonAdminUser.id, { emailValid: true });
 
+      // should return admin priviledges error
       client.apiKey = nonAdminApiKey;
       res = await client.get("/user");
       resJson = await res.json();
-      condition = Array.isArray(resJson);
-      expect(res.status).toBe(200);
-      expect(condition).toBe(false);
+      expect(res.status).toBe(403);
+      expect(resJson.errors[0]).toBe("user does not have admin priviledges");
 
       // adding emailValid true to admin user
       await db.user.update(adminUser.id, { emailValid: true });
 
+      // only jwt auth should be allowed access to this list API
       client.apiKey = adminApiKey;
       res = await client.get("/user");
       resJson = await res.json();
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(403);
+      expect(resJson.errors[0]).toBe("user does not have admin priviledges");
 
       client.apiKey = undefined;
       client.basicAuth = `${adminUser.id}:${adminApiKey}`;
       res = await client.get("/user");
       resJson = await res.json();
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(403);
+      expect(resJson.errors[0]).toBe("user does not have admin priviledges");
     });
 
     it("should return verified user", async () => {

--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -151,7 +151,7 @@ app.get("/", authMiddleware({ admin: true }), async (req, res) => {
   res.json(db.user.cleanWriteOnlyResponses(output));
 });
 
-app.get("/me", authMiddleware({}), async (req, res) => {
+app.get("/me", authMiddleware({ allowUnverified: true }), async (req, res) => {
   const user = await db.user.get(req.user.id);
   res.status(200);
   return res.json(cleanUserFields(user, req.user.admin));

--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -131,7 +131,7 @@ const fieldsMap: FieldsMap = {
   stripeProductId: `data->>'stripeProductId'`,
 };
 
-app.get("/", authMiddleware({ allowUnverified: true }), async (req, res) => {
+app.get("/", authMiddleware({}), async (req, res) => {
   if (req.user.admin !== true) {
     const user = await db.user.get(req.user.id);
     res.status(200);

--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -131,12 +131,7 @@ const fieldsMap: FieldsMap = {
   stripeProductId: `data->>'stripeProductId'`,
 };
 
-app.get("/", authMiddleware({}), async (req, res) => {
-  if (req.user.admin !== true) {
-    const user = await db.user.get(req.user.id);
-    res.status(200);
-    return res.json(cleanUserFields(user, req.user.admin));
-  }
+app.get("/", authMiddleware({ admin: true }), async (req, res) => {
   let { limit, cursor, order, filters } = toStringValues(req.query);
   if (isNaN(parseInt(limit))) {
     limit = undefined;
@@ -154,6 +149,12 @@ app.get("/", authMiddleware({}), async (req, res) => {
     res.links({ next: makeNextHREF(req, newCursor) });
   }
   res.json(db.user.cleanWriteOnlyResponses(output));
+});
+
+app.get("/me", authMiddleware({}), async (req, res) => {
+  const user = await db.user.get(req.user.id);
+  res.status(200);
+  return res.json(cleanUserFields(user, req.user.admin));
 });
 
 app.get("/:id", authMiddleware({ allowUnverified: true }), async (req, res) => {

--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -131,7 +131,12 @@ const fieldsMap: FieldsMap = {
   stripeProductId: `data->>'stripeProductId'`,
 };
 
-app.get("/", authMiddleware({ admin: true }), async (req, res) => {
+app.get("/", authMiddleware({ allowUnverified: true }), async (req, res) => {
+  if (req.user.admin !== true) {
+    const user = await db.user.get(req.user.id);
+    res.status(200);
+    return res.json(cleanUserFields(user, req.user.admin));
+  }
   let { limit, cursor, order, filters } = toStringValues(req.query);
   if (isNaN(parseInt(limit))) {
     limit = undefined;


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Some api endpoints require the `userId`.
There is no way for the user to retrieve its information using the api token, so a user would not be able to get its `userId` and call the needed endpoint.  
  
This little pr modifies the `get user` endpoint returning the user info if the user is not admin, keeping the list response if admin.


**Specific updates (required)**

- Added non-admin retrieve of user info
- Changed tests to allow non-admin user to retrieve personal information


**How did you test each of these updates (required)**

Yarn test and dev frontend check

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
