### PR TITLE
www: Disable contract field when not on right network

### DIFF
--- a/packages/www/pages/mint-nft/index.tsx
+++ b/packages/www/pages/mint-nft/index.tsx
@@ -327,7 +327,11 @@ export default () => {
                             ? ""
                             : state.contractAddress
                         }
-                        disabled={isMinting.on}
+                        disabled={
+                          isMinting.on ||
+                          status !== "connected" ||
+                          !(chainId in networks)
+                        }
                         placeholder={
                           !defaultContractAddress
                             ? ""

--- a/packages/www/pages/mint-nft/index.tsx
+++ b/packages/www/pages/mint-nft/index.tsx
@@ -334,7 +334,7 @@ export default () => {
                         }
                         placeholder={
                           !defaultContractAddress
-                            ? ""
+                            ? "Unsupported network"
                             : `Livepeer Video NFT (${defaultContractAddress})`
                         }
                         onChange={(e) =>


### PR DESCRIPTION
It can be confusing since we were showing an empty placeholder
when the network was wrong (no default contract address).

With this, we disable the field and also show an unsupported network
placeholder.