### PR TITLE
Mark half of the Orchestrators on Staging as 'untrusted'

### DIFF
--- a/packages/api/src/app-router.ts
+++ b/packages/api/src/app-router.ts
@@ -77,6 +77,7 @@ export default async function makeApp(params: CliArgs) {
     stripeSecretKey,
     amqpUrl,
     returnRegionInOrchestrator,
+    halfRegionOrchestratorsUntrusted,
   } = params;
 
   if (supportAddr || sendgridTemplateId || sendgridApiKey) {
@@ -197,7 +198,9 @@ export default async function makeApp(params: CliArgs) {
 
   if (returnRegionInOrchestrator) {
     app.use((req, res, next) => {
-      req.orchestratorsGetters.push(regionsGetter);
+      req.orchestratorsGetters.push(
+        regionsGetter(halfRegionOrchestratorsUntrusted)
+      );
       return next();
     });
   }

--- a/packages/api/src/app-router.ts
+++ b/packages/api/src/app-router.ts
@@ -198,7 +198,7 @@ export default async function makeApp(params: CliArgs) {
 
   if (returnRegionInOrchestrator) {
     app.use((req, res, next) => {
-      req.orchestratorsGetters.push(
+      req.orchestratorsGetters.push(() =>
         regionsGetter(halfRegionOrchestratorsUntrusted)
       );
       return next();

--- a/packages/api/src/controllers/region.js
+++ b/packages/api/src/controllers/region.js
@@ -16,12 +16,10 @@ function flatRegions(regions = [], halfRegionOrchestratorsUntrusted = false) {
   );
 }
 
-export function regionsGetter(halfRegionOrchestratorsUntrusted = false) {
-  return async function regionsGetter2() {
-    const [regions, cursor] = await db.region.find({}, { limit: 100 });
+export async function regionsGetter(halfRegionOrchestratorsUntrusted = false) {
+  const [regions, cursor] = await db.region.find({}, { limit: 100 });
 
-    return flatRegions(regions, halfRegionOrchestratorsUntrusted);
-  };
+  return flatRegions(regions, halfRegionOrchestratorsUntrusted);
 }
 
 app.get("/", async (req, res, next) => {

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -292,6 +292,12 @@ export default function parseCli(argv?: string | readonly string[]) {
         default: false,
         type: "boolean",
       },
+      "half-region-orchestrators-untrusted": {
+        describe:
+          "mark half of the orchestrators returned by /api/region as untrusted. For use in staging!",
+        default: false,
+        type: "boolean",
+      },
       json: {
         describe: "print MistController-compatible json description",
         default: false,


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

When a new flag is passed, mark 50% of the Orchestrators as "untrusted" to allow us to test Fast Verification on Staging, where there are no community Orchestrators.

**Specific updates (required)**

* Add boolean "half-region-orchestrators-untrusted" parameter.
* Mark every other O as untrusted when this is passed.

**How did you test each of these updates (required)**

* Deploying to Staging to test

**Does this pull request close any open issues?**

No

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
