### PR TITLE
api/queue: Fix delayed messages logic

### DIFF
--- a/packages/api/src/store/queue.ts
+++ b/packages/api/src/store/queue.ts
@@ -12,8 +12,6 @@ const EXCHANGES = {
 const QUEUES = {
   events: "webhook_events_queue_v1",
   webhooks: "webhook_cannon_single_url_v1",
-  events_old: "webhook_events_queue",
-  webhooks_old: "webhook_cannon_single_url",
   delayed: "webhook_delayed_queue",
   task: "task_results_queue",
 } as const;
@@ -134,27 +132,6 @@ export class RabbitQueue implements Queue {
               channel.bindQueue(QUEUES.delayed, EXCHANGES.delayed, "#")
             ),
           channel.prefetch(2),
-        ]);
-        // TODO: Remove this once all old queues have been deleted.
-        await Promise.all([
-          channel.unbindQueue(
-            QUEUES.events_old,
-            EXCHANGES.webhooks,
-            "events.#"
-          ),
-          channel.unbindQueue(
-            QUEUES.webhooks_old,
-            EXCHANGES.webhooks,
-            "webhooks.#"
-          ),
-          channel.deleteQueue(QUEUES.events_old, {
-            ifUnused: true,
-            ifEmpty: true,
-          }),
-          channel.deleteQueue(QUEUES.webhooks_old, {
-            ifUnused: true,
-            ifEmpty: true,
-          }),
         ]);
       },
     });

--- a/packages/api/src/store/queue.ts
+++ b/packages/api/src/store/queue.ts
@@ -15,8 +15,7 @@ const QUEUES = {
   task: "task_results_queue",
   delayed_old: "webhook_delayed_queue",
 } as const;
-const delayedWebhookQueue = (delaySec: number) =>
-  `delayed_webhook_${delaySec}s`;
+const delayedWebhookQueue = (delayMs: number) => `delayed_webhook_${delayMs}ms`;
 
 type QueueName = keyof typeof QUEUES;
 type ExchangeName = keyof typeof EXCHANGES;
@@ -222,8 +221,8 @@ export class RabbitQueue implements Queue {
     msg: messages.Any,
     delay: number
   ): Promise<void> {
-    const delaySec = delay / 1000;
-    const delayedQueueName = delayedWebhookQueue(delaySec);
+    delay = Math.round(delay);
+    const delayedQueueName = delayedWebhookQueue(delay);
     // TODO: Find a way to reimplement this without on-demand queues.
     return this.withSetup(
       async (channel: Channel) => {

--- a/packages/api/src/store/queue.ts
+++ b/packages/api/src/store/queue.ts
@@ -246,7 +246,7 @@ export class RabbitQueue implements Queue {
           `emitting delayed message: delay=${delay / 1000}s msg=`,
           msg
         );
-        return this.channel.sendToQueue(delayedQueueName, msg, {
+        return this.channel.publish(delayedQueueName, routingKey, msg, {
           persistent: true,
         });
       }

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -232,7 +232,7 @@ export default class WebhookCannon {
     }
     let newInterval = lastInterval * BACKOFF_COEF;
     if (newInterval > MAX_BACKOFF) {
-      return lastInterval;
+      return MAX_BACKOFF;
     }
     // RabbitMQ expects integer
     return newInterval | 0;


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

In #800 I actually broke the logic of the API for delaying messages.

This was caused by this behavior of RabbitMQ: 
> Only when expired messages reach the head of a queue will they actually be discarded (or dead-lettered)

> When setting per-message TTL expired messages can queue up behind non-expired ones until the latter are consumed or expired. Hence resources used by such expired messages will not be freed, and they will be counted in queue statistics (e.g. the number of messages in the queue).

That means that the message with the highest TTL in the queue would block any other messages from being
processed (expired and then deadlettered/rescheduled) until that highest TTL message in front of the queue
expired. Since we have a maximum webhook delay of 1 hour, this means that messages could be delayed for
up to 1 hour even if they had been scheduled for a few seconds after the publishing.

This is especially relevant for recordings, since those are processed through a RabbitMQ message delayed for
5 minutes. If at the same time/region there was a webhook delayed for more than that, we could easily observe
delays in the stream recording processing. We actually had gotten reports from users about that but had no idea
how it could occur. From investigating the event surges in MDW I realized what was going on.

**Specific updates (required)**

This reverts #800 and also tries to make some improvements on the previous logic, by not creating a separate
queue for each routing key but only for each expiration time. Details better explained in the commit order and
messages.

## -

- **How did you test each of these updates (required)**
For now `yarn test` but I intend on testing it running locally and/or in staging.

**Does this pull request close any open issues?**
Last step to close https://github.com/livepeer/livepeer-infra/issues/808

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
