### PR TITLE
www: Allow sending copyright suspension email from admin dashboard

### DIFF
--- a/packages/www/components/Admin/UserTable/index.tsx
+++ b/packages/www/components/Admin/UserTable/index.tsx
@@ -6,6 +6,7 @@ import { Button, Flex, Container, Select } from "@theme-ui/components";
 import Modal from "../Modal";
 import { products } from "@livepeer.com/api/src/config";
 import CommonAdminTable from "@components/Admin/CommonAdminTable";
+import { Box, Checkbox, Label, Tooltip } from "@livepeer.com/design-system";
 
 type UserTableProps = {
   userId: string;
@@ -20,6 +21,7 @@ const UserTable = ({ userId, id }: UserTableProps) => {
   const [adminModal, setAdminModal] = useState(false);
   const [removeAdminModal, setRemoveAdminModal] = useState(false);
   const [suspendModal, setSuspendModal] = useState(false);
+  const [isCopyrightInfringiment, setIsCopyrightInfringiment] = useState(true);
   const [unsuspendModal, setUnsuspendModal] = useState(false);
   const [nextCursor, setNextCursor] = useState("");
   const [lastCursor, setLastCursor] = useState("");
@@ -154,6 +156,23 @@ const UserTable = ({ userId, id }: UserTableProps) => {
           <p>
             Are you sure you want to <b>suspend</b> user "{selectedUser.email}"?
           </p>
+
+          <Box css={{ display: "flex", mt: "$2" }}>
+            <Checkbox
+              id="isCopyrightInfringiment"
+              checked={isCopyrightInfringiment}
+              onCheckedChange={(e) =>
+                setIsCopyrightInfringiment(e.target.checked)
+              }
+            />
+            <Tooltip
+              content="Checking this will send the copyright infringiment email instead of the default one."
+              multiline>
+              <Label css={{ pl: "$2", mr: "$1" }} htmlFor="corsFullAccess">
+                Is copyright infringiment?
+              </Label>
+            </Tooltip>
+          </Box>
           <Flex sx={{ justifyContent: "flex-end" }}>
             <Button
               type="button"
@@ -166,7 +185,12 @@ const UserTable = ({ userId, id }: UserTableProps) => {
               type="button"
               variant="primarySmall"
               onClick={() => {
-                setUserSuspended(selectedUser.id, true)
+                setUserSuspended(selectedUser.id, {
+                  suspended: true,
+                  emailTemplate: isCopyrightInfringiment
+                    ? "copyright"
+                    : undefined,
+                })
                   .then(refecth)
                   .finally(close);
               }}>
@@ -194,7 +218,7 @@ const UserTable = ({ userId, id }: UserTableProps) => {
               type="button"
               variant="primarySmall"
               onClick={() => {
-                setUserSuspended(selectedUser.id, false)
+                setUserSuspended(selectedUser.id, { suspended: false })
                   .then(refecth)
                   .finally(close);
               }}>

--- a/packages/www/components/Admin/UserTable/index.tsx
+++ b/packages/www/components/Admin/UserTable/index.tsx
@@ -157,7 +157,7 @@ const UserTable = ({ userId, id }: UserTableProps) => {
             Are you sure you want to <b>suspend</b> user "{selectedUser.email}"?
           </p>
 
-          <Box css={{ display: "flex", mt: "$2" }}>
+          <Box sx={{ display: "flex", mt: 2, mb: 2 }}>
             <Checkbox
               id="isCopyrightInfringiment"
               checked={isCopyrightInfringiment}
@@ -168,11 +168,12 @@ const UserTable = ({ userId, id }: UserTableProps) => {
             <Tooltip
               content="Checking this will send the copyright infringiment email instead of the default one."
               multiline>
-              <Label css={{ pl: "$2", mr: "$1" }} htmlFor="corsFullAccess">
-                Is copyright infringiment?
+              <Label sx={{ ml: 2 }} htmlFor="isCopyrightInfringiment">
+                Copyright infringiment
               </Label>
             </Tooltip>
           </Box>
+
           <Flex sx={{ justifyContent: "flex-end" }}>
             <Button
               type="button"

--- a/packages/www/hooks/use-api.tsx
+++ b/packages/www/hooks/use-api.tsx
@@ -10,6 +10,7 @@ import {
   StreamPatchPayload,
   ObjectStore,
   MultistreamTargetPatchPayload,
+  SuspendUserPayload,
 } from "@livepeer.com/api";
 import qs from "qs";
 import { isStaging, isDevelopment, HttpError } from "../lib/utils";
@@ -372,11 +373,11 @@ const makeContext = (state: ApiState, setState) => {
 
     async setUserSuspended(
       userId: string,
-      suspended: boolean
+      payload: SuspendUserPayload
     ): Promise<[Response, ApiError]> {
       const [res, body] = await context.fetch(`/user/${userId}/suspended`, {
         method: "PATCH",
-        body: JSON.stringify({ suspended }),
+        body: JSON.stringify(payload),
         headers: {
           "content-type": "application/json",
         },


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
Following up on #989 we also need a way to set that email from the admin dashboard
when suspending a user.

**Specific updates (required)**
Add a checkbox in suspend user dialog to send the copyright email instead of the default.

## -

- **How did you test each of these updates (required)**
Suspend a user from dashboard with/without checkbox.

**Does this pull request close any open issues?**
The other one closed it.

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
