### PR TITLE
api/vod: Inline storage info in the asset resource

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -35,6 +35,7 @@
     "go-livepeer:broadcaster": "bin/livepeer -broadcaster -datadir ./bin/broadcaster -orchAddr 127.0.0.1:3086 -rtmpAddr 0.0.0.0:3035 -httpAddr :3085 -cliAddr :3075 -v 6 -authWebhookUrl http://127.0.0.1:3004/api/stream/hook -orchWebhookUrl http://127.0.0.1:3004/api/orchestrator",
     "go-livepeer:orchestrator": "bin/livepeer -orchestrator -datadir ./bin/orchestrator -transcoder -serviceAddr 127.0.0.1:3086 -cliAddr :3076 -v 6",
     "test": "jest \"${PWD}/src\" -i --silent",
+    "test:watch": "jest \"${PWD}/src\" -i --silent --watch",
     "test:build": "parcel build --no-autoinstall --no-minify --bundle-node-modules -t browser --out-dir ../dist-worker ../src/worker.js",
     "coverage": "yarn run test --coverage",
     "pkg": "pkg --out-path=bin --no-bytecode --public-packages \"*\" --public . --compress GZip ",

--- a/packages/api/src/app-router.ts
+++ b/packages/api/src/app-router.ts
@@ -252,6 +252,7 @@ export default async function makeApp(params: CliArgs) {
   return {
     router: app,
     webhookCannon,
+    taskScheduler,
     store,
     db,
     queue,

--- a/packages/api/src/controllers/asset.test.ts
+++ b/packages/api/src/controllers/asset.test.ts
@@ -3,6 +3,8 @@ import { TestClient, clearDatabase, setupUsers } from "../test-helpers";
 import { v4 as uuid } from "uuid";
 import { Asset, MultistreamTarget, User } from "../schema/types";
 import { db } from "../store";
+import { WithID } from "../store/types";
+import { ConsumeMessage } from "amqplib";
 
 // includes auth file tests
 
@@ -31,23 +33,23 @@ afterEach(async () => {
 });
 
 describe("controllers/asset", () => {
-  describe("assets status schema migration", () => {
-    let client: TestClient;
-    let adminUser: User;
-    let adminToken: string;
-    let nonAdminUser: User;
-    let nonAdminToken: string;
+  let client: TestClient;
+  let adminUser: User;
+  let adminToken: string;
+  let nonAdminUser: User;
+  let nonAdminToken: string;
 
-    beforeEach(async () => {
-      await db.objectStore.create({
-        id: "mock_vod_store",
-        url: "http://user:password@localhost:8080/us-east-1/vod",
-      });
-      ({ client, adminUser, adminToken, nonAdminUser, nonAdminToken } =
-        await setupUsers(server, mockAdminUserInput, mockNonAdminUserInput));
-      client.jwtAuth = nonAdminToken;
+  beforeEach(async () => {
+    await db.objectStore.create({
+      id: "mock_vod_store",
+      url: "http://user:password@localhost:8080/us-east-1/vod",
     });
+    ({ client, adminUser, adminToken, nonAdminUser, nonAdminToken } =
+      await setupUsers(server, mockAdminUserInput, mockNonAdminUserInput));
+    client.jwtAuth = nonAdminToken;
+  });
 
+  describe("assets status schema migration", () => {
     it("should create assets in the new format", async () => {
       const res = await client.post("/asset/request-upload", { name: "zoo" });
       expect(res.status).toBe(200);
@@ -71,7 +73,7 @@ describe("controllers/asset", () => {
         status: "ready",
         userId: nonAdminUser.id,
       } as any);
-      const res = await client.get("/asset/" + asset.id);
+      const res = await client.get(`/asset/${asset.id}`);
       expect(res.status).toBe(200);
       const assetRes = await res.json();
 
@@ -79,6 +81,192 @@ describe("controllers/asset", () => {
       expect(assetRes).toMatchObject({
         ...expected,
         status: { phase: "ready", updatedAt: asset.updatedAt },
+      });
+    });
+  });
+
+  describe("asset inline storage", () => {
+    let asset: WithID<Asset>;
+
+    beforeEach(async () => {
+      asset = await db.asset.create({
+        id: uuid(),
+        name: "test-storage",
+        createdAt: Date.now(),
+        status: {
+          phase: "ready",
+          updatedAt: Date.now(),
+        },
+        userId: nonAdminUser.id,
+      });
+    });
+
+    it("should allow editing asset name", async () => {
+      const res = await client.patch(`/asset/${asset.id}`, { name: "zoo" });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toMatchObject({ ...asset, name: "zoo" });
+    });
+
+    it("should start export task when adding IPFS storage", async () => {
+      let res = await client.patch(`/asset/${asset.id}`, {
+        storage: { ipfs: { nftMetadata: { a: "b" } } },
+      });
+      expect(res.status).toBe(200);
+      const patched = await res.json();
+      expect(patched).toMatchObject({
+        ...asset,
+        storage: { ipfs: { nftMetadata: { a: "b" } } },
+        status: {
+          ...asset.status,
+          updatedAt: expect.any(Number),
+          storage: {
+            ipfs: {
+              taskIds: {
+                pending: expect.any(String),
+              },
+            },
+          },
+        },
+      });
+
+      const taskId = patched.status.storage.ipfs.taskIds.pending;
+      res = await client.get("/task/" + taskId);
+      expect(res.status).toBe(200);
+      expect(res.json()).resolves.toMatchObject({
+        id: taskId,
+        type: "export",
+        inputAssetId: asset.id,
+        params: {
+          export: {
+            ipfs: {
+              nftMetadata: { a: "b" },
+            },
+          },
+        },
+      });
+    });
+
+    it("should update asset storage when manually exporting to IPFS", async () => {
+      let res = await client.post(`/asset/${asset.id}/export`, {
+        ipfs: { nftMetadata: { a: "b" } },
+      });
+      expect(res.status).toBe(201);
+      const { task } = await res.json();
+      expect(task).toMatchObject({
+        id: expect.any(String),
+        type: "export",
+        inputAssetId: asset.id,
+      });
+
+      res = await client.get(`/asset/${asset.id}`);
+      expect(res.status).toBe(200);
+      expect(res.json()).resolves.toMatchObject({
+        ...asset,
+        storage: {
+          ipfs: { nftMetadata: { a: "b" } },
+        },
+        status: {
+          ...asset.status,
+          updatedAt: expect.any(Number),
+          storage: {
+            ipfs: {
+              taskIds: {
+                pending: task.id,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it("should update asset status when task finishes", async () => {
+      let res = await client.patch(`/asset/${asset.id}`, {
+        storage: { ipfs: {} },
+      });
+      expect(res.status).toBe(200);
+      const patched = await res.json();
+      const taskId = patched.status.storage.ipfs.taskIds.pending;
+      await server.taskScheduler.processTaskEvent({
+        id: uuid(),
+        type: "task_result",
+        timestamp: Date.now(),
+        task: {
+          id: taskId,
+          type: "export",
+          snapshot: await db.task.get(taskId),
+        },
+        error: null,
+        output: {
+          export: {
+            ipfs: {
+              videoFileCid: "QmX",
+              nftMetadataCid: "QmY",
+            },
+          },
+        },
+      });
+
+      res = await client.get(`/asset/${asset.id}`);
+      expect(res.status).toBe(200);
+      expect(res.json()).resolves.toEqual({
+        ...patched,
+        status: {
+          phase: "ready",
+          updatedAt: expect.any(Number),
+          storage: {
+            ipfs: {
+              taskIds: {
+                last: taskId,
+              },
+              data: {
+                videoFileCid: "QmX",
+                nftMetadataCid: "QmY",
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it("should update asset status when task fails", async () => {
+      let res = await client.patch(`/asset/${asset.id}`, {
+        storage: { ipfs: {} },
+      });
+      expect(res.status).toBe(200);
+      const patched = await res.json();
+      const taskId = patched.status.storage.ipfs.taskIds.pending;
+      await server.taskScheduler.processTaskEvent({
+        id: uuid(),
+        type: "task_result",
+        timestamp: Date.now(),
+        task: {
+          id: taskId,
+          type: "export",
+          snapshot: await db.task.get(taskId),
+        },
+        error: {
+          message: "failed!",
+          unretriable: true,
+        },
+        output: null,
+      });
+
+      res = await client.get(`/asset/${asset.id}`);
+      expect(res.status).toBe(200);
+      expect(res.json()).resolves.toEqual({
+        ...patched,
+        status: {
+          phase: "ready",
+          updatedAt: expect.any(Number),
+          storage: {
+            ipfs: {
+              taskIds: {
+                failed: taskId,
+              },
+            },
+          },
+        },
       });
     });
   });

--- a/packages/api/src/controllers/asset.test.ts
+++ b/packages/api/src/controllers/asset.test.ts
@@ -1,0 +1,85 @@
+import serverPromise, { TestServer } from "../test-server";
+import { TestClient, clearDatabase, setupUsers } from "../test-helpers";
+import { v4 as uuid } from "uuid";
+import { Asset, MultistreamTarget, User } from "../schema/types";
+import { db } from "../store";
+
+// includes auth file tests
+
+let server: TestServer;
+let mockAdminUserInput: User;
+let mockNonAdminUserInput: User;
+
+// jest.setTimeout(70000)
+
+beforeAll(async () => {
+  server = await serverPromise;
+
+  mockAdminUserInput = {
+    email: "user_admin@gmail.com",
+    password: "x".repeat(64),
+  };
+
+  mockNonAdminUserInput = {
+    email: "user_non_admin@gmail.com",
+    password: "y".repeat(64),
+  };
+});
+
+afterEach(async () => {
+  await clearDatabase(server);
+});
+
+describe("controllers/asset", () => {
+  describe("assets status schema migration", () => {
+    let client: TestClient;
+    let adminUser: User;
+    let adminToken: string;
+    let nonAdminUser: User;
+    let nonAdminToken: string;
+
+    beforeEach(async () => {
+      await db.objectStore.create({
+        id: "mock_vod_store",
+        url: "http://user:password@localhost:8080/us-east-1/vod",
+      });
+      ({ client, adminUser, adminToken, nonAdminUser, nonAdminToken } =
+        await setupUsers(server, mockAdminUserInput, mockNonAdminUserInput));
+      client.jwtAuth = nonAdminToken;
+    });
+
+    it("should create assets in the new format", async () => {
+      const res = await client.post("/asset/request-upload", { name: "zoo" });
+      expect(res.status).toBe(200);
+      const { asset } = await res.json();
+      const expected = {
+        id: expect.any(String),
+        name: "zoo",
+        status: { phase: "waiting", updatedAt: expect.any(Number) },
+      };
+      expect(asset).toMatchObject(expected);
+      const dbAsset = await db.asset.get(asset.id);
+      expect(dbAsset).toMatchObject(expected);
+    });
+
+    it("should support assets in the old format in database", async () => {
+      const asset: any = await db.asset.create({
+        id: uuid(),
+        name: "test2",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        status: "ready",
+        userId: nonAdminUser.id,
+      } as any);
+      const res = await client.get("/asset/" + asset.id);
+      expect(res.status).toBe(200);
+      const assetRes = await res.json();
+
+      const { updatedAt, ...expected } = asset;
+      expect(assetRes).toMatchObject({
+        ...expected,
+        status: { phase: "ready", updatedAt: asset.updatedAt },
+      });
+    });
+  });
+});

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -336,7 +336,10 @@ app.post(
             ...status.storage,
             ipfs: {
               ...status.storage?.ipfs,
-              pendingTaskId: task.id,
+              taskIds: {
+                ...status.storage?.ipfs?.taskIds,
+                pending: task.id,
+              },
             },
           },
         },
@@ -563,7 +566,8 @@ app.delete("/:id", authorizer({}), async (req, res) => {
 
 app.patch("/:id", authorizer({}), validatePost("asset"), async (req, res) => {
   // update a specific asset
-  const asset = await db.asset.get(req.params.id);
+  const { id } = req.params;
+  const asset = await db.asset.get(id);
   if (!asset) {
     throw new NotFoundError(`asset not found`);
   }
@@ -589,20 +593,21 @@ app.patch("/:id", authorizer({}), validatePost("asset"), async (req, res) => {
         ...status.storage,
         ipfs: {
           ...status.storage?.ipfs,
-          pendingTaskId: taskId,
+          taskIds: {
+            ...status.storage?.ipfs?.taskIds,
+            pending: taskId,
+          },
         },
       },
     };
   }
-  const patch = {
+  await db.asset.update(id, {
     name,
     storage: { ...asset.storage, ...storage },
     status,
-  };
-  await db.asset.update(req.body.id, patch);
-
-  res.status(200);
-  res.json({ ...asset, ...patch });
+  });
+  const updated = await db.asset.get(id, { useReplica: false });
+  res.status(200).json(updated);
 });
 
 export default app;

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -31,6 +31,7 @@ import {
   Task,
 } from "../schema/types";
 import { WithID } from "../store/types";
+import { mergeAssetStatus } from "../store/asset-table";
 
 const app = Router();
 
@@ -135,19 +136,15 @@ async function reconcileAssetStorage(
       );
     }
     storage = { ...storage, ipfs: newStorage.ipfs };
-    status = {
-      ...status,
+    status = mergeAssetStatus(status, {
       storage: {
-        ...status.storage,
         ipfs: {
-          ...status.storage?.ipfs,
           taskIds: {
-            ...status.storage?.ipfs?.taskIds,
             pending: task.id,
           },
         },
       },
-    };
+    });
   }
   return { storage, status };
 }

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -561,10 +561,9 @@ app.delete("/:id", authorizer({}), async (req, res) => {
   res.end();
 });
 
-// TODO: Delete this API as well?
 app.patch("/:id", authorizer({}), validatePost("asset"), async (req, res) => {
   // update a specific asset
-  const asset = await db.asset.get(req.body.id);
+  const asset = await db.asset.get(req.params.id);
   if (!asset) {
     throw new NotFoundError(`asset not found`);
   }
@@ -595,14 +594,15 @@ app.patch("/:id", authorizer({}), validatePost("asset"), async (req, res) => {
       },
     };
   }
-  await db.asset.update(req.body.id, {
+  const patch = {
     name,
     storage: { ...asset.storage, ...storage },
     status,
-  });
+  };
+  await db.asset.update(req.body.id, patch);
 
   res.status(200);
-  res.json({ id: req.body.id });
+  res.json({ ...asset, ...patch });
 });
 
 export default app;

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -578,13 +578,6 @@ app.delete("/:id", authorizer({}), async (req, res) => {
 });
 
 app.patch("/:id", authorizer({}), validatePost("asset"), async (req, res) => {
-  // update a specific asset
-  const { id } = req.params;
-  const asset = await db.asset.get(id);
-  if (!asset) {
-    throw new NotFoundError(`asset not found`);
-  }
-
   // these are the only updateable fields
   let { name, storage, ...rest } = req.body as Asset;
   if (storage?.ipfs?.pinata) {
@@ -593,6 +586,13 @@ app.patch("/:id", authorizer({}), validatePost("asset"), async (req, res) => {
     );
   } else if (Object.keys(rest).length) {
     throw new BadRequestError("Only asset name and storage can be updated");
+  }
+
+  // update a specific asset
+  const { id } = req.params;
+  const asset = await db.asset.get(id);
+  if (!asset) {
+    throw new NotFoundError(`asset not found`);
   }
 
   const storageUpdates = await reconcileAssetStorage(req, asset, storage);

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -627,7 +627,7 @@ app.post(
     for (const asset of toUpdate) {
       // the db.asset will actually already return the asset transformed to the
       // updated format. All we need to do is re-save it as returned here.
-      await db.asset.update(asset.id, asset);
+      await db.asset.replace(asset);
     }
 
     if (toUpdate.length > 0 && nextCursor) {

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -581,7 +581,10 @@ app.patch("/:id", authorizer({}), validatePost("asset"), async (req, res) => {
   let status = assetStatus(asset);
   const ipfsParamsEq =
     JSON.stringify(storage.ipfs) === JSON.stringify(asset.storage?.ipfs);
-  if (storage.ipfs && !ipfsParamsEq) {
+  if (!ipfsParamsEq) {
+    if (!storage.ipfs) {
+      throw new BadRequestError("Cannot remove asset from IPFS");
+    }
     const { id: taskId } = await req.taskScheduler.scheduleTask(
       "export",
       { export: { ipfs: storage.ipfs } },

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -74,7 +74,14 @@ export default async function makeApp(params: CliArgs) {
     throw e;
     // process.exit(1)
   });
-  const { db, queue, router, store, webhookCannon: webhook } = appRoute;
+  const {
+    db,
+    queue,
+    router,
+    store,
+    webhookCannon: webhook,
+    taskScheduler,
+  } = appRoute;
 
   const app = express();
   const isSilentTest =
@@ -125,6 +132,7 @@ export default async function makeApp(params: CliArgs) {
     store,
     db,
     webhook,
+    taskScheduler,
     queue,
   };
 }

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -629,6 +629,15 @@ components:
           description: Timestamp (in milliseconds) at which the stream started.
           example: 1587667174725
 
+    asset-patch-payload:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          $ref: "#/components/schemas/asset/properties/name"
+        storage:
+          $ref: "#/components/schemas/asset/properties/storage"
+
     stream-patch-payload:
       type: object
       additionalProperties: false

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -903,9 +903,37 @@ components:
           description: Set to true when the asset is deleted
         objectStoreId:
           type: string
-          description: Object store ID where the asset is stored
+          deprecated: true
+          description:
+            "@deprecated Use storageProviders.[].objectStoreId instead"
           writeOnly: true
-          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
+        storageProviders:
+          required: [objectStoreId]
+          additionalProperties: false
+          properties:
+            objectStoreId:
+              type: string
+              description: Object store ID where the asset is stored
+              writeOnly: true
+              example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
+            ipfs:
+              type: object
+              additionalProperties: false
+              required: [params]
+              properties:
+                params:
+                  $ref: "#/components/schemas/export-task-params/oneOf/1/properties/ipfs"
+                status:
+                  additionalProperties: false
+                  required: [taskId]
+                  properties:
+                    taskId:
+                      type: string
+                      description:
+                        ID of the task responsible for saving this asset in
+                        IPFS.
+                    addresses:
+                      $ref: "#/components/schemas/task/properties/output/properties/export/properties/ipfs"
         name:
           type: string
           description:

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1225,6 +1225,7 @@ components:
         status:
           type: object
           additionalProperties: false
+          readOnly: true
           description: Status of the task
           properties:
             phase:

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -922,6 +922,7 @@ components:
                 - failed
             - type: object
               additionalProperties: false
+              readOnly: true
               required: [phase]
               description: Status of the asset
               properties:
@@ -944,19 +945,26 @@ components:
                   properties:
                     ipfs:
                       additionalProperties: false
-                      readOnly: true
-                      required: [taskId]
+                      required: [taskIds]
                       properties:
-                        pendingTaskId:
-                          type: string
-                          description:
-                            ID of any currently running task that is exporting
-                            this asset to IPFS.
-                        lastTaskId:
-                          type: string
-                          description:
-                            ID of the last task to run successfully, that the
-                            currently saved data.
+                        taskIds:
+                          type: object
+                          additionalProperties: false
+                          properties:
+                            pending:
+                              type: string
+                              description:
+                                ID of any currently running task that is
+                                exporting this asset to IPFS.
+                            last:
+                              type: string
+                              description:
+                                ID of the last task to run successfully, that
+                                the currently saved data.
+                            failed:
+                              type: string
+                              description:
+                                ID of the last task to fail execution.
                         data:
                           $ref: "#/components/schemas/task/properties/output/properties/export/properties/ipfs"
         name:

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -904,10 +904,9 @@ components:
         objectStoreId:
           type: string
           deprecated: true
-          description:
-            "@deprecated Use storageProviders.[].objectStoreId instead"
+          description: "@deprecated Use storage.objectStoreId instead"
           writeOnly: true
-        storageProviders:
+        storage:
           required: [objectStoreId]
           additionalProperties: false
           properties:
@@ -917,24 +916,50 @@ components:
               writeOnly: true
               example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
             ipfs:
-              type: object
+              $ref: "#/components/schemas/export-task-params/oneOf/1/properties/ipfs"
+        status:
+          oneOf:
+            - type: string
+              deprecated: true
+              description: "@deprecated use status.phase instead"
+              enum:
+                - waiting
+                - ready
+                - failed
+            - type: object
               additionalProperties: false
-              required: [params]
+              required: [phase]
+              description: Status of the asset
               properties:
-                params:
-                  $ref: "#/components/schemas/export-task-params/oneOf/1/properties/ipfs"
-                status:
+                phase:
+                  type: string
+                  description: Phase of the asset
+                  enum:
+                    - waiting
+                    - ready
+                    - failed
+                updatedAt:
+                  type: number
+                  description:
+                    Timestamp (in milliseconds) at which the asset was last
+                    updated
+                  example: 1587667174725
+                storage:
+                  type: object
                   additionalProperties: false
-                  readOnly: true
-                  required: [taskId]
                   properties:
-                    taskId:
-                      type: string
-                      description:
-                        ID of the task responsible for saving this asset in
-                        IPFS.
-                    addresses:
-                      $ref: "#/components/schemas/task/properties/output/properties/export/properties/ipfs"
+                    ipfs:
+                      additionalProperties: false
+                      readOnly: true
+                      required: [taskId]
+                      properties:
+                        taskId:
+                          type: string
+                          description:
+                            ID of the task responsible for saving this asset in
+                            IPFS.
+                        addresses:
+                          $ref: "#/components/schemas/task/properties/output/properties/export/properties/ipfs"
         name:
           type: string
           description:
@@ -954,9 +979,8 @@ components:
             }
         updatedAt:
           type: number
-          description:
-            Timestamp (in milliseconds) at which the asset was last updated
-          example: 1587667174725
+          deprecated: true
+          description: "@deprecated Use status.updatedAt instead"
         createdAt:
           type: number
           readOnly: true
@@ -1066,13 +1090,6 @@ components:
                     type: number
                     description: Bit depth of the track - only for audio tracks
                     example: 16
-        status:
-          type: string
-          description: Status of the asset
-          enum:
-            - waiting
-            - ready
-            - failed
         sourceAssetId:
           type: string
           index: true

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -950,8 +950,8 @@ components:
                         last:
                           type: string
                           description:
-                            ID of the last task to run successfully, that the
-                            currently saved data.
+                            ID of the last task to run successfully, that
+                            created the currently saved data.
                         failed:
                           type: string
                           description: ID of the last task to fail execution.

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -912,61 +912,51 @@ components:
             ipfs:
               $ref: "#/components/schemas/export-task-params/oneOf/1/properties/ipfs"
         status:
-          oneOf:
-            - type: string
-              deprecated: true
-              description: "@deprecated use status.phase instead"
+          type: object
+          additionalProperties: false
+          readOnly: true
+          required: [phase, updatedAt]
+          description: Status of the asset
+          properties:
+            phase:
+              type: string
+              description: Phase of the asset
               enum:
                 - waiting
                 - ready
                 - failed
-            - type: object
+            updatedAt:
+              type: number
+              description:
+                Timestamp (in milliseconds) at which the asset was last updated
+              example: 1587667174725
+            storage:
+              type: object
               additionalProperties: false
-              readOnly: true
-              required: [phase]
-              description: Status of the asset
               properties:
-                phase:
-                  type: string
-                  description: Phase of the asset
-                  enum:
-                    - waiting
-                    - ready
-                    - failed
-                updatedAt:
-                  type: number
-                  description:
-                    Timestamp (in milliseconds) at which the asset was last
-                    updated
-                  example: 1587667174725
-                storage:
-                  type: object
+                ipfs:
                   additionalProperties: false
+                  required: [taskIds]
                   properties:
-                    ipfs:
+                    taskIds:
+                      type: object
                       additionalProperties: false
-                      required: [taskIds]
                       properties:
-                        taskIds:
-                          type: object
-                          additionalProperties: false
-                          properties:
-                            pending:
-                              type: string
-                              description:
-                                ID of any currently running task that is
-                                exporting this asset to IPFS.
-                            last:
-                              type: string
-                              description:
-                                ID of the last task to run successfully, that
-                                the currently saved data.
-                            failed:
-                              type: string
-                              description:
-                                ID of the last task to fail execution.
-                        data:
-                          $ref: "#/components/schemas/task/properties/output/properties/export/properties/ipfs"
+                        pending:
+                          type: string
+                          description:
+                            ID of any currently running task that is exporting
+                            this asset to IPFS.
+                        last:
+                          type: string
+                          description:
+                            ID of the last task to run successfully, that the
+                            currently saved data.
+                        failed:
+                          type: string
+                          description: ID of the last task to fail execution.
+                    data:
+                      $ref: "#/components/schemas/task/properties/output/properties/export/properties/ipfs"
         name:
           type: string
           description:
@@ -984,10 +974,6 @@ components:
               "description": "This is a video of my awesome life",
               "tags": ["awesome", "life", "video"],
             }
-        updatedAt:
-          type: number
-          deprecated: true
-          description: "@deprecated Use status.updatedAt instead"
         createdAt:
           type: number
           readOnly: true

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -925,6 +925,7 @@ components:
                   $ref: "#/components/schemas/export-task-params/oneOf/1/properties/ipfs"
                 status:
                   additionalProperties: false
+                  readOnly: true
                   required: [taskId]
                   properties:
                     taskId:

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -903,18 +903,12 @@ components:
           description: Set to true when the asset is deleted
         objectStoreId:
           type: string
-          deprecated: true
-          description: "@deprecated Use storage.objectStoreId instead"
+          description: Object store ID where the asset is stored
           writeOnly: true
+          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
         storage:
-          required: [objectStoreId]
           additionalProperties: false
           properties:
-            objectStoreId:
-              type: string
-              description: Object store ID where the asset is stored
-              writeOnly: true
-              example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
             ipfs:
               $ref: "#/components/schemas/export-task-params/oneOf/1/properties/ipfs"
         status:
@@ -953,12 +947,17 @@ components:
                       readOnly: true
                       required: [taskId]
                       properties:
-                        taskId:
+                        pendingTaskId:
                           type: string
                           description:
-                            ID of the task responsible for saving this asset in
-                            IPFS.
-                        addresses:
+                            ID of any currently running task that is exporting
+                            this asset to IPFS.
+                        lastTaskId:
+                          type: string
+                          description:
+                            ID of the last task to run successfully, that the
+                            currently saved data.
+                        data:
                           $ref: "#/components/schemas/task/properties/output/properties/export/properties/ipfs"
         name:
           type: string

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -930,6 +930,9 @@ components:
               description:
                 Timestamp (in milliseconds) at which the asset was last updated
               example: 1587667174725
+            errorMessage:
+              type: string
+              description: Error message if the asset creation failed.
             storage:
               type: object
               additionalProperties: false

--- a/packages/api/src/store/asset-table.ts
+++ b/packages/api/src/store/asset-table.ts
@@ -37,6 +37,27 @@ const assetStatusCompat = (asset: DBAsset): WithID<Asset> =>
         },
       };
 
+export const mergeAssetStatus = (
+  s1: Asset["status"],
+  s2: Partial<Asset["status"]>
+): Asset["status"] => ({
+  ...s1,
+  ...s2,
+  storage: {
+    ...s1?.storage,
+    ...s2?.storage,
+    ipfs: {
+      ...s1?.storage?.ipfs,
+      ...s2?.storage?.ipfs,
+      taskIds: {
+        ...s1?.storage?.ipfs?.taskIds,
+        ...s2?.storage?.ipfs?.taskIds,
+      },
+      // data is not mergeable, just keep the result of the spread above (s2>s1)
+    },
+  },
+});
+
 // This is mostly a compatibility helper which transforms assets read from the
 // database into the new schema (with status object instead of status string).
 //

--- a/packages/api/src/store/asset-table.ts
+++ b/packages/api/src/store/asset-table.ts
@@ -1,0 +1,72 @@
+import { QueryResult } from "pg";
+import { SQLStatement } from "sql-template-strings";
+import { Asset } from "../schema/types";
+import Table from "./table";
+import {
+  FindOptions,
+  FindQuery,
+  GetOptions,
+  UpdateOptions,
+  WithID,
+} from "./types";
+
+// Ideally this type should never be used outside of this file. It's only here
+// to fix some backward incompatible change we made on the asset.status field.
+type DBAsset =
+  | Omit<Asset, "status"> & {
+      id: string;
+
+      // These are deprecated fields from when we didn't have the top-level
+      // status object in the asset resources.
+      updatedAt?: Asset["status"]["updatedAt"];
+      status?: Asset["status"] | Asset["status"]["phase"];
+    };
+
+// Receives an asset from database and returns it in the new status schema.
+//
+// TODO: Update existing objects in DB with the new schema to remove this
+// compatibility code.
+const assetStatusCompat = (asset: DBAsset): WithID<Asset> =>
+  !asset || typeof asset.status === "object"
+    ? (asset as WithID<Asset>)
+    : {
+        ...{ ...asset, updatedAt: undefined },
+        status: {
+          phase: asset.status,
+          updatedAt: asset.updatedAt,
+        },
+      };
+
+// This is mostly a compatibility helper which transforms assets read from the
+// database into the new schema (with status object instead of status string).
+//
+// Any methods not overridden here will return the raw DBAsset objects and that
+// is by design. If you need to use any method that is not here and need to
+// access the status as an object, first create the corresponding override which
+// transforms the returned objects here.
+export default class AssetTable extends Table<DBAsset> {
+  async get(id: string, opts?: GetOptions): Promise<WithID<Asset>> {
+    const asset = await super.get(id, opts);
+    return assetStatusCompat(asset);
+  }
+
+  async find(
+    query?: FindQuery | SQLStatement[],
+    opts?: FindOptions
+  ): Promise<[WithID<Asset>[], string]> {
+    const [assets, cursor] = await super.find(query, opts);
+    return [assets?.map(assetStatusCompat), cursor];
+  }
+
+  create(doc: WithID<Asset>): Promise<WithID<Asset>> {
+    return super.create(doc) as Promise<WithID<Asset>>;
+  }
+
+  update(
+    query: string | SQLStatement[],
+    doc: Partial<WithID<Asset>>,
+    opts?: UpdateOptions
+  ): Promise<QueryResult<unknown>> {
+    return super.update(query, doc, opts);
+  }
+}

--- a/packages/api/src/store/asset-table.ts
+++ b/packages/api/src/store/asset-table.ts
@@ -39,10 +39,12 @@ const assetStatusCompat = (asset: DBAsset): WithID<Asset> =>
 
 export const mergeAssetStatus = (
   s1: Asset["status"],
-  s2: Partial<Asset["status"]>
+  s2: Partial<Asset["status"]>,
+  updatedAt: number = Date.now()
 ): Asset["status"] => ({
   ...s1,
   ...s2,
+  updatedAt,
   storage: {
     ...s1?.storage,
     ...s2?.storage,

--- a/packages/api/src/store/db.ts
+++ b/packages/api/src/store/db.ts
@@ -9,10 +9,7 @@ import {
   ObjectStore,
   ApiToken,
   User,
-  Webhook,
   PasswordResetToken,
-  MultistreamTarget,
-  Asset,
   Task,
   Usage,
   Region,
@@ -27,6 +24,7 @@ import { QueryOptions, WithID } from "./types";
 import MultistreamTargetTable from "./multistream-table";
 import WebhookTable from "./webhook-table";
 import { CdnUsageTable } from "./cdn-usage-table";
+import AssetTable from "./asset-table";
 
 // Should be configurable, perhaps?
 const CONNECT_TIMEOUT = 5000;
@@ -64,7 +62,7 @@ export class DB {
   stream: StreamTable;
   objectStore: Table<ObjectStore>;
   multistreamTarget: MultistreamTargetTable;
-  asset: Table<Asset>;
+  asset: AssetTable;
   task: Table<Task>;
   apiToken: Table<ApiToken>;
   user: Table<User>;
@@ -147,7 +145,7 @@ export class DB {
       db: this,
       schema: schemas["api-token"],
     });
-    this.asset = makeTable<Asset>({
+    this.asset = new AssetTable({
       db: this,
       schema: schemas["asset"],
     });

--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -158,6 +158,33 @@ export default class TaskScheduler {
         updatedAt: Date.now(),
       });
     }
+    switch (task.type) {
+      case "export":
+        const inputAsset = await db.asset.get(task.inputAssetId);
+        if (
+          typeof inputAsset.status === "object" &&
+          inputAsset.status?.storage?.ipfs?.taskIds?.pending === task.id
+        ) {
+          const { storage } = inputAsset.status;
+          await db.asset.update(inputAsset.id, {
+            status: {
+              ...inputAsset.status,
+              storage: {
+                ...storage,
+                ipfs: {
+                  ...storage.ipfs,
+                  taskIds: {
+                    ...storage.ipfs.taskIds,
+                    pending: null,
+                    failed: task.id,
+                  },
+                },
+              },
+            },
+          });
+        }
+        break;
+    }
   }
 
   async scheduleTask(

--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -111,7 +111,7 @@ export default class TaskScheduler {
         const inputAsset = await db.asset.get(task.inputAssetId);
         if (
           typeof inputAsset.status === "object" &&
-          inputAsset.status?.storage?.ipfs?.taskId === task.id
+          inputAsset.status?.storage?.ipfs?.pendingTaskId === task.id
         ) {
           await db.asset.update(inputAsset.id, {
             status: {
@@ -119,9 +119,9 @@ export default class TaskScheduler {
               storage: {
                 ...inputAsset.status.storage,
                 ipfs: {
-                  ...inputAsset.status.storage.ipfs,
-                  taskId: task.id,
-                  addresses: task.output.export.ipfs,
+                  pendingTaskId: null,
+                  lastTaskId: task.id,
+                  data: task.output.export.ipfs,
                 },
               },
             },

--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -123,7 +123,7 @@ export default class TaskScheduler {
                     pending: undefined,
                     last: task.id,
                   },
-                  data: task.output.export.ipfs,
+                  data: event.output.export.ipfs,
                 },
               },
             }),

--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -107,6 +107,23 @@ export default class TaskScheduler {
           updatedAt: Date.now(),
         });
         break;
+      case "export":
+        const inputAsset = await db.asset.get(task.inputAssetId);
+        if (inputAsset.storageProviders?.ipfs?.status?.taskId === task.id) {
+          await db.asset.update(inputAsset.id, {
+            storageProviders: {
+              ...inputAsset.storageProviders,
+              ipfs: {
+                ...inputAsset.storageProviders.ipfs,
+                status: {
+                  taskId: task.id,
+                  addresses: task.output.export.ipfs,
+                },
+              },
+            },
+          });
+        }
+        break;
     }
     await db.task.update(task.id, {
       status: {

--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -148,21 +148,17 @@ export default class TaskScheduler {
   }
 
   private async failTask(task: Task, error: string, output?: Task["output"]) {
+    const status = {
+      phase: "failed",
+      updatedAt: Date.now(),
+      errorMessage: error,
+    } as const;
     await db.task.update(task.id, {
       output,
-      status: {
-        phase: "failed",
-        updatedAt: Date.now(),
-        errorMessage: error,
-      },
+      status,
     });
     if (task.outputAssetId) {
-      await db.asset.update(task.outputAssetId, {
-        status: {
-          phase: "failed",
-          updatedAt: Date.now(),
-        },
-      });
+      await db.asset.update(task.outputAssetId, { status });
     }
     switch (task.type) {
       case "export":

--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -111,16 +111,20 @@ export default class TaskScheduler {
         const inputAsset = await db.asset.get(task.inputAssetId);
         if (
           typeof inputAsset.status === "object" &&
-          inputAsset.status?.storage?.ipfs?.pendingTaskId === task.id
+          inputAsset.status?.storage?.ipfs?.taskIds?.pending === task.id
         ) {
+          const ipfs = inputAsset.status.storage.ipfs;
           await db.asset.update(inputAsset.id, {
             status: {
               ...inputAsset.status,
               storage: {
                 ...inputAsset.status.storage,
                 ipfs: {
-                  pendingTaskId: null,
-                  lastTaskId: task.id,
+                  taskIds: {
+                    ...ipfs.taskIds,
+                    pending: null,
+                    last: task.id,
+                  },
                   data: task.output.export.ipfs,
                 },
               },

--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -68,42 +68,45 @@ export default class TaskScheduler {
       return true;
     }
 
-    if (event.task.type === "import") {
-      const assetSpec = event.output?.import?.assetSpec;
-      if (!assetSpec) {
-        const error = "bad task output: missing assetSpec";
-        console.error(
-          `task event process error: err=${error} taskId=${event.task.id}`
-        );
-        await this.failTask(task, error, event.output);
-        return true;
-      }
-      await db.asset.update(task.outputAssetId, {
-        size: assetSpec.size,
-        hash: assetSpec.hash,
-        videoSpec: assetSpec.videoSpec,
-        playbackRecordingId: assetSpec.playbackRecordingId,
-        status: "ready",
-        updatedAt: Date.now(),
-      });
-    } else if (event.task.type === "transcode") {
-      const assetSpec = event.output?.transcode?.asset?.assetSpec;
-      if (!assetSpec) {
-        const error = "bad task output: missing assetSpec";
-        console.error(
-          `task event process error: err=${error} taskId=${event.task.id}`
-        );
-        await this.failTask(task, error, event.output);
-        return true;
-      }
-      await db.asset.update(task.outputAssetId, {
-        size: assetSpec.size,
-        hash: assetSpec.hash,
-        videoSpec: assetSpec.videoSpec,
-        playbackRecordingId: assetSpec.playbackRecordingId,
-        status: "ready",
-        updatedAt: Date.now(),
-      });
+    switch (event.task.type) {
+      case "import":
+        let assetSpec = event.output?.import?.assetSpec;
+        if (!assetSpec) {
+          const error = "bad task output: missing assetSpec";
+          console.error(
+            `task event process error: err=${error} taskId=${event.task.id}`
+          );
+          await this.failTask(task, error, event.output);
+          return true;
+        }
+        await db.asset.update(task.outputAssetId, {
+          size: assetSpec.size,
+          hash: assetSpec.hash,
+          videoSpec: assetSpec.videoSpec,
+          playbackRecordingId: assetSpec.playbackRecordingId,
+          status: "ready",
+          updatedAt: Date.now(),
+        });
+        break;
+      case "transcode":
+        assetSpec = event.output?.transcode?.asset?.assetSpec;
+        if (!assetSpec) {
+          const error = "bad task output: missing assetSpec";
+          console.error(
+            `task event process error: err=${error} taskId=${event.task.id}`
+          );
+          await this.failTask(task, error, event.output);
+          return true;
+        }
+        await db.asset.update(task.outputAssetId, {
+          size: assetSpec.size,
+          hash: assetSpec.hash,
+          videoSpec: assetSpec.videoSpec,
+          playbackRecordingId: assetSpec.playbackRecordingId,
+          status: "ready",
+          updatedAt: Date.now(),
+        });
+        break;
     }
     await db.task.update(task.id, {
       status: {

--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -84,8 +84,10 @@ export default class TaskScheduler {
           hash: assetSpec.hash,
           videoSpec: assetSpec.videoSpec,
           playbackRecordingId: assetSpec.playbackRecordingId,
-          status: "ready",
-          updatedAt: Date.now(),
+          status: {
+            phase: "ready",
+            updatedAt: Date.now(),
+          },
         });
         break;
       case "transcode":
@@ -103,8 +105,10 @@ export default class TaskScheduler {
           hash: assetSpec.hash,
           videoSpec: assetSpec.videoSpec,
           playbackRecordingId: assetSpec.playbackRecordingId,
-          status: "ready",
-          updatedAt: Date.now(),
+          status: {
+            phase: "ready",
+            updatedAt: Date.now(),
+          },
         });
         break;
       case "export":
@@ -154,8 +158,10 @@ export default class TaskScheduler {
     });
     if (task.outputAssetId) {
       await db.asset.update(task.outputAssetId, {
-        status: "failed",
-        updatedAt: Date.now(),
+        status: {
+          phase: "failed",
+          updatedAt: Date.now(),
+        },
       });
     }
     switch (task.type) {

--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -109,13 +109,17 @@ export default class TaskScheduler {
         break;
       case "export":
         const inputAsset = await db.asset.get(task.inputAssetId);
-        if (inputAsset.storageProviders?.ipfs?.status?.taskId === task.id) {
+        if (
+          typeof inputAsset.status === "object" &&
+          inputAsset.status?.storage?.ipfs?.taskId === task.id
+        ) {
           await db.asset.update(inputAsset.id, {
-            storageProviders: {
-              ...inputAsset.storageProviders,
-              ipfs: {
-                ...inputAsset.storageProviders.ipfs,
-                status: {
+            status: {
+              ...inputAsset.status,
+              storage: {
+                ...inputAsset.status.storage,
+                ipfs: {
+                  ...inputAsset.status.storage.ipfs,
                   taskId: task.id,
                   addresses: task.output.export.ipfs,
                 },

--- a/packages/api/src/test-server.ts
+++ b/packages/api/src/test-server.ts
@@ -67,6 +67,7 @@ async function setupServer() {
     db: server.db,
     queue: server.queue,
     webhook: server.webhook,
+    taskScheduler: server.taskScheduler,
   };
 }
 

--- a/packages/api/src/test-server.ts
+++ b/packages/api/src/test-server.ts
@@ -39,6 +39,7 @@ params.sendgridTemplateId = sendgridTemplateId;
 params.sendgridApiKey = sendgridApiKey;
 params.postgresUrl = `postgresql://postgres@127.0.0.1/${testId}`;
 params.recordObjectStoreId = "mock_store";
+params.vodObjectStoreId = "mock_vod_store";
 params.ingest =
   '[{"ingest": "rtmp://test/live","playback": "https://test/hls","base": "https://test"}]';
 params.amqpUrl = `amqp://localhost:5672/${testId}`;

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -512,12 +512,13 @@ export default class WebhookCannon {
     const id = uuid();
     const playbackId = await generateUniquePlaybackId(this.store, sessionId);
 
+    const createdAt = Date.now();
     const asset = await this.db.asset.create({
       id,
       playbackId,
       userId,
-      createdAt: Date.now(),
-      status: "waiting",
+      createdAt,
+      status: { phase: "waiting", updatedAt: createdAt },
       name: `live-to-vod-${sessionId}`,
       objectStoreId: this.vodObjectStoreId,
     });

--- a/packages/www/components/Dashboard/AssetsTable/index.tsx
+++ b/packages/www/components/Dashboard/AssetsTable/index.tsx
@@ -160,7 +160,11 @@ const AssetsTable = ({
             fallback: <Box css={{ color: "$primary8" }}>—</Box>,
           },
           updatedAt: {
-            date: asset.updatedAt ? new Date(asset.updatedAt) : null,
+            date:
+              asset.status.updatedAt &&
+              asset.status.updatedAt !== asset.createdAt
+                ? new Date(asset.status.updatedAt)
+                : null,
             fallback: <Box css={{ color: "$primary8" }}>—</Box>,
           },
           downloadUrl: {

--- a/packages/www/docs/api-reference/vod/export.mdx
+++ b/packages/www/docs/api-reference/vod/export.mdx
@@ -50,10 +50,10 @@ curl --location --request POST 'https://livepeer.com/api/asset/$ASSET_ID/export'
       description: "Will be added to the `pinata_secret_api_key` header.",
     },
     {
-      parameter: <code>ipfs.erc1155Metadata</code>,
+      parameter: <code>ipfs.nftMetadata</code>,
       type: <code>object</code>,
       description:
-        "Additional data to add to the automatic ERC-1155 default export. Will be deep merged with the default metadata regularly exported.",
+        "Additional data to add to the NFT metadata also exported to IPFS. Will be deep merged with the default metadata regularly exported.",
     },
     {
       parameter: <code>custom</code>,

--- a/packages/www/docs/api-reference/vod/list.mdx
+++ b/packages/www/docs/api-reference/vod/list.mdx
@@ -59,10 +59,12 @@ curl --location --request GET 'https://livepeer.com/api/asset/$ASSET_ID' \
     ],
     "name": "Example name",
     "size": 52615193,
-    "status": "ready",
+    "status": {
+      "phase": "ready",
+      "updatedAt": 1644546541218
+    },
     "userId": "$USER_ID",
     "createdAt": 1644546528636,
-    "updatedAt": 1644546541218,
     "videoSpec": {
         "format": "mp4",
         "tracks": [

--- a/packages/www/docs/api-reference/vod/upload.mdx
+++ b/packages/www/docs/api-reference/vod/upload.mdx
@@ -49,14 +49,37 @@ curl --location --request POST 'https://livepeer.com/api/asset/request-upload' \
     "url": "https://origin.livepeer.com/api/asset/upload/aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL2xwLW55Yy12b2QtbW9uc3Rlci9kaXJlY3RVcGxvYWQvNjI3OHQyZWlrY2JqZXUxNC9zb3VyY2U%2F...",
     "asset": {
         "id": "$ASSET_ID",
+        "name": "Example name",
         "playbackId": "$PLAYBACK_ID",
         "userId": "$USER_ID",
         "createdAt": 1644595454248,
-        "status": "waiting",
-        "name": "Example name"
+        "status": {
+          "phase": "waiting",
+          "updatedAt": 1644595454248
+        }
+    },
+    "task": {
+        "id": "$TASK_ID",
+        "type": "import",
+        "outputAssetId": "$ASSET_ID",
+        "params": {
+          "import": {
+            "uploadedObjectKey": "directUpload/$PLAYBACK_ID/source"
+          }
+        },
+        "createdAt": 1652813126031,
+        "status": {
+            "phase": "pending",
+            "updatedAt": 1652813126031
+        }
     }
 }
 ```
+
+You can use the returned `task` object to monitor the progress of processing the
+asset after the contents have been uploaded. Check the
+[Retrieve a Task](/docs/api-reference/vod/list-tasks#retrieve-a-task) API for
+more information.
 
 ## Step 2: Upload the contents
 


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This is an improvement proposal to the VOD API, from some feedback that we've already got from users
and evolutions we would like to make to the API for easier use, like. for example for abstraction-matching
the new VOD dashboard pages. The changes are specifically regarding the relation between assets and
tasks and more extensively with the export to IPFS task.

The idea is that instead of having an asset loosely tied to a bunch of export tasks, it will now have explicit
fields for the current desired storage for the asset and status for those storages (as it can take a while until
the desired state becomes reality). This storage is currently only IPFS, but we will add other d3 storages in
the future. The object store ID is not changeable for now.

There's a whole migration strategy for the `status` field of the assets that have changed:
 - for now, would deploy this change with backward compatibility code implemented directly in the DB layer
 - created a migration API which, once we're confident with the change, should be called until all assets are migrated
 - after that (migration API starts returning `0`), we can remove the compatibility code

We are actually breaking the public schema of assets, but I believe this should be OK since it's not being
used in many places. This new design is more extensible and will allow us to make other changes in the future
without breaking compatibility again.

**Specific updates (required)**
 - Make the `status` field in the asset be an object just like from tasks. The previous `status` becomes `status.phase` and the previous `updatedAt` becomes `status.updatedAt`.
 - Create a `storage` field in the asset and allow patching it
 - Update `storage` and `status` field on the right places (when exporting an asset on IPFS, when tasks finish, etc)
 - Update `www` code to use the new `status` field (all responses will come with that from day1, old schema will be only in the DB)
 - Update VOD documentation with new asset schema

Pending:
 - TODO after deploying this: Update `video-nft` SDK with new asset schema

## -

- **How did you test each of these updates (required)**
`yarn test`, running all the new VOD tests!

I'll try to add some unit tests here while this gets reviewed, otherwise will test locally and/or on staging.

**Does this pull request close any open issues?**

Implements #1020 

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
