### PR TITLE
api: Optimize recording assets generation

### DIFF
--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -168,7 +168,7 @@ function getRecordingUrl(ingest: string, session: DBSession, mp4 = false) {
   return pathJoin(
     ingest,
     `recordings`,
-    session.lastSessionId ? session.lastSessionId : session.id,
+    session.lastSessionId ?? session.id,
     mp4 ? `source.mp4` : `index.m3u8`
   );
 }
@@ -968,7 +968,7 @@ const sendSetActiveHooks = async (
             streamId: stream.id,
             event: "recording.ready",
             userId: stream.userId,
-            sessionId: session.id,
+            sessionId: session.lastSessionId ?? session.id,
             payload: {
               recordingUrl,
               mp4Url,

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1243,6 +1243,12 @@ components:
                   type: string
                   description: URL of the asset to import
                   example: https://cdn.livepeer.com/ABC123/filename.mp4
+                recordedSessionId:
+                  type: string
+                  description:
+                    ID of the original recorded session to avoid re-transcoding
+                    of the same content.
+                  example: 78df0075-b5f3-4683-a618-1086faca35dc
                 uploadedObjectKey:
                   type: string
                   description: S3 object key of the uploaded asset

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -522,12 +522,12 @@ export default class WebhookCannon {
       },
       this.queue
     );
-
-    const task = await this.taskScheduler.scheduleTask(
+    await this.taskScheduler.scheduleTask(
       "import",
       {
         import: {
           url: mp4RecordingUrl,
+          recordedSessionId: sessionId,
         },
       },
       undefined,


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.com/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Implements the API side of: https://github.com/livepeer/task-runner/pull/45

We should avoid re-transcoding recordings for generating the assets playback URLs.

Should just re-use the same HLS playlists.

For that, pass the original session ID in the import task params so it can be reused.

**Specific updates (required)**

 - Add recorded session ID field to import task params

## -

- **How did you test each of these updates (required)**
`yarn test` doesn't break

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
