### PR TITLE
api: Fix RabbitMQ tests flakiness

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -24,7 +24,7 @@ jobs:
         ports:
           - 5432:5432
       rabbitmq:
-        image: rabbitmq@sha256:f0be9e47ec42081a36593dfc6604274a623caed074fc043e0a927fbd1533dc20
+        image: rabbitmq:3.9-management
         env:
           RABBITMQ_DEFAULT_VHOST: "livepeer"
         ports:

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -29,6 +29,7 @@ jobs:
           RABBITMQ_DEFAULT_VHOST: "livepeer"
         ports:
           - 5672:5672
+          - 15672:15672
 
     steps:
       - name: checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
           RABBITMQ_DEFAULT_VHOST: "livepeer"
         ports:
           - 5672:5672
+          - 15672:15672
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         ports:
           - 5432:5432
       rabbitmq:
-        image: rabbitmq@sha256:f0be9e47ec42081a36593dfc6604274a623caed074fc043e0a927fbd1533dc20
+        image: rabbitmq:3.9-management
         env:
           RABBITMQ_DEFAULT_VHOST: "livepeer"
         ports:

--- a/packages/api/src/store/queue.test.ts
+++ b/packages/api/src/store/queue.test.ts
@@ -1,13 +1,17 @@
 import { semaphore, sleep } from "../util";
 import { RabbitQueue } from "./queue";
+import { rabbitMgmt } from "../test-helpers";
 
 jest.setTimeout(10000);
 
 describe("Queue", () => {
   let queue: RabbitQueue;
+  let vhost: string;
   beforeEach(async () => {
     try {
-      queue = await RabbitQueue.connect("amqp://localhost:5672/livepeer");
+      vhost = `test_${Date.now()}`;
+      await rabbitMgmt.createVhost(vhost);
+      queue = await RabbitQueue.connect(`amqp://localhost:5672/${vhost}`);
     } catch (e) {
       console.error(e);
       throw e;
@@ -16,6 +20,7 @@ describe("Queue", () => {
 
   afterEach(async () => {
     await queue.close();
+    await rabbitMgmt.deleteVhost(vhost);
   });
 
   it("should be able to emit events and catch it via default consumer", async () => {

--- a/packages/api/src/test-helpers.ts
+++ b/packages/api/src/test-helpers.ts
@@ -6,6 +6,14 @@ import schema from "./schema/schema.json";
 import { User } from "./schema/types";
 import { TestServer } from "./test-server";
 
+const vhostUrl = (vhost: string) =>
+  `http://guest:guest@localhost:15672/api/vhosts/${vhost}`;
+
+export const rabbitMgmt = {
+  createVhost: (vhost: string) => fetch(vhostUrl(vhost), { method: "PUT" }),
+  deleteVhost: (vhost: string) => fetch(vhostUrl(vhost), { method: "DELETE" }),
+};
+
 /**
  * Clear the entire database! Not to be used outside of tests
  */


### PR DESCRIPTION
We have a lot of tests that fail because one event
leaks from one test to another. With this change, we
create a new vhost in RabbitMQ for every test suite
run, and additionally also create one vhost for every
test run in the specific queue test, which tests the
delayed events and thus could have more leaks.

This will hopefully make them more independent and also
not affect the local development environments (e.g. the box)
whenever we run tests on localhost.
