### PR TITLE
api: New API to get playback URL from an identifier

### DIFF
--- a/packages/api/src/app-router.ts
+++ b/packages/api/src/app-router.ts
@@ -159,7 +159,10 @@ export default async function makeApp(params: CliArgs) {
   app.use(
     authenticateWithCors({
       cors: {
-        anyOriginPathPrefixes: [pathJoin("/", httpPrefix, "/asset/upload/")],
+        anyOriginPathPrefixes: [
+          pathJoin("/", httpPrefix, "/asset/upload/"),
+          pathJoin("/", httpPrefix, "/playback/"),
+        ],
         jwtOrigin: corsJwtAllowlist,
         baseOpts: {
           credentials: true,

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -97,20 +97,25 @@ async function validateAssetPayload(
   };
 }
 
+export function getPlaybackUrl(ingest: string, asset: WithID<Asset>): string {
+  if (!asset.playbackRecordingId) {
+    return undefined;
+  }
+  return pathJoin(
+    ingest,
+    "recordings",
+    asset.playbackRecordingId,
+    "index.m3u8"
+  );
+}
+
 function withPlaybackUrls(asset: WithID<Asset>, ingest: string): WithID<Asset> {
   if (asset.status.phase !== "ready") {
     return asset;
   }
-  if (asset.playbackRecordingId) {
-    asset.playbackUrl = pathJoin(
-      ingest,
-      "recordings",
-      asset.playbackRecordingId,
-      "index.m3u8"
-    );
-  }
   return {
     ...asset,
+    playbackUrl: getPlaybackUrl(ingest, asset),
     downloadUrl: pathJoin(ingest, "asset", asset.playbackId, "video"),
   };
 }

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -109,7 +109,7 @@ export function getPlaybackUrl(ingest: string, asset: WithID<Asset>): string {
   );
 }
 
-function withPlaybackUrls(asset: WithID<Asset>, ingest: string): WithID<Asset> {
+function withPlaybackUrls(ingest: string, asset: WithID<Asset>): WithID<Asset> {
   if (asset.status.phase !== "ready") {
     return asset;
   }
@@ -209,8 +209,8 @@ app.use(
     const ingest = ingests[0].base;
     const toExternalAsset = (a: WithID<Asset>) =>
       req.user.admin
-        ? withPlaybackUrls(a, ingest)
-        : db.asset.cleanWriteOnlyResponse(withPlaybackUrls(a, ingest));
+        ? withPlaybackUrls(ingest, a)
+        : db.asset.cleanWriteOnlyResponse(withPlaybackUrls(ingest, a));
 
     if (Array.isArray(data)) {
       return data.map(toExternalAsset);

--- a/packages/api/src/controllers/index.js
+++ b/packages/api/src/controllers/index.js
@@ -18,6 +18,7 @@ import usage from "./usage";
 import region from "./region";
 import session from "./session";
 import cdnData from "./cdn-data";
+import playback from "./playback";
 
 // Annoying but necessary to get the routing correct
 export default {
@@ -41,4 +42,5 @@ export default {
   usage,
   session,
   "cdn-data": cdnData,
+  playback,
 };

--- a/packages/api/src/controllers/playback.test.ts
+++ b/packages/api/src/controllers/playback.test.ts
@@ -1,0 +1,230 @@
+import serverPromise, { TestServer } from "../test-server";
+import { TestClient, clearDatabase, setupUsers } from "../test-helpers";
+import { Asset, User } from "../schema/types";
+import { db } from "../store";
+import { DBStream } from "../store/stream-table";
+import { WithID } from "../store/types";
+import { DBSession } from "../store/db";
+
+let server: TestServer;
+let ingest: string;
+let mockAdminUserInput: User;
+let mockNonAdminUserInput: User;
+
+// jest.setTimeout(70000)
+
+beforeAll(async () => {
+  server = await serverPromise;
+  ingest = JSON.parse(server.ingest)[0].base;
+
+  mockAdminUserInput = {
+    email: "user_admin@gmail.com",
+    password: "x".repeat(64),
+  };
+
+  mockNonAdminUserInput = {
+    email: "user_non_admin@gmail.com",
+    password: "y".repeat(64),
+  };
+});
+
+afterEach(async () => {
+  await clearDatabase(server);
+});
+
+describe("controllers/playback", () => {
+  describe("fetching playback URL of different objects", () => {
+    let client: TestClient;
+    let nonAdminToken: string;
+
+    let stream: DBStream;
+    let session: DBStream;
+    let userSession: DBSession;
+    let asset: WithID<Asset>;
+
+    beforeEach(async () => {
+      await db.objectStore.create({
+        id: "mock_vod_store",
+        url: "http://user:password@localhost:8080/us-east-1/vod",
+      });
+
+      ({ client, nonAdminToken } = await setupUsers(
+        server,
+        mockAdminUserInput,
+        mockNonAdminUserInput
+      ));
+      client.jwtAuth = nonAdminToken;
+
+      let res = await client.post("/stream", {
+        name: "test-stream",
+      });
+      expect(res.status).toBe(201);
+      stream = await res.json();
+
+      res = await client.post("/asset/request-upload", {
+        name: "test-session",
+      });
+      expect(res.status).toBe(200);
+      ({ asset } = await res.json());
+
+      res = await client.post(`/stream/${stream.id}/stream`, {
+        name: "test-recording",
+      });
+      expect(res.status).toBe(201);
+      session = await res.json();
+      expect(session).toMatchObject({ id: expect.any(String) });
+
+      userSession = await client
+        .get(`/session/${session.id}`)
+        .then((res) => res.json());
+      expect(userSession).toMatchObject({
+        id: session.id,
+        playbackId: stream.playbackId,
+      });
+
+      // API should be open without any auth
+      client.jwtAuth = null;
+    });
+
+    describe("for streams", () => {
+      it("should return playback URL for streams", async () => {
+        const res = await client.get(`/playback/${stream.playbackId}`);
+        expect(res.status).toBe(200);
+        await expect(res.json()).resolves.toMatchObject({
+          type: "live",
+          meta: {
+            live: 0,
+            source: [
+              {
+                hrn: "HLS (TS)",
+                type: "html5/application/vnd.apple.mpegurl",
+                url: `${ingest}/hls/${stream.playbackId}/index.m3u8`,
+              },
+            ],
+          },
+        });
+      });
+
+      it("should indicate active streams in live field", async () => {
+        await db.stream.update(stream.id, { isActive: true });
+
+        const res = await client.get(`/playback/${stream.playbackId}`);
+        expect(res.status).toBe(200);
+        await expect(res.json()).resolves.toMatchObject({
+          type: "live",
+          meta: {
+            live: 1,
+          },
+        });
+      });
+    });
+
+    describe("for assets", () => {
+      it("should return clean 404 for assets without playback recording", async () => {
+        const res = await client.get(`/playback/${asset.playbackId}`);
+        expect(res.status).toBe(404);
+      });
+
+      it("should return playback URL for assets", async () => {
+        await db.asset.update(asset.id, {
+          playbackRecordingId: "mock_recording_id",
+        });
+        const res = await client.get(`/playback/${asset.playbackId}`);
+        expect(res.status).toBe(200);
+        await expect(res.json()).resolves.toMatchObject({
+          type: "vod",
+          meta: {
+            source: [
+              {
+                hrn: "HLS (TS)",
+                type: "html5/application/vnd.apple.mpegurl",
+                url: `${ingest}/recordings/mock_recording_id/index.m3u8`,
+              },
+            ],
+          },
+        });
+      });
+    });
+
+    describe("for recordings", () => {
+      it("should return 404 for unrecorded streams and sessions", async () => {
+        let res = await client.get(`/playback/${stream.id}`);
+        expect(res.status).toBe(404);
+        res = await client.get(`/playback/${session.id}`);
+        expect(res.status).toBe(404);
+        res = await client.get(`/playback/${userSession.id}`);
+        expect(res.status).toBe(404);
+      });
+
+      it("should return 404 for recorded sessions without recording ready", async () => {
+        await db.stream.update(session.id, { record: true });
+        let res = await client.get(`/playback/${session.id}`);
+        expect(res.status).toBe(404);
+
+        await db.stream.update(session.id, {
+          recordObjectStoreId: "mock_store",
+        });
+        res = await client.get(`/playback/${session.id}`);
+        expect(res.status).toBe(404);
+
+        await db.stream.update(session.id, { lastSeen: Date.now() });
+        res = await client.get(`/playback/${session.id}`);
+        expect(res.status).toBe(404);
+      });
+
+      it("should return playback URL for sessions with recording ready", async () => {
+        await db.stream.update(session.id, {
+          record: true,
+          recordObjectStoreId: "mock_store",
+          lastSeen: Date.now() - 60 * 60 * 1000,
+        });
+        const res = await client.get(`/playback/${session.id}`);
+        expect(res.status).toBe(200);
+        await expect(res.json()).resolves.toMatchObject({
+          type: "recording",
+          meta: {
+            source: [
+              {
+                hrn: "HLS (TS)",
+                type: "html5/application/vnd.apple.mpegurl",
+                url: `${ingest}/recordings/${session.id}/index.m3u8`,
+              },
+            ],
+          },
+        });
+      });
+    });
+
+    it("should return playback URL for user sessions", async () => {
+      await db.session.update(userSession.id, {
+        record: true,
+        recordObjectStoreId: "mock_store",
+        lastSeen: Date.now() - 60 * 60 * 1000,
+      });
+      const res = await client.get(`/playback/${userSession.id}`);
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toMatchObject({
+        type: "recording",
+      });
+    });
+
+    it("should return playback URL for top-level streams", async () => {
+      await db.stream.update(stream.id, {
+        record: true,
+        recordObjectStoreId: "mock_store",
+        lastSeen: Date.now() - 60 * 60 * 1000,
+      });
+      let res = await client.get(`/playback/${stream.id}`);
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toMatchObject({
+        type: "recording",
+      });
+
+      res = await client.get(`/playback/${stream.playbackId}`);
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toMatchObject({
+        type: "live",
+      });
+    });
+  });
+});

--- a/packages/api/src/controllers/playback.ts
+++ b/packages/api/src/controllers/playback.ts
@@ -6,7 +6,6 @@ import {
 } from "./stream";
 import { getPlaybackUrl as assetPlaybackUrl } from "./asset";
 import { NotFoundError } from "@cloudflare/kv-asset-handler";
-import { SSEKMS } from "@aws-sdk/client-s3";
 
 // This should be compatible with the Mist format: https://gist.github.com/iameli/3e9d20c2b7f11365ea8785c5a8aa6aa6
 type PlaybackInfo = {

--- a/packages/api/src/controllers/playback.ts
+++ b/packages/api/src/controllers/playback.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { db } from "../store";
 import {
   getPlaybackUrl as streamPlaybackUrl,
-  setRecordingStatus as setRecordingPlaybackUrl,
+  getRecordingFields,
 } from "./stream";
 import { getPlaybackUrl as assetPlaybackUrl } from "./asset";
 import { NotFoundError } from "@cloudflare/kv-asset-handler";
@@ -63,9 +63,11 @@ async function getPlaybackInfo(
 
   const recordingPlaybackUrl = async (table: Table<DBSession>) => {
     const session = await table.get(id);
-    if (!session || session.deleted) return null;
-    setRecordingPlaybackUrl(ingest, session, false);
-    return session.recordingUrl;
+    if (!session || session.deleted) {
+      return null;
+    }
+    const { recordingUrl } = getRecordingFields(ingest, session, false);
+    return recordingUrl;
   };
   const recordingUrl =
     (await recordingPlaybackUrl(db.session)) ??

--- a/packages/api/src/controllers/playback.ts
+++ b/packages/api/src/controllers/playback.ts
@@ -1,0 +1,81 @@
+import { Router } from "express";
+import { db } from "../store";
+import {
+  getPlaybackUrl as streamPlaybackUrl,
+  getRecordingUrl as recordingPlaybackUrl,
+} from "./stream";
+import { getPlaybackUrl as assetPlaybackUrl } from "./asset";
+import { NotFoundError } from "@cloudflare/kv-asset-handler";
+import { SSEKMS } from "@aws-sdk/client-s3";
+
+// This should be compatible with the Mist format: https://gist.github.com/iameli/3e9d20c2b7f11365ea8785c5a8aa6aa6
+type PlaybackInfo = {
+  type: "live" | "vod" | "recording";
+  meta: {
+    live?: 0 | 1;
+    source: {
+      // the only supported format is HLS for now
+      hrn: "HLS (TS)";
+      type: "html5/application/vnd.apple.mpegurl";
+      url: string;
+    }[];
+  };
+};
+
+const newPlaybackInfo = (
+  type: PlaybackInfo["type"],
+  hlsUrl: string,
+  live?: PlaybackInfo["meta"]["live"]
+): PlaybackInfo => ({
+  type,
+  meta: {
+    live,
+    source: [
+      {
+        hrn: "HLS (TS)",
+        type: "html5/application/vnd.apple.mpegurl",
+        url: hlsUrl,
+      },
+    ],
+  },
+});
+
+async function getPlaybackInfo(
+  ingest: string,
+  id: string
+): Promise<PlaybackInfo> {
+  const stream = await db.stream.getByPlaybackId(id);
+  if (stream && !stream.deleted) {
+    return newPlaybackInfo(
+      "live",
+      streamPlaybackUrl(ingest, stream),
+      stream.isActive ? 1 : 0
+    );
+  }
+  const asset = await db.asset.getByPlaybackId(id);
+  if (asset && !asset.deleted) {
+    return newPlaybackInfo("vod", assetPlaybackUrl(ingest, asset));
+  }
+  const session = (await db.session.get(id)) ?? (await db.stream.get(id));
+  if (session?.record && !session.deleted) {
+    return newPlaybackInfo("recording", recordingPlaybackUrl(ingest, session));
+  }
+  throw new NotFoundError(`No playback URL found for ${id}`);
+}
+
+const app = Router();
+
+app.get("/:id", async (req, res) => {
+  const ingests = await req.getIngest();
+  if (!ingests.length) {
+    res.status(501);
+    return res.json({ errors: ["Ingest not configured"] });
+  }
+  const ingest = ingests[0].base;
+
+  let { id } = req.params;
+  const info = await getPlaybackInfo(ingest, id);
+  res.status(200).json(info);
+});
+
+export default app;

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -333,7 +333,7 @@ export function getRecordingFields(
       };
 }
 
-function withRecordingFields(
+export function withRecordingFields(
   ingest: string,
   session: DBSession,
   forceUrl: boolean

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -318,8 +318,7 @@ app.get("/", authorizer({}), async (req, res) => {
   );
 });
 
-function setRecordingStatus(
-  req: Request,
+export function setRecordingStatus(
   ingest: string,
   session: DBSession,
   forceUrl: boolean
@@ -386,7 +385,7 @@ app.get(
 
     const olderThen = Date.now() - USER_SESSION_TIMEOUT;
     sessions = sessions.map((session) => {
-      setRecordingStatus(req, ingest, session, !!forceUrl);
+      setRecordingStatus(ingest, session, !!forceUrl);
       if (!raw) {
         if (session.previousSessions && session.previousSessions.length) {
           session.id = session.previousSessions[0]; // return id of the first session object so
@@ -530,7 +529,7 @@ app.get("/:id", authorizer({ allowCorsApiKey: true }), async (req, res) => {
     const ingests = await req.getIngest();
     if (ingests.length) {
       const ingest = ingests[0].base;
-      setRecordingStatus(req, ingest, stream, false);
+      setRecordingStatus(ingest, stream, false);
     }
   }
   res.status(200);

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -158,6 +158,10 @@ async function triggerManyIdleStreamsWebhook(ids: string[], queue: Queue) {
   );
 }
 
+export function getPlaybackUrl(ingest: string, stream: DBStream) {
+  return pathJoin(ingest, `hls`, stream.playbackId, `index.m3u8`);
+}
+
 export function getRecordingUrl(
   ingest: string,
   session: DBSession,
@@ -168,7 +172,7 @@ export function getRecordingUrl(
     `recordings`,
     session.lastSessionId ? session.lastSessionId : session.id,
     mp4 ? `source.mp4` : `index.m3u8`
-  ) as string;
+  );
 }
 
 function isActuallyNotActive(stream: DBStream) {

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -162,11 +162,7 @@ export function getPlaybackUrl(ingest: string, stream: DBStream) {
   return pathJoin(ingest, `hls`, stream.playbackId, `index.m3u8`);
 }
 
-export function getRecordingUrl(
-  ingest: string,
-  session: DBSession,
-  mp4 = false
-) {
+function getRecordingUrl(ingest: string, session: DBSession, mp4 = false) {
   return pathJoin(
     ingest,
     `recordings`,
@@ -318,20 +314,34 @@ app.get("/", authorizer({}), async (req, res) => {
   );
 });
 
-export function setRecordingStatus(
+export function getRecordingFields(
   ingest: string,
   session: DBSession,
   forceUrl: boolean
-) {
-  const olderThen = Date.now() - USER_SESSION_TIMEOUT;
-  if (session.record && session.recordObjectStoreId && session.lastSeen > 0) {
-    const isReady = session.lastSeen > 0 && session.lastSeen < olderThen;
-    session.recordingStatus = isReady ? "ready" : "waiting";
-    if (isReady || forceUrl) {
-      session.recordingUrl = getRecordingUrl(ingest, session);
-      session.mp4Url = getRecordingUrl(ingest, session, true);
-    }
+): Pick<DBSession, "recordingStatus" | "recordingUrl" | "mp4Url"> {
+  if (!session.record || !session.recordObjectStoreId || !session.lastSeen) {
+    return {};
   }
+  const readyThreshold = Date.now() - USER_SESSION_TIMEOUT;
+  const isReady = session.lastSeen > 0 && session.lastSeen < readyThreshold;
+  return !isReady && !forceUrl
+    ? { recordingStatus: "waiting" }
+    : {
+        recordingStatus: isReady ? "ready" : "waiting",
+        recordingUrl: getRecordingUrl(ingest, session),
+        mp4Url: getRecordingUrl(ingest, session, true),
+      };
+}
+
+function withRecordingFields(
+  ingest: string,
+  session: DBSession,
+  forceUrl: boolean
+): DBSession {
+  return {
+    ...session,
+    ...getRecordingFields(ingest, session, forceUrl),
+  };
 }
 
 // returns only 'user' sessions and adds
@@ -383,9 +393,8 @@ app.get(
       cursor,
     });
 
-    const olderThen = Date.now() - USER_SESSION_TIMEOUT;
     sessions = sessions.map((session) => {
-      setRecordingStatus(ingest, session, !!forceUrl);
+      session = withRecordingFields(ingest, session, !!forceUrl);
       if (!raw) {
         if (session.previousSessions && session.previousSessions.length) {
           session.id = session.previousSessions[0]; // return id of the first session object so
@@ -529,7 +538,7 @@ app.get("/:id", authorizer({ allowCorsApiKey: true }), async (req, res) => {
     const ingests = await req.getIngest();
     if (ingests.length) {
       const ingest = ingests[0].base;
-      setRecordingStatus(ingest, stream, false);
+      stream = withRecordingFields(ingest, stream, false);
     }
   }
   res.status(200);

--- a/packages/api/src/store/asset-table.ts
+++ b/packages/api/src/store/asset-table.ts
@@ -1,11 +1,13 @@
 import { QueryResult } from "pg";
-import { SQLStatement } from "sql-template-strings";
+import sql, { SQLStatement } from "sql-template-strings";
 import { Asset } from "../schema/types";
 import Table from "./table";
 import {
+  DBLegacyObject,
   FindOptions,
   FindQuery,
   GetOptions,
+  QueryOptions,
   UpdateOptions,
   WithID,
 } from "./types";
@@ -91,5 +93,18 @@ export default class AssetTable extends Table<DBAsset> {
     opts?: UpdateOptions
   ): Promise<QueryResult<unknown>> {
     return super.update(query, doc, opts);
+  }
+
+  async getByPlaybackId(
+    playbackId: string,
+    opts?: QueryOptions
+  ): Promise<WithID<Asset>> {
+    const res: QueryResult<DBLegacyObject> = await this.db.queryWithOpts(
+      sql`SELECT id, data FROM ${this.name} WHERE data->>'playbackId'=${playbackId}`.setName(
+        `${this.name}_by_playbackid`
+      ),
+      opts
+    );
+    return res.rowCount < 1 ? null : (res.rows[0].data as WithID<Asset>);
   }
 }

--- a/packages/api/src/store/asset-table.ts
+++ b/packages/api/src/store/asset-table.ts
@@ -100,11 +100,14 @@ export default class AssetTable extends Table<DBAsset> {
     opts?: QueryOptions
   ): Promise<WithID<Asset>> {
     const res: QueryResult<DBLegacyObject> = await this.db.queryWithOpts(
-      sql`SELECT id, data FROM ${this.name} WHERE data->>'playbackId'=${playbackId}`.setName(
+      sql`SELECT id, data FROM asset WHERE data->>'playbackId' = ${playbackId}`.setName(
         `${this.name}_by_playbackid`
       ),
       opts
     );
-    return res.rowCount < 1 ? null : (res.rows[0].data as WithID<Asset>);
+    if (res.rowCount < 1) {
+      return null;
+    }
+    return assetStatusCompat(res.rows[0].data as WithID<Asset>);
   }
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

This creates an API to facilitate and create a consistent interface for creating a playback URL
given an identifier. It could be either a stream or asset playback ID, or also a recorded session
ID and it will return a response in the same format containing the corresponding HLS playback URL.

The context for this is the creation of the Lens publication video NFTs with an embeddable HLS player.
Ideally the NFT would have no internal identifiers from livepeer.com, maybe referencing assets by their
CIDs instead. While we don't do that, we can at least simplify that internal identifier and only provide a
playback ID (additionally from the CID of the original file). The playback ID will be used to playback 
a pre-processed version of the video in an optimized format. 

Having this API also makes these NFTs future-proof, since we will be able to change their format without
it breaking every previously minted NFT that had the broken references. The reference will be only a simple
playback ID and we can change the response of that API freely.

This also has a soft dependency on #1051 but they can be deployed independently. It's also based on top of
#1014 but I believe it can also be rebased, no strict dependencies in the code.

**Specific updates (required)**
 - Create new API for resolving the playback URL
 - Add tests 🙌 

## -

- **How did you test each of these updates (required)**
`yarn test` ✨ 

**Does this pull request close any open issues?**

Implements #1058

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
