### PR TITLE
Split trusted/untrusted across all nodes, rather than within a region

### DIFF
--- a/packages/api/src/controllers/region.js
+++ b/packages/api/src/controllers/region.js
@@ -7,9 +7,11 @@ const defaultScore = 1;
 const app = Router();
 
 function flatRegions(regions = [], halfRegionOrchestratorsUntrusted = false) {
+  let count = 0;
   return regions.flatMap((reg) =>
-    reg.orchestrators.map((orch, i) => ({
-      score: halfRegionOrchestratorsUntrusted && i % 2 == 0 ? 0 : defaultScore,
+    reg.orchestrators.map((orch) => ({
+      score:
+        halfRegionOrchestratorsUntrusted && count++ % 2 == 0 ? 0 : defaultScore,
       region: reg.region,
       ...orch,
     }))


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Follow-on PR from https://github.com/livepeer/livepeer-com/pull/1064. That PR marks 50% of Os within a region as untrusted, but the actual desired behaviour was an overall 50/50 split.

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

## -

**How did you test each of these updates (required)**

Deployed to Staging and hit the `/region` API endpoint to test

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
