### PR TITLE
www/admin: Allow content moderation from a single page

### DIFF
--- a/packages/www/components/Admin/SuspendUserModal/index.tsx
+++ b/packages/www/components/Admin/SuspendUserModal/index.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useApi } from "hooks";
 import Modal from "../Modal";
 import { Button, Flex } from "@theme-ui/components";
@@ -16,6 +16,10 @@ type Props = {
 const SuspendUserModal = ({ user, isOpen, onClose, onSuspend }: Props) => {
   const [isCopyrightInfringiment, setIsCopyrightInfringiment] = useState(true);
   const { setUserSuspended } = useApi();
+
+  useEffect(() => {
+    setIsCopyrightInfringiment(true);
+  }, [isOpen]);
 
   return !(user && isOpen) ? null : (
     <Modal onClose={onClose}>

--- a/packages/www/components/Admin/SuspendUserModal/index.tsx
+++ b/packages/www/components/Admin/SuspendUserModal/index.tsx
@@ -1,0 +1,71 @@
+/** @jsxImportSource @emotion/react */
+import { useState } from "react";
+import { useApi } from "hooks";
+import Modal from "../Modal";
+import { Button, Flex } from "@theme-ui/components";
+import { Box, Checkbox, Label, Tooltip } from "@livepeer/design-system";
+import { User } from "@livepeer.com/api";
+
+type Props = {
+  user: User;
+  isOpen: boolean;
+  onClose: () => void;
+  onSuspend: () => PromiseLike<void>;
+};
+
+const SuspendUserModal = ({ user, isOpen, onClose, onSuspend }: Props) => {
+  const [isCopyrightInfringiment, setIsCopyrightInfringiment] = useState(true);
+  const { setUserSuspended } = useApi();
+
+  return !(user && isOpen) ? null : (
+    <Modal onClose={onClose}>
+      <h3>Suspend user</h3>
+      <p>
+        Are you sure you want to <b>suspend</b> user "{user.email}"?
+      </p>
+
+      <Box sx={{ display: "flex", mt: 2, mb: 2 }}>
+        <Checkbox
+          id="isCopyrightInfringiment"
+          checked={isCopyrightInfringiment}
+          style={{ color: "black" }}
+          onCheckedChange={(checked: boolean) =>
+            setIsCopyrightInfringiment(checked)
+          }
+        />
+        <Tooltip
+          content="Checking this will send the copyright infringiment email instead of the default one."
+          multiline>
+          <Label sx={{ ml: 2 }} htmlFor="isCopyrightInfringiment">
+            Copyright infringiment
+          </Label>
+        </Tooltip>
+      </Box>
+
+      <Flex sx={{ justifyContent: "flex-end" }}>
+        <Button
+          type="button"
+          variant="outlineSmall"
+          onClick={onClose}
+          sx={{ mr: 2 }}>
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          variant="primarySmall"
+          onClick={() => {
+            setUserSuspended(user.id, {
+              suspended: true,
+              emailTemplate: isCopyrightInfringiment ? "copyright" : undefined,
+            })
+              .then(onSuspend)
+              .finally(onClose);
+          }}>
+          Suspend User
+        </Button>
+      </Flex>
+    </Modal>
+  );
+};
+
+export default SuspendUserModal;

--- a/packages/www/components/Admin/SuspendUserModal/index.tsx
+++ b/packages/www/components/Admin/SuspendUserModal/index.tsx
@@ -10,7 +10,7 @@ type Props = {
   user: User;
   isOpen: boolean;
   onClose: () => void;
-  onSuspend: () => PromiseLike<void>;
+  onSuspend: () => PromiseLike<void> | void;
 };
 
 const SuspendUserModal = ({ user, isOpen, onClose, onSuspend }: Props) => {

--- a/packages/www/components/Admin/UserTable/index.tsx
+++ b/packages/www/components/Admin/UserTable/index.tsx
@@ -1,12 +1,11 @@
 /** @jsxImportSource @emotion/react */
-import { jsx } from "theme-ui";
 import { useState, useMemo } from "react";
 import { useApi } from "hooks";
 import { Button, Flex, Container, Select } from "@theme-ui/components";
 import Modal from "../Modal";
 import { products } from "@livepeer.com/api/src/config";
 import CommonAdminTable from "@components/Admin/CommonAdminTable";
-import { Box, Checkbox, Label, Tooltip } from "@livepeer/design-system";
+import SuspendUserModal from "../SuspendUserModal";
 
 type UserTableProps = {
   userId: string;
@@ -21,7 +20,6 @@ const UserTable = ({ userId, id }: UserTableProps) => {
   const [adminModal, setAdminModal] = useState(false);
   const [removeAdminModal, setRemoveAdminModal] = useState(false);
   const [suspendModal, setSuspendModal] = useState(false);
-  const [isCopyrightInfringiment, setIsCopyrightInfringiment] = useState(true);
   const [unsuspendModal, setUnsuspendModal] = useState(false);
   const [nextCursor, setNextCursor] = useState("");
   const [lastCursor, setLastCursor] = useState("");
@@ -137,7 +135,7 @@ const UserTable = ({ userId, id }: UserTableProps) => {
       .finally(() => setLoading(false));
   };
 
-  const refecth = () => {
+  const refetch = () => {
     fetchData(
       { order: lastOrder, cursor: lastCursor, filters: lastFilters },
       true
@@ -150,56 +148,12 @@ const UserTable = ({ userId, id }: UserTableProps) => {
       sx={{
         my: 2,
       }}>
-      {suspendModal && selectedUser && (
-        <Modal onClose={close}>
-          <h3>Suspend user</h3>
-          <p>
-            Are you sure you want to <b>suspend</b> user "{selectedUser.email}"?
-          </p>
-
-          <Box sx={{ display: "flex", mt: 2, mb: 2 }}>
-            <Checkbox
-              id="isCopyrightInfringiment"
-              checked={isCopyrightInfringiment}
-              onCheckedChange={(checked: boolean) =>
-                setIsCopyrightInfringiment(checked)
-              }
-            />
-            <Tooltip
-              content="Checking this will send the copyright infringiment email instead of the default one."
-              multiline>
-              <Label sx={{ ml: 2 }} htmlFor="isCopyrightInfringiment">
-                Copyright infringiment
-              </Label>
-            </Tooltip>
-          </Box>
-
-          <Flex sx={{ justifyContent: "flex-end" }}>
-            <Button
-              type="button"
-              variant="outlineSmall"
-              onClick={close}
-              sx={{ mr: 2 }}>
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              variant="primarySmall"
-              onClick={() => {
-                setUserSuspended(selectedUser.id, {
-                  suspended: true,
-                  emailTemplate: isCopyrightInfringiment
-                    ? "copyright"
-                    : undefined,
-                })
-                  .then(refecth)
-                  .finally(close);
-              }}>
-              Suspend User
-            </Button>
-          </Flex>
-        </Modal>
-      )}
+      <SuspendUserModal
+        user={selectedUser}
+        isOpen={suspendModal}
+        onClose={close}
+        onSuspend={refetch}
+      />
       {unsuspendModal && selectedUser && (
         <Modal onClose={close}>
           <h3>Unsuspend user</h3>
@@ -220,7 +174,7 @@ const UserTable = ({ userId, id }: UserTableProps) => {
               variant="primarySmall"
               onClick={() => {
                 setUserSuspended(selectedUser.id, { suspended: false })
-                  .then(refecth)
+                  .then(refetch)
                   .finally(close);
               }}>
               Unsuspend User
@@ -247,7 +201,7 @@ const UserTable = ({ userId, id }: UserTableProps) => {
               variant="primarySmall"
               onClick={() => {
                 makeUserAdmin(selectedUser.email, true)
-                  .then(refecth)
+                  .then(refetch)
                   .finally(close);
               }}>
               Make User Admin
@@ -275,7 +229,7 @@ const UserTable = ({ userId, id }: UserTableProps) => {
               variant="primarySmall"
               onClick={() => {
                 makeUserAdmin(selectedUser.email, false)
-                  .then(refecth)
+                  .then(refetch)
                   .finally(close);
               }}>
               Remove Admin Rights

--- a/packages/www/pages/app/stream/[id].tsx
+++ b/packages/www/pages/app/stream/[id].tsx
@@ -266,13 +266,24 @@ const ID = () => {
   const userField = useMemo(() => {
     let value = streamOwner?.email;
     if (streamOwner?.admin) {
-      value = `${value} (admin)`;
+      value += " (admin)";
     }
     if (streamOwner?.suspended) {
-      value = `${value} (suspended)`;
+      value = " (suspended)";
     }
     return value;
   }, [streamOwner?.email, streamOwner?.admin, streamOwner?.suspended]);
+  const playerUrl = useMemo(() => {
+    if (!stream?.playbackId) {
+      return "https://lvpr.tv/";
+    }
+    const autoplay = query.autoplay?.toString() ?? "0";
+    let url = `https://lvpr.tv/?theme=fantasy&live=${stream?.playbackId}&autoplay=${autoplay}`;
+    if (isStaging() || isDevelopment()) {
+      url += "&monster";
+    }
+    return url;
+  }, [query.autoplay, stream?.playbackId]);
   const [keyRevealed, setKeyRevealed] = useState(false);
   const close = () => {
     setSuspendModal(false);
@@ -448,472 +459,506 @@ const ID = () => {
               <Heading as="h3" sx={{ mb: "0.5em" }}>
                 {stream.name}
               </Heading>
-              <Box
+              <Flex
                 sx={{
-                  display: "grid",
-                  alignItems: "center",
-                  gridTemplateColumns: "10em auto",
-                  width: "100%",
-                  fontSize: 0,
-                  position: "relative",
+                  justifyContent: "flex-end",
+                  mb: 3,
                 }}>
-                <Cell>Stream name</Cell>
-                <Cell>{stream.name}</Cell>
-                <Cell>Stream ID</Cell>
-                <Cell>
-                  <ClipBut text={stream.id}></ClipBut>
-                </Cell>
-                <Cell>Stream key</Cell>
-                <Cell>
-                  {keyRevealed ? (
-                    <Flex>
-                      {stream.streamKey}
-                      <CopyToClipboard
-                        text={stream.streamKey}
-                        onCopy={() => setCopied(2000)}>
-                        <Flex
-                          sx={{
-                            alignItems: "center",
-                            cursor: "pointer",
-                            ml: 1,
-                          }}>
-                          <Copy
-                            sx={{
-                              mr: 1,
-                              width: 14,
-                              height: 14,
-                              color: "offBlack",
-                            }}
-                          />
-                          {!!isCopied && (
-                            <Box sx={{ fontSize: 12, color: "offBlack" }}>
-                              Copied
-                            </Box>
-                          )}
-                        </Flex>
-                      </CopyToClipboard>
-                    </Flex>
-                  ) : (
-                    <Button
-                      type="button"
-                      variant="outlineSmall"
-                      onClick={() => setKeyRevealed(true)}
-                      sx={{ mr: 0, py: "4px", fontSize: 0 }}>
-                      Show secret stream key
-                    </Button>
-                  )}
-                </Cell>
-                <Cell>RTMP ingest URL</Cell>
-                <Cell>
-                  <ShowURL text="" url={globalIngestUrl} anchor={true} />
-                </Cell>
-                <Cell>Playback URL</Cell>
-                <Cell>
-                  <ShowURL text="" url={globalPlaybackUrl} anchor={true} />
-                </Cell>
                 <Box
                   sx={{
-                    mx: "0.4em",
-                    mt: "0.4em",
-                    mb: "0",
-                    gridColumn: "1/-1",
-                  }}>
-                  <Box
-                    onClick={() => setRegionalUrlsVisible(!regionalUrlsVisible)}
-                    sx={{
-                      cursor: "pointer",
-                      display: "inline-block",
-                      transform: regionalUrlsVisible
-                        ? "rotate(90deg)"
-                        : "rotate(0deg)",
-                      transition: "transform 0.4s ease",
-                    }}>
-                    ▶
-                  </Box>{" "}
-                  Regional ingest and playback URL pairs
-                </Box>
-                <Box
-                  sx={{
-                    gridColumn: "1/-1",
+                    display: "grid",
+                    alignItems: "center",
+                    gridTemplateColumns: "10em auto",
+                    width: "60%",
+                    fontSize: 0,
                     position: "relative",
-                    overflow: "hidden",
-                    mb: "0.8em",
                   }}>
+                  <Cell>Stream name</Cell>
+                  <Cell>{stream.name}</Cell>
+                  <Cell>Stream ID</Cell>
+                  <Cell>
+                    <ClipBut text={stream.id}></ClipBut>
+                  </Cell>
+                  <Cell>Stream key</Cell>
+                  <Cell>
+                    {keyRevealed ? (
+                      <Flex>
+                        {stream.streamKey}
+                        <CopyToClipboard
+                          text={stream.streamKey}
+                          onCopy={() => setCopied(2000)}>
+                          <Flex
+                            sx={{
+                              alignItems: "center",
+                              cursor: "pointer",
+                              ml: 1,
+                            }}>
+                            <Copy
+                              sx={{
+                                mr: 1,
+                                width: 14,
+                                height: 14,
+                                color: "offBlack",
+                              }}
+                            />
+                            {!!isCopied && (
+                              <Box sx={{ fontSize: 12, color: "offBlack" }}>
+                                Copied
+                              </Box>
+                            )}
+                          </Flex>
+                        </CopyToClipboard>
+                      </Flex>
+                    ) : (
+                      <Button
+                        type="button"
+                        variant="outlineSmall"
+                        onClick={() => setKeyRevealed(true)}
+                        sx={{ mr: 0, py: "4px", fontSize: 0 }}>
+                        Show secret stream key
+                      </Button>
+                    )}
+                  </Cell>
+                  <Cell>RTMP ingest URL</Cell>
+                  <Cell>
+                    <ShowURL text="" url={globalIngestUrl} anchor={true} />
+                  </Cell>
+                  <Cell>Playback URL</Cell>
+                  <Cell>
+                    <ShowURL text="" url={globalPlaybackUrl} anchor={true} />
+                  </Cell>
                   <Box
                     sx={{
+                      mx: "0.4em",
+                      mt: "0.4em",
+                      mb: "0",
+                      gridColumn: "1/-1",
+                    }}>
+                    <Box
+                      onClick={() =>
+                        setRegionalUrlsVisible(!regionalUrlsVisible)
+                      }
+                      sx={{
+                        cursor: "pointer",
+                        display: "inline-block",
+                        transform: regionalUrlsVisible
+                          ? "rotate(90deg)"
+                          : "rotate(0deg)",
+                        transition: "transform 0.4s ease",
+                      }}>
+                      ▶
+                    </Box>{" "}
+                    Regional ingest and playback URL pairs
+                  </Box>
+                  <Box
+                    sx={{
+                      gridColumn: "1/-1",
                       position: "relative",
                       overflow: "hidden",
-                      transition: "margin-bottom .4s ease",
-                      mb: regionalUrlsVisible ? "0" : "-100%",
-                      display: "grid",
-                      alignItems: "center",
-                      gridTemplateColumns: "10em auto",
+                      mb: "0.8em",
                     }}>
                     <Box
                       sx={{
-                        mx: "0.4em",
-                        mt: "0.4em",
-                        gridColumn: "1/-1",
-                        width: ["100%", "100%", "75%", "50%"],
+                        position: "relative",
+                        overflow: "hidden",
+                        transition: "margin-bottom .4s ease",
+                        mb: regionalUrlsVisible ? "0" : "-100%",
+                        display: "grid",
+                        alignItems: "center",
+                        gridTemplateColumns: "10em auto",
                       }}>
-                      The global RTMP ingest and playback URL pair above auto
-                      detects livestreamer and viewer locations to provide the
-                      optimal Livepeer.com experience.
-                      <Link
-                        href="/docs/guides/dashboard/ingest-playback-url-pair"
-                        passHref>
-                        <A target="_blank">
-                          <i>
-                            Learn more about forgoing the global ingest and
-                            playback URLs before selecting a regional URL pair.
-                          </i>
-                        </A>
-                      </Link>
+                      <Box
+                        sx={{
+                          mx: "0.4em",
+                          mt: "0.4em",
+                          gridColumn: "1/-1",
+                          width: ["100%", "100%", "75%", "50%"],
+                        }}>
+                        The global RTMP ingest and playback URL pair above auto
+                        detects livestreamer and viewer locations to provide the
+                        optimal Livepeer.com experience.
+                        <Link
+                          href="/docs/guides/dashboard/ingest-playback-url-pair"
+                          passHref>
+                          <A target="_blank">
+                            <i>
+                              Learn more about forgoing the global ingest and
+                              playback URLs before selecting a regional URL
+                              pair.
+                            </i>
+                          </A>
+                        </Link>
+                      </Box>
+                      {!ingest.length && (
+                        <Spinner sx={{ mb: 3, width: 32, height: 32 }} />
+                      )}
+                      {ingest.map((_, i) => {
+                        return (
+                          <>
+                            <Cell>RTMP ingest URL {i + 1}</Cell>
+                            <Cell>
+                              <ShowURL
+                                text=""
+                                url={getIngestURL(stream, false, i)}
+                                urlToCopy={getIngestURL(stream, false, i)}
+                                anchor={false}
+                              />
+                            </Cell>
+                            <Box
+                              sx={{
+                                m: "0.4em",
+                                mb: "1.4em",
+                              }}>
+                              Playback URL {i + 1}
+                            </Box>
+                            <Box
+                              sx={{
+                                m: "0.4em",
+                                mb: "1.4em",
+                              }}>
+                              <ShowURL
+                                text=""
+                                url={getPlaybackURL(stream, i)}
+                                anchor={true}
+                              />
+                            </Box>
+                          </>
+                        );
+                      })}
                     </Box>
-                    {!ingest.length && (
-                      <Spinner sx={{ mb: 3, width: 32, height: 32 }} />
-                    )}
-                    {ingest.map((_, i) => {
-                      return (
-                        <>
-                          <Cell>RTMP ingest URL {i + 1}</Cell>
-                          <Cell>
-                            <ShowURL
-                              text=""
-                              url={getIngestURL(stream, false, i)}
-                              urlToCopy={getIngestURL(stream, false, i)}
-                              anchor={false}
-                            />
-                          </Cell>
-                          <Box
-                            sx={{
-                              m: "0.4em",
-                              mb: "1.4em",
-                            }}>
-                            Playback URL {i + 1}
-                          </Box>
-                          <Box
-                            sx={{
-                              m: "0.4em",
-                              mb: "1.4em",
-                            }}>
-                            <ShowURL
-                              text=""
-                              url={getPlaybackURL(stream, i)}
-                              anchor={true}
-                            />
-                          </Box>
-                        </>
-                      );
-                    })}
                   </Box>
-                </Box>
-                <Box sx={{ m: "0.4em", gridColumn: "1/-1" }}>
-                  <hr />
-                </Box>
-                <Cell>Record sessions</Cell>
-                <Box
-                  sx={{
-                    m: "0.4em",
-                    justifySelf: "flex-start",
-                    cursor: "pointer",
-                  }}>
-                  <Flex
+                  <Box sx={{ m: "0.4em", gridColumn: "1/-1" }}>
+                    <hr />
+                  </Box>
+                  <Cell>Record sessions</Cell>
+                  <Box
                     sx={{
-                      alignItems: "flex-start",
-                      justifyItems: "center",
+                      m: "0.4em",
+                      justifySelf: "flex-start",
+                      cursor: "pointer",
                     }}>
-                    <Label
-                      onClick={() => {
-                        if (!stream.record) {
-                          doSetRecord(stream, true);
-                        }
-                      }}>
-                      <Radio
-                        autocomplete="off"
-                        name="record-mode"
-                        value={`${!!stream.record}`}
-                        checked={!!stream.record}
-                      />
-                      <Flex sx={{ alignItems: "center" }}>On</Flex>
-                    </Label>
-                    <Label sx={{ ml: "0.5em" }}>
-                      <Radio
-                        autocomplete="off"
-                        name="record-mode"
-                        value={`${!stream.record}`}
-                        checked={!stream.record}
-                        onClick={(e) => {
-                          if (stream.record) {
-                            setRecordOffModal(true);
-                          }
-                        }}
-                      />
-                      <Flex sx={{ alignItems: "center" }}>Off</Flex>
-                    </Label>
                     <Flex
                       sx={{
-                        ml: "0.5em",
-                        minWidth: "24px",
-                        height: "24px",
-                        alignItems: "center",
+                        alignItems: "flex-start",
+                        justifyItems: "center",
                       }}>
-                      <Help
-                        data-tip
-                        data-for={`tooltip-record-${stream.id}`}
+                      <Label
+                        onClick={() => {
+                          if (!stream.record) {
+                            doSetRecord(stream, true);
+                          }
+                        }}>
+                        <Radio
+                          autocomplete="off"
+                          name="record-mode"
+                          value={`${!!stream.record}`}
+                          checked={!!stream.record}
+                        />
+                        <Flex sx={{ alignItems: "center" }}>On</Flex>
+                      </Label>
+                      <Label sx={{ ml: "0.5em" }}>
+                        <Radio
+                          autocomplete="off"
+                          name="record-mode"
+                          value={`${!stream.record}`}
+                          checked={!stream.record}
+                          onClick={(e) => {
+                            if (stream.record) {
+                              setRecordOffModal(true);
+                            }
+                          }}
+                        />
+                        <Flex sx={{ alignItems: "center" }}>Off</Flex>
+                      </Label>
+                      <Flex
                         sx={{
-                          color: "muted",
-                          cursor: "pointer",
-                          ml: 1,
-                          width: "18px",
-                          height: "18px",
-                        }}
-                      />
+                          ml: "0.5em",
+                          minWidth: "24px",
+                          height: "24px",
+                          alignItems: "center",
+                        }}>
+                        <Help
+                          data-tip
+                          data-for={`tooltip-record-${stream.id}`}
+                          sx={{
+                            color: "muted",
+                            cursor: "pointer",
+                            ml: 1,
+                            width: "18px",
+                            height: "18px",
+                          }}
+                        />
+                      </Flex>
                     </Flex>
-                  </Flex>
-                  <ReactTooltip
-                    id={`tooltip-record-${stream.id}`}
-                    className="tooltip"
-                    place="top"
-                    type="dark"
-                    effect="solid">
-                    <p>
-                      When checked, transcoded streaming sessions will be
-                      recorded and stored by Livepeer.com.
-                      <br /> Each recorded session will have a recording .m3u8
-                      URL for playback and an MP4 download link.
-                      <br />
-                      This feature is currently free.
-                    </p>
-                  </ReactTooltip>
-                </Box>
-                <Box sx={{ m: "0.4em", gridColumn: "1/-1" }}>
-                  <hr />
-                </Box>
-                <Cell>Suspend and block</Cell>
-                <Box
-                  sx={{
-                    m: "0.4em",
-                    justifySelf: "flex-start",
-                    cursor: "pointer",
-                  }}>
-                  <Flex
+                    <ReactTooltip
+                      id={`tooltip-record-${stream.id}`}
+                      className="tooltip"
+                      place="top"
+                      type="dark"
+                      effect="solid">
+                      <p>
+                        When checked, transcoded streaming sessions will be
+                        recorded and stored by Livepeer.com.
+                        <br /> Each recorded session will have a recording .m3u8
+                        URL for playback and an MP4 download link.
+                        <br />
+                        This feature is currently free.
+                      </p>
+                    </ReactTooltip>
+                  </Box>
+                  <Box sx={{ m: "0.4em", gridColumn: "1/-1" }}>
+                    <hr />
+                  </Box>
+                  <Cell>Suspend and block</Cell>
+                  <Box
                     sx={{
-                      alignItems: "flex-start",
-                      justifyItems: "center",
+                      m: "0.4em",
+                      justifySelf: "flex-start",
+                      cursor: "pointer",
                     }}>
-                    <Label
-                      onClick={() => {
-                        if (!stream.suspended) {
-                          setSuspendModal(true);
-                        }
+                    <Flex
+                      sx={{
+                        alignItems: "flex-start",
+                        justifyItems: "center",
                       }}>
-                      <Radio
-                        autocomplete="off"
-                        name="suspend-mode"
-                        value={`${!!stream.suspended}`}
-                        checked={!!stream.suspended}
-                      />
-                      <Flex sx={{ alignItems: "center" }}>On</Flex>
-                    </Label>
-                    <Label sx={{ ml: "0.5em" }}>
-                      <Radio
-                        autocomplete="off"
-                        name="suspend-mode"
-                        value={`${!stream.suspended}`}
-                        checked={!stream.suspended}
-                        onClick={(e) => {
-                          if (stream.suspended) {
+                      <Label
+                        onClick={() => {
+                          if (!stream.suspended) {
                             setSuspendModal(true);
                           }
-                        }}
-                      />
-                      <Flex sx={{ alignItems: "center" }}>Off</Flex>
-                    </Label>
-                    <Flex
-                      sx={{
-                        ml: "0.5em",
-                        minWidth: "24px",
-                        height: "24px",
-                        alignItems: "center",
-                      }}>
-                      <Help
-                        data-tip
-                        data-for={`tooltip-suspend-${stream.id}`}
+                        }}>
+                        <Radio
+                          autocomplete="off"
+                          name="suspend-mode"
+                          value={`${!!stream.suspended}`}
+                          checked={!!stream.suspended}
+                        />
+                        <Flex sx={{ alignItems: "center" }}>On</Flex>
+                      </Label>
+                      <Label sx={{ ml: "0.5em" }}>
+                        <Radio
+                          autocomplete="off"
+                          name="suspend-mode"
+                          value={`${!stream.suspended}`}
+                          checked={!stream.suspended}
+                          onClick={(e) => {
+                            if (stream.suspended) {
+                              setSuspendModal(true);
+                            }
+                          }}
+                        />
+                        <Flex sx={{ alignItems: "center" }}>Off</Flex>
+                      </Label>
+                      <Flex
                         sx={{
-                          color: "muted",
-                          cursor: "pointer",
-                          ml: 1,
-                          width: "18px",
-                          height: "18px",
-                        }}
-                      />
+                          ml: "0.5em",
+                          minWidth: "24px",
+                          height: "24px",
+                          alignItems: "center",
+                        }}>
+                        <Help
+                          data-tip
+                          data-for={`tooltip-suspend-${stream.id}`}
+                          sx={{
+                            color: "muted",
+                            cursor: "pointer",
+                            ml: 1,
+                            width: "18px",
+                            height: "18px",
+                          }}
+                        />
+                      </Flex>
                     </Flex>
-                  </Flex>
-                  <ReactTooltip
-                    id={`tooltip-suspend-${stream.id}`}
-                    className="tooltip"
-                    place="top"
-                    type="dark"
-                    effect="solid">
-                    <p>
-                      When turned on, any active stream sessions will
-                      immediately end.
-                      <br />
-                      New sessions will be prevented from starting until turned
-                      off.
-                    </p>
-                  </ReactTooltip>
+                    <ReactTooltip
+                      id={`tooltip-suspend-${stream.id}`}
+                      className="tooltip"
+                      place="top"
+                      type="dark"
+                      effect="solid">
+                      <p>
+                        When turned on, any active stream sessions will
+                        immediately end.
+                        <br />
+                        New sessions will be prevented from starting until
+                        turned off.
+                      </p>
+                    </ReactTooltip>
+                  </Box>
+                  <Box sx={{ m: "0.4em", gridColumn: "1/-1" }}>
+                    <hr />
+                  </Box>
+                  <Cell>User</Cell>
+                  <Cell>{userField}</Cell>
+                  <Cell>Renditions</Cell>
+                  <Cell>
+                    <RenditionsDetails stream={stream} />
+                  </Cell>
+                  <Cell>Created at</Cell>
+                  <Cell>
+                    <RelativeTime
+                      id="cat"
+                      prefix="createdat"
+                      tm={stream.createdAt}
+                      swap={true}
+                    />
+                  </Cell>
+                  <Cell>Last seen</Cell>
+                  <Cell>
+                    <RelativeTime
+                      id="last"
+                      prefix="lastSeen"
+                      tm={stream.lastSeen}
+                      swap={true}
+                    />
+                  </Cell>
+                  <Cell>Status</Cell>
+                  <Cell>{stream.isActive ? "Active" : "Idle"}</Cell>
+                  <Cell>Suspended</Cell>
+                  <Cell>{stream.suspended ? "Yes" : " No"}</Cell>
+                  {user.admin || isStaging() || isDevelopment() ? (
+                    <>
+                      <Cell> </Cell>
+                      <Cell>
+                        <strong>Admin or staging only fields:</strong>
+                      </Cell>
+                    </>
+                  ) : null}
+                  {user.admin ? (
+                    <>
+                      <Cell> </Cell>
+                      <Cell>
+                        <strong>Admin only fields:</strong>
+                      </Cell>
+                      <Cell>Deleted</Cell>
+                      <Cell>
+                        {stream.deleted ? <strong>Yes</strong> : "No"}
+                      </Cell>
+                      <Cell>Source segments</Cell>
+                      <Cell>{stream.sourceSegments || 0}</Cell>
+                      <Cell>Transcoded segments</Cell>
+                      <Cell>{stream.transcodedSegments || 0}</Cell>
+                      <Cell>Source duration</Cell>
+                      <Cell>
+                        {formatNumber(stream.sourceSegmentsDuration || 0, 0)}{" "}
+                        sec (
+                        {formatNumber(
+                          (stream.sourceSegmentsDuration || 0) / 60,
+                          2
+                        )}{" "}
+                        min)
+                      </Cell>
+                      <Cell>Transcoded duration</Cell>
+                      <Cell>
+                        {formatNumber(
+                          stream.transcodedSegmentsDuration || 0,
+                          0
+                        )}{" "}
+                        sec (
+                        {formatNumber(
+                          (stream.transcodedSegmentsDuration || 0) / 60,
+                          2
+                        )}{" "}
+                        min)
+                      </Cell>
+                      <Cell>Source bytes</Cell>
+                      <Cell>{formatNumber(stream.sourceBytes || 0, 0)}</Cell>
+                      <Cell>Transcoded bytes</Cell>
+                      <Cell>
+                        {formatNumber(stream.transcodedBytes || 0, 0)}
+                      </Cell>
+                      <Cell>Ingest rate</Cell>
+                      <Cell>
+                        {formatNumber(stream.ingestRate || 0, 3)} bytes/sec (
+                        {formatNumber((stream.ingestRate || 0) * 8, 0)})
+                        bits/sec
+                      </Cell>
+                      <Cell>Outgoing rate</Cell>
+                      <Cell>
+                        {formatNumber(stream.outgoingRate || 0, 3)} bytes/sec (
+                        {formatNumber((stream.outgoingRate || 0) * 8, 0)})
+                        bits/sec
+                      </Cell>
+                      <Cell>Papertrail to stream key</Cell>
+                      <Cell>
+                        <Box
+                          as="a"
+                          target="_blank"
+                          href={`https://papertrailapp.com/groups/16613582/events?q=${stream.streamKey}`}
+                          sx={{ userSelect: "all" }}>
+                          {stream.streamKey}
+                        </Box>
+                      </Cell>
+                      <Cell>Papertrail to playback id</Cell>
+                      <Cell>
+                        <Box
+                          as="a"
+                          target="_blank"
+                          href={`https://papertrailapp.com/groups/16613582/events?q=${stream.playbackId}`}
+                          sx={{ userSelect: "all" }}>
+                          {stream.playbackId}
+                        </Box>
+                      </Cell>
+                      <Cell>Papertrail to stream id</Cell>
+                      <Cell>
+                        <Box
+                          as="a"
+                          target="_blank"
+                          href={`https://papertrailapp.com/groups/16613582/events?q=${stream.id}`}
+                          sx={{ userSelect: "all" }}>
+                          {stream.id}
+                        </Box>
+                      </Cell>
+                      <Cell>Region/Broadcaster</Cell>
+                      <Cell>
+                        {region}{" "}
+                        {broadcasterHost ? " / " + broadcasterHost : ""}
+                        {stream && stream.mistHost
+                          ? " / " + stream.mistHost
+                          : ""}
+                      </Cell>
+                      {broadcasterPlaybackUrl ? (
+                        <>
+                          <Cell>Broadcaster playback</Cell>
+                          <Cell>
+                            <Box
+                              as="a"
+                              target="_blank"
+                              href={broadcasterPlaybackUrl}
+                              sx={{ userSelect: "all" }}>
+                              {broadcasterPlaybackUrl}
+                            </Box>
+                          </Cell>
+                        </>
+                      ) : null}
+                    </>
+                  ) : null}
                 </Box>
-                <Box sx={{ m: "0.4em", gridColumn: "1/-1" }}>
-                  <hr />
+                <Box
+                  sx={{
+                    display: "block",
+                    alignItems: "center",
+                    width: "40%",
+                  }}>
+                  <iframe
+                    src={playerUrl}
+                    style={{ width: "100%", aspectRatio: "4 / 3" }}
+                    frameBorder="0"
+                    allowFullScreen
+                    allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+                    sandbox="allow-scripts"></iframe>
                 </Box>
-                <Cell>User</Cell>
-                <Cell>{userField}</Cell>
-                <Cell>Renditions</Cell>
-                <Cell>
-                  <RenditionsDetails stream={stream} />
-                </Cell>
-                <Cell>Created at</Cell>
-                <Cell>
-                  <RelativeTime
-                    id="cat"
-                    prefix="createdat"
-                    tm={stream.createdAt}
-                    swap={true}
-                  />
-                </Cell>
-                <Cell>Last seen</Cell>
-                <Cell>
-                  <RelativeTime
-                    id="last"
-                    prefix="lastSeen"
-                    tm={stream.lastSeen}
-                    swap={true}
-                  />
-                </Cell>
-                <Cell>Status</Cell>
-                <Cell>{stream.isActive ? "Active" : "Idle"}</Cell>
-                <Cell>Suspended</Cell>
-                <Cell>{stream.suspended ? "Yes" : " No"}</Cell>
-                {user.admin || isStaging() || isDevelopment() ? (
-                  <>
-                    <Cell> </Cell>
-                    <Cell>
-                      <strong>Admin or staging only fields:</strong>
-                    </Cell>
-                  </>
-                ) : null}
-                {user.admin ? (
-                  <>
-                    <Cell> </Cell>
-                    <Cell>
-                      <strong>Admin only fields:</strong>
-                    </Cell>
-                    <Cell>Deleted</Cell>
-                    <Cell>{stream.deleted ? <strong>Yes</strong> : "No"}</Cell>
-                    <Cell>Source segments</Cell>
-                    <Cell>{stream.sourceSegments || 0}</Cell>
-                    <Cell>Transcoded segments</Cell>
-                    <Cell>{stream.transcodedSegments || 0}</Cell>
-                    <Cell>Source duration</Cell>
-                    <Cell>
-                      {formatNumber(stream.sourceSegmentsDuration || 0, 0)} sec
-                      (
-                      {formatNumber(
-                        (stream.sourceSegmentsDuration || 0) / 60,
-                        2
-                      )}{" "}
-                      min)
-                    </Cell>
-                    <Cell>Transcoded duration</Cell>
-                    <Cell>
-                      {formatNumber(stream.transcodedSegmentsDuration || 0, 0)}{" "}
-                      sec (
-                      {formatNumber(
-                        (stream.transcodedSegmentsDuration || 0) / 60,
-                        2
-                      )}{" "}
-                      min)
-                    </Cell>
-                    <Cell>Source bytes</Cell>
-                    <Cell>{formatNumber(stream.sourceBytes || 0, 0)}</Cell>
-                    <Cell>Transcoded bytes</Cell>
-                    <Cell>{formatNumber(stream.transcodedBytes || 0, 0)}</Cell>
-                    <Cell>Ingest rate</Cell>
-                    <Cell>
-                      {formatNumber(stream.ingestRate || 0, 3)} bytes/sec (
-                      {formatNumber((stream.ingestRate || 0) * 8, 0)}) bits/sec
-                    </Cell>
-                    <Cell>Outgoing rate</Cell>
-                    <Cell>
-                      {formatNumber(stream.outgoingRate || 0, 3)} bytes/sec (
-                      {formatNumber((stream.outgoingRate || 0) * 8, 0)})
-                      bits/sec
-                    </Cell>
-                    <Cell>Papertrail to stream key</Cell>
-                    <Cell>
-                      <Box
-                        as="a"
-                        target="_blank"
-                        href={`https://papertrailapp.com/groups/16613582/events?q=${stream.streamKey}`}
-                        sx={{ userSelect: "all" }}>
-                        {stream.streamKey}
-                      </Box>
-                    </Cell>
-                    <Cell>Papertrail to playback id</Cell>
-                    <Cell>
-                      <Box
-                        as="a"
-                        target="_blank"
-                        href={`https://papertrailapp.com/groups/16613582/events?q=${stream.playbackId}`}
-                        sx={{ userSelect: "all" }}>
-                        {stream.playbackId}
-                      </Box>
-                    </Cell>
-                    <Cell>Papertrail to stream id</Cell>
-                    <Cell>
-                      <Box
-                        as="a"
-                        target="_blank"
-                        href={`https://papertrailapp.com/groups/16613582/events?q=${stream.id}`}
-                        sx={{ userSelect: "all" }}>
-                        {stream.id}
-                      </Box>
-                    </Cell>
-                    <Cell>Region/Broadcaster</Cell>
-                    <Cell>
-                      {region} {broadcasterHost ? " / " + broadcasterHost : ""}
-                      {stream && stream.mistHost ? " / " + stream.mistHost : ""}
-                    </Cell>
-                    {broadcasterPlaybackUrl ? (
-                      <>
-                        <Cell>Broadcaster playback</Cell>
-                        <Cell>
-                          <Box
-                            as="a"
-                            target="_blank"
-                            href={broadcasterPlaybackUrl}
-                            sx={{ userSelect: "all" }}>
-                            {broadcasterPlaybackUrl}
-                          </Box>
-                        </Cell>
-                      </>
-                    ) : null}
-                  </>
-                ) : null}
-              </Box>
+              </Flex>
+              <TimedAlert
+                text={resultText}
+                close={() => setResultText("")}
+                variant="info"
+              />
+              <TimedAlert
+                text={alertText}
+                close={() => setAlertText("")}
+                variant="attention"
+              />
             </Flex>
-            <TimedAlert
-              text={resultText}
-              close={() => setResultText("")}
-              variant="info"
-            />
-            <TimedAlert
-              text={alertText}
-              close={() => setAlertText("")}
-              variant="attention"
-            />
             <Flex
               sx={{
                 justifyContent: "flex-end",

--- a/packages/www/pages/app/stream/[id].tsx
+++ b/packages/www/pages/app/stream/[id].tsx
@@ -22,7 +22,7 @@ import Copy from "../../../public/img/copy.svg";
 import { useRouter } from "next/router";
 import Router from "next/router";
 import { useApi, usePageVisibility } from "../../../hooks";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import TabbedLayout from "@components/Admin/TabbedLayout";
 import StreamSessionsTable from "@components/Admin/StreamSessionsTable";
 import DeleteStreamModal from "@components/Admin/DeleteStreamModal";
@@ -262,6 +262,16 @@ const ID = () => {
     const interval = setInterval(() => fetchStream(id), 5000);
     return () => clearInterval(interval);
   }, [id, fetchStream, isVisible]);
+  const userField = useMemo(() => {
+    let value = streamOwner?.email;
+    if (streamOwner?.admin) {
+      value = `${value} (admin)`;
+    }
+    if (streamOwner?.suspended) {
+      value = `${value} (suspended)`;
+    }
+    return value;
+  }, [streamOwner?.email, streamOwner?.admin, streamOwner?.suspended]);
   const [keyRevealed, setKeyRevealed] = useState(false);
   const close = () => {
     setSuspendModal(false);
@@ -757,6 +767,8 @@ const ID = () => {
                 <Box sx={{ m: "0.4em", gridColumn: "1/-1" }}>
                   <hr />
                 </Box>
+                <Cell>User</Cell>
+                <Cell>{userField}</Cell>
                 <Cell>Renditions</Cell>
                 <Cell>
                   <RenditionsDetails stream={stream} />
@@ -782,7 +794,7 @@ const ID = () => {
                 <Cell>Status</Cell>
                 <Cell>{stream.isActive ? "Active" : "Idle"}</Cell>
                 <Cell>Suspended</Cell>
-                <Cell>{stream.suspended ? "Suspended" : "Normal"}</Cell>
+                <Cell>{stream.suspended ? "Yes" : " No"}</Cell>
                 {user.admin || isStaging() || isDevelopment() ? (
                   <>
                     <Cell> </Cell>

--- a/packages/www/pages/app/stream/[id].tsx
+++ b/packages/www/pages/app/stream/[id].tsx
@@ -235,7 +235,10 @@ const ID = () => {
       })
       .catch((err) => console.error(err)); // todo: surface this
   }, [id]);
-  const fetchStream = useCallback(async (id: string) => {
+  const fetchStream = useCallback(async () => {
+    if (!id) {
+      return;
+    }
     try {
       const [res, info] = await getStreamInfo(id);
       if (res.status === 404) {
@@ -248,20 +251,18 @@ const ID = () => {
     } catch (err) {
       console.error(err); // todo: surface this
     }
-  }, []);
+  }, [id]);
   useEffect(() => {
-    if (id) {
-      fetchStream(id);
-    }
-  }, [id, fetchStream]);
+    fetchStream();
+  }, [fetchStream]);
   const isVisible = usePageVisibility();
   useEffect(() => {
-    if (!isVisible || !id || notFound) {
+    if (!isVisible || notFound) {
       return;
     }
-    const interval = setInterval(() => fetchStream(id), 5000);
+    const interval = setInterval(fetchStream, 5000);
     return () => clearInterval(interval);
-  }, [id, fetchStream, isVisible]);
+  }, [fetchStream, isVisible, notFound]);
   const userField = useMemo(() => {
     let value = streamOwner?.email;
     if (streamOwner?.admin) {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This is to make it easier to inspect a given running stream and nuking (suspending) the user.

It allows all that to be done from the same stream detail page, by having an embedded player in
there and adding a button to suspend the user. Additionally, page can now be opened with the
playback ID of the stream, making it easier to go from alert to moderation page (alerts can even 
link to it directly).

**Specific updates (required)**
 - Create separate "SuspendUserModal" component to be reused
 - Created suspend user button in the bottom of page
 - Stream detail page made addressable by playback ID
 - Added embedded player in the page to check the content (autoplay off by default, can enable on querystring)

## -

- **How did you test each of these updates (required)**
Open stream detail page and check player works, check suspending the user works.

**Does this pull request close any open issues?**
No.

**Screenshots (optional):**
<img width="842" alt="Screen Shot 2022-05-18 at 20 14 18" src="https://user-images.githubusercontent.com/1613383/169170258-8ee88dea-0b4d-41fc-9c16-e246a47d7646.png">

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
