### PR TITLE
api: Send user suspension email automatically + suspend all streams

### DIFF
--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -152,8 +152,23 @@ export async function getS3PresignedUrl(
   return url;
 }
 
+type EmailParams = {
+  email: string;
+  bcc?: string;
+  supportAddr: [string, string];
+  sendgridTemplateId: string;
+  sendgridApiKey: string;
+  subject: string;
+  preheader: string;
+  text: string;
+  buttonText: string;
+  buttonUrl: string;
+  unsubscribe: string;
+};
+
 export async function sendgridEmail({
   email,
+  bcc,
   supportAddr,
   sendgridTemplateId,
   sendgridApiKey,
@@ -163,12 +178,13 @@ export async function sendgridEmail({
   buttonText,
   buttonUrl,
   unsubscribe,
-}) {
+}: EmailParams) {
   const [supportName, supportEmail] = supportAddr;
   const msg = {
     personalizations: [
       {
         to: [{ email }],
+        bcc: bcc ? [{ email: bcc }] : undefined,
         dynamicTemplateData: {
           subject,
           preheader,

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1229,7 +1229,7 @@ app.delete("/:id/terminate", authMiddleware({}), async (req, res) => {
   return res.json({ result, errors });
 });
 
-async function terminateStreamReq(
+export async function terminateStreamReq(
   req: Request,
   stream: DBStream
 ): Promise<{ status: number; errors?: string[]; result?: boolean | any }> {

--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -36,6 +36,9 @@ import { terminateStreamReq } from "./stream";
 
 const adminOnlyFields = ["verifiedAt", "planChangedAt"];
 
+const salesEmail = "sales@livepeer.org";
+const infraEmail = "infraservice@livepeer.org";
+
 function cleanAdminOnlyFields(fields: string[], obj: Record<string, any>) {
   for (const f of fields) {
     delete obj[f];
@@ -320,6 +323,7 @@ app.post("/", validatePost("user"), async (req, res) => {
       await sendgridEmail({
         email,
         supportAddr,
+        bcc: infraEmail,
         sendgridTemplateId,
         sendgridApiKey,
         subject: "Verify your Livepeer.com Email",
@@ -440,7 +444,6 @@ app.post("/verify", validatePost("user-verification"), async (req, res) => {
   if (user.emailValidToken === req.body.emailValidToken) {
     // alert sales of new verified user
     const { supportAddr, sendgridTemplateId, sendgridApiKey } = req.config;
-    const salesEmail = "sales@livepeer.org";
 
     if (req.headers.host.includes("livepeer.com")) {
       try {

--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -357,6 +357,20 @@ app.post("/", validatePost("user"), async (req, res) => {
   res.json(user);
 });
 
+const suspensionEmailText = (
+  emailTemplate: SuspendUserPayload["emailTemplate"]
+) => {
+  switch (emailTemplate) {
+    case "copyright":
+      return [
+        "We were notified that your stream contained illegal or copyrighted content. We have suspended your account.",
+        "Please note that you cannot use Livepeer to stream copyrighted content. Any copyrighted content will be taken down and your account will be suspended.",
+      ].join("\n\n");
+    default:
+      return "Your account has been suspended. Please contact us for more information.";
+  }
+};
+
 app.patch(
   "/:id/suspended",
   validatePost("suspend-user-payload"),
@@ -379,7 +393,7 @@ app.patch(
       );
     });
 
-    if (suspended && emailTemplate === "copyright") {
+    if (suspended) {
       const {
         frontendDomain,
         supportAddr,
@@ -397,10 +411,7 @@ app.patch(
           buttonText: "Appeal Suspension",
           buttonUrl: frontendUrl(req, "/contact"),
           unsubscribe: unsubscribeUrl(req),
-          text: [
-            "We were notified that your stream contained illegal or copyrighted content. We have suspended your account.",
-            "Please note that you cannot use Livepeer to stream copyrighted content. Any copyrighted content will be taken down and your account will be suspended.",
-          ].join("\n\n"),
+          text: suspensionEmailText(emailTemplate),
         });
       } catch (err) {
         logger.error(

--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -391,7 +391,7 @@ app.patch(
           subject: "Account Suspended",
           preheader: `Your ${frontendDomain} account has been suspended.`,
           buttonText: "Appeal Suspension",
-          buttonUrl: unsubscribeUrl(req),
+          buttonUrl: frontendUrl(req, "/contact"),
           unsubscribe: unsubscribeUrl(req),
           text: [
             "We were notified that your stream contained illegal or copyrighted content. We have suspended your account.",

--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -88,7 +88,7 @@ export async function suspendUserStreams(
       }
       await Promise.all(promises);
     } catch (err) {
-      console.error(
+      logger.error(
         `error suspending stream id=${stream.id} userId=${userId} err=${err}`
       );
     }
@@ -399,7 +399,7 @@ app.patch(
           ].join("\n\n"),
         });
       } catch (err) {
-        console.error(
+        logger.error(
           `error sending suspension email to user=${email} err=${err}`
         );
       }
@@ -460,7 +460,7 @@ app.post("/verify", validatePost("user-verification"), async (req, res) => {
           ].join("\n\n"),
         });
       } catch (err) {
-        console.error(`error sending email to ${salesEmail}: error: ${err}`);
+        logger.error(`error sending email to ${salesEmail}: error: ${err}`);
       }
     }
 
@@ -654,7 +654,7 @@ app.post(
     }
 
     if (!customer) {
-      console.warn(
+      logger.warn(
         `deprecated /create-customer API used. userEmail=${user.email} createdAt=${user.createdAt}`
       );
       customer = await getOrCreateCustomer(req.stripe, email);
@@ -731,13 +731,13 @@ app.post(
       );
       return res.send(subscription);
     }
-    console.warn(
+    logger.warn(
       `deprecated /create-subscription API used. userEmail=${user.email} createdAt=${user.createdAt}`
     );
 
     // Attach the payment method to the customer if it exists (free plan doesn't require payment)
     if (stripeCustomerPaymentMethodId) {
-      console.warn(
+      logger.warn(
         `attaching payment method through /create-subscription. userEmail=${user.email} createdAt=${user.createdAt}`
       );
       try {

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -138,7 +138,8 @@ export default function parseCli(argv?: string | readonly string[]) {
         describe:
           "email address where outgoing emails originate. should be of the form name/email@example.com",
         type: "string",
-        coerce: (supportAddr) => {
+        default: undefined,
+        coerce: (supportAddr: string) => {
           if (!supportAddr) {
             return undefined;
           }
@@ -148,7 +149,7 @@ export default function parseCli(argv?: string | readonly string[]) {
               `supportAddr should be of the form name / email, got ${supportAddr} `
             );
           }
-          return split;
+          return split as [string, string];
         },
       },
       "sendgrid-api-key": {

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -626,6 +626,19 @@ components:
         multistream:
           $ref: "#/components/schemas/stream/properties/multistream"
 
+    suspend-user-payload:
+      type: object
+      additionalProperties: false
+      required: [suspended]
+      properties:
+        suspended:
+          $ref: "#/components/schemas/user/properties/suspended"
+        emailTemplate:
+          type: string
+          description:
+            Name of template to send to the users regarding the suspension.
+          enum: [copyright]
+
     multistream-target-patch-payload:
       $ref: "#/components/schemas/multistream-target"
       required: []

--- a/packages/api/src/test-server.ts
+++ b/packages/api/src/test-server.ts
@@ -17,7 +17,7 @@ const trustedDomain = "livepeer.org";
 const jwtAudience = "livepeer";
 const jwtSecret = "secret";
 // enable to test SendGrid integration
-const supportAddr = "Livepeer Team/angie@livepeer.org";
+const supportAddr: [string, string] = ["Livepeer Team", "angie@livepeer.org"];
 const sendgridTemplateId = "iamanid";
 const sendgridApiKey = "SG. iamanapikey";
 

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -30,7 +30,7 @@ export default class WebhookCannon {
   frontendDomain: string;
   sendgridTemplateId: string;
   sendgridApiKey: string;
-  supportAddr: string;
+  supportAddr: [string, string];
   taskScheduler: TaskScheduler;
   vodObjectStoreId: string;
   resolver: any;


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This is to send the suspension email automatically when we suspend the user.
Callers only need to update their calls to include the `emailTemplate: copyright` field.

In the end also realized it was easy to add a suspension to all the user streams as well.
It won't work 100%, but it will make bans from the admin dashboard already a tad more
reliable.

**Specific updates (required)**
 - Send suspension email when user is suspended
 - Suspend and terminate all streams of the user when the user is suspended

## -

- **How did you test each of these updates (required)**
Trust the code.

**Does this pull request close any open issues?**
Implements #987 

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
