### PR TITLE
www: Fix component imports in admin users table

### DIFF
--- a/packages/www/components/Admin/UserTable/index.tsx
+++ b/packages/www/components/Admin/UserTable/index.tsx
@@ -2,19 +2,11 @@
 import { jsx } from "theme-ui";
 import { useState, useMemo } from "react";
 import { useApi } from "hooks";
+import { Button, Flex, Container, Select } from "@theme-ui/components";
 import Modal from "../Modal";
 import { products } from "@livepeer.com/api/src/config";
 import CommonAdminTable from "@components/Admin/CommonAdminTable";
-import {
-  Button,
-  Flex,
-  Container,
-  Select,
-  Box,
-  Checkbox,
-  Label,
-  Tooltip,
-} from "@livepeer/design-system";
+import { Box, Checkbox, Label, Tooltip } from "@livepeer/design-system";
 
 type UserTableProps = {
   userId: string;


### PR DESCRIPTION
This fixes a regression caused by: https://github.com/livepeer/livepeer-com/pull/1032

Turns out we are mixing @theme-ui/components with the
@livepeer/design-system in that page.

We should probably migrate everything to design system
altogether, but while we don't do that let's keep it
working as before.

![image](https://user-images.githubusercontent.com/1613383/169119927-54e071bf-3b2a-4d1b-ad39-27bb10f2ed6f.png)
