### PR TITLE
api/stream: Improve reliability of `/setactive` API

### DIFF
--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -952,6 +952,16 @@ app.put(
       }
     }
 
+    const sameFromStream =
+      stream.region === req.config.ownRegion && stream.mistHost === hostName;
+    if (stream.isActive && !active && !sameFromStream) {
+      // Don't clear the isActive field if this is being called for a different
+      // session than the last one to update the stream object. This probably
+      // means the user is doing more than 1 session with the same stream key.
+      // We only support 1 conc. session tho so ignore all but the last one.
+      return res.status(204).end();
+    }
+
     const patch = {
       isActive: active,
       lastSeen: Date.now(),

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -891,7 +891,7 @@ app.put(
       stream.region === req.config.ownRegion && stream.mistHost === hostName;
     if (stream.isActive && !active && !sameFromStream) {
       // Don't clear the isActive field if this is being called for a different
-      // session than the last one to update the stream object. This probably
+      // session than the last one that updated the stream object. This probably
       // means the user is doing more than 1 session with the same stream key.
       // We only support 1 conc. session tho so ignore all but the last one.
       return res.status(204).end();

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -890,10 +890,12 @@ app.put(
     const sameFromStream =
       stream.region === req.config.ownRegion && stream.mistHost === hostName;
     if (stream.isActive && !active && !sameFromStream) {
-      // Don't clear the isActive field if this is being called for a different
-      // session than the last one that updated the stream object. This probably
-      // means the user is doing more than 1 session with the same stream key.
-      // We only support 1 conc. session tho so ignore all but the last one.
+      // This likely means the user is doing multiple sessions with the same
+      // stream key. We only support 1 conc. session so ignore previous ones.
+      logger.info(
+        `Ignoring /setactive false since another session had already started. ` +
+          `stream=${id} currMist="${stream.region}-${stream.mistHost}" oldMist="${req.config.ownRegion}-${hostName}"`
+      );
       return res.status(204).end();
     }
 

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -853,14 +853,17 @@ app.put(
   authMiddleware({ anyAdmin: true }),
   async (req, res) => {
     const { id } = req.params;
-    // logger.info(`got /setactive/${id}: ${JSON.stringify(req.body)}`)
+    const { active, startedAt, hostName } = req.body;
+    logger.info(
+      `got /setactive for stream=${id} active=${active} hostName=${hostName} startedAt=${startedAt}`
+    );
+
     const stream = await db.stream.get(id, { useReplica: false });
     if (!stream || (stream.deleted && !req.user.admin)) {
       res.status(404);
       return res.json({ errors: ["not found"] });
     }
 
-    const { active } = req.body;
     if (active && stream.suspended) {
       res.status(403);
       return res.json({ errors: ["stream is suspended"] });

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -969,9 +969,11 @@ app.put(
       region: req.config.ownRegion,
     };
     await db.stream.update(stream.id, patch);
-    await db.user.update(stream.userId, {
-      lastStreamedAt: Date.now(),
-    });
+    if (active) {
+      await db.user.update(stream.userId, {
+        lastStreamedAt: Date.now(),
+      });
+    }
 
     if (stream.parentId) {
       const pStream = await db.stream.get(stream.parentId);

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -854,14 +854,14 @@ app.put(
   async (req, res) => {
     const { id } = req.params;
     // logger.info(`got /setactive/${id}: ${JSON.stringify(req.body)}`)
-    const useReplica = !req.body.active;
-    const stream = await db.stream.get(id, { useReplica });
+    const stream = await db.stream.get(id, { useReplica: false });
     if (!stream || (stream.deleted && !req.user.admin)) {
       res.status(404);
       return res.json({ errors: ["not found"] });
     }
 
-    if (stream.suspended) {
+    const { active } = req.body;
+    if (active && stream.suspended) {
       res.status(403);
       return res.json({ errors: ["stream is suspended"] });
     }
@@ -872,7 +872,7 @@ app.put(
       return res.json({ errors: ["not found"] });
     }
 
-    if (user.suspended) {
+    if (active && user.suspended) {
       res.status(403);
       return res.json({ errors: ["user is suspended"] });
     }

--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -381,7 +381,7 @@ app.patch(
     if (!user) {
       return res.status(404).json({ errors: ["not found"] });
     }
-    const { email } = user;
+    const { email, suspended: wasSuspended } = user;
 
     logger.info(`set user ${id} (${email}) suspended ${suspended}`);
     await db.user.update(id, { suspended });
@@ -392,7 +392,7 @@ app.patch(
       );
     });
 
-    if (suspended) {
+    if (suspended && !wasSuspended) {
       const {
         frontendDomain,
         supportAddr,

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -615,6 +615,21 @@ components:
           items:
             type: string
 
+    stream-set-active-payload:
+      type: object
+      required: [active]
+      properties:
+        active:
+          $ref: "#/components/schemas/stream/properties/isActive"
+        hostName:
+          $ref: "#/components/schemas/stream/properties/mistHost"
+        startedAt:
+          type: number
+          description:
+            Timestamp (in milliseconds) at which the stream started.
+          example: 1587667174725
+
+
     stream-patch-payload:
       type: object
       additionalProperties: false

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -625,10 +625,8 @@ components:
           $ref: "#/components/schemas/stream/properties/mistHost"
         startedAt:
           type: number
-          description:
-            Timestamp (in milliseconds) at which the stream started.
+          description: Timestamp (in milliseconds) at which the stream started.
           example: 1587667174725
-
 
     stream-patch-payload:
       type: object

--- a/packages/api/src/store/table.ts
+++ b/packages/api/src/store/table.ts
@@ -108,7 +108,6 @@ export default class Table<T extends DBObject> {
     if (Array.isArray(query)) {
       filters = [...query];
     }
-
     // ...or a {name: "whatever"} query
     else {
       for (const [key, value] of Object.entries(query)) {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This is to do a couple improvements in the `/setactive` API, specifically made for improving
reliability of it. This is especially important for our stream nuking APIs, since for those we need
a reliable source of "where is the stream?". In the worst case we can start fetching this info
from the Stream Health API, but I believe a very simple change to the `/setactive` API should 
already make this a lot more reliable, especially against malicious actors like our soccer
streamers who have learned how to explore the bugs in that API.

Apart from that very simple change, inplemented here https://github.com/livepeer/livepeer-com/commit/8045d8d9514004df8f203e64360fe8bb683a90b0, also made a bunch of
improvements to the API performance, since I noticed from our metrics that it's already 
running dangerously close to the `mist-api-connector` timeout a lot of the times: [[grafana](http://eu-metrics-monitoring.livepeer.live/grafana/explore?orgId=1&left=%5B%22now-6h%22,%22now%22,%22Prometheus%22,%7B%22refId%22:%22A%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22histogram_quantile(0.9,%20sum%20by%20(region,%20le)%20(rate(livepeer_api_http_request_duration_seconds_bucket%7Bpath%3D%5C%22%2Fapi%2Fstream%2F%23val%2Fsetactive%5C%22%7D%5B10m%5D)))%22%7D%5D)]

Also did a small fix in the `/user/suspended` API here, just to avoid re-emailing the same user
that has already been suspended.

**Specific updates (required)**
 - Avoid responding 403 to a `/setactive: false` request for a suspended stream (only when active=true)
 - Ignore `/setactive` calls from sessions that are not the last one
 - Optimize API handler execution by moving Webhooks and aux DB updates to background
 - Only send account suspended emails to not already suspended users

## -

- **How did you test each of these updates (required)**
`yarn test`
also deployed to staging and checked things still work

**Does this pull request close any open issues?**
It is related to but does not close https://github.com/livepeer/livepeer-infra/issues/830

I'm hoping that this change will make a full backend calling the `kube-api` unnecessary.
Our stream termination logic from the API should work perfectly.

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
