### PR TITLE
api: Do not skip index creation on tests

### DIFF
--- a/packages/api/src/store/table.ts
+++ b/packages/api/src/store/table.ts
@@ -332,24 +332,29 @@ export default class Table<T extends DBObject> {
 
   // on startup: auto-create indices if they don't exist
   async ensureIndex(propName, prop) {
-    // if (!prop.index && !prop.unique) {
-    //   return;
-    // }
-    // let unique = "";
-    // if (prop.unique) {
-    //   unique = "unique";
-    // }
-    // const indexName = `${this.name}_${propName}`;
-    // try {
-    //   await this.db.query(`
-    //       CREATE ${unique} INDEX "${indexName}" ON "${this.name}" USING BTREE ((data->>'${propName}'));
-    //     `);
-    // } catch (e) {
-    //   if (!e.message.includes("already exists")) {
-    //     throw e;
-    //   }
-    //   return;
-    // }
-    // logger.info(`Created ${unique} index ${indexName} on ${this.name}`);
+    if (process.env.NODE_ENV !== "test") {
+      // avoid creating indexes in production right now...
+      return;
+    }
+
+    if (!prop.index && !prop.unique) {
+      return;
+    }
+    let unique = "";
+    if (prop.unique) {
+      unique = "unique";
+    }
+    const indexName = `${this.name}_${propName}`;
+    try {
+      await this.db.query(`
+          CREATE ${unique} INDEX "${indexName}" ON "${this.name}" USING BTREE ((data->>'${propName}'));
+        `);
+    } catch (e) {
+      if (!e.message.includes("already exists")) {
+        throw e;
+      }
+      return;
+    }
+    logger.info(`Created ${unique} index ${indexName} on ${this.name}`);
   }
 }


### PR DESCRIPTION
We cannot create indexes in production because that is affecting our DB reliability.

We need to create them on tests though because many of our tests rely on that, like for example the ones that check for user email uniqueness.

This fixes that by creating indexes at leas on the tests runs.