### PR TITLE
livepeer.studio -> livepeer.com for RTMP and playback URLs in docs

### DIFF
--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1242,7 +1242,7 @@ components:
                 url:
                   type: string
                   description: URL of the asset to import
-                  example: https://cdn.livepeer.studio/ABC123/filename.mp4
+                  example: https://cdn.livepeer.com/ABC123/filename.mp4
                 recordedSessionId:
                   type: string
                   description:

--- a/packages/www/components/Dashboard/AssetsTable/index.tsx
+++ b/packages/www/components/Dashboard/AssetsTable/index.tsx
@@ -147,7 +147,7 @@ const AssetsTable = ({
               <Box>
                 {sourceUrl &&
                 (sourceUrl.indexOf("https://livepeercdn.com") === 0 ||
-                  sourceUrl.indexOf("https://cdn.livepeer.studio") === 0)
+                  sourceUrl.indexOf("https://cdn.livepeer.com") === 0)
                   ? "Live Stream"
                   : "Import"}
               </Box>

--- a/packages/www/docs/api-reference/ingest.mdx
+++ b/packages/www/docs/api-reference/ingest.mdx
@@ -31,8 +31,8 @@ playback URL pairs.
 [
   {
     ingest: "rtmp://<reg>-rtmp.livepeer.com/live",
-    playback: "https://<reg>-cdn.livepeer.studio/hls",
-    base:"https://<reg>-cdn.livepeer.studio/"
+    playback: "https://<reg>-cdn.livepeer.com/hls",
+    base:"https://<reg>-cdn.livepeer.com/"
   }
 ]
 ```

--- a/packages/www/docs/api-reference/ingest.mdx
+++ b/packages/www/docs/api-reference/ingest.mdx
@@ -30,7 +30,7 @@ playback URL pairs.
 ```bash
 [
   {
-    ingest: "rtmp://<reg>-rtmp.livepeer.studio/live",
+    ingest: "rtmp://<reg>-rtmp.livepeer.com/live",
     playback: "https://<reg>-cdn.livepeer.studio/hls",
     base:"https://<reg>-cdn.livepeer.studio/"
   }

--- a/packages/www/docs/api-reference/session/list-recorded-sessions.mdx
+++ b/packages/www/docs/api-reference/session/list-recorded-sessions.mdx
@@ -26,7 +26,7 @@ curl -H 'authorization: Bearer {api-key}' \
     "parentId":"nnnnnnnn-nnnn-nnnn-nnnn-nnnn",
     "recordingStatus":"ready",
     "recordingUrl":"https://livepeercdn.com/recordings/aaaaaaaa-aaaa-aaaa-aaaa-aaaa/index.m3u8"},
-    "mp4URL":"https://mdw-cdn.livepeer.studio/recordings/ccccccc-cccc-cccc-cccc-cccccccccccccc/2021_01_01_01_00_01-source.mp4",
+    "mp4URL":"https://mdw-cdn.livepeer.com/recordings/ccccccc-cccc-cccc-cccc-cccccccccccccc/2021_01_01_01_00_01-source.mp4",
     {other asset object keys, like createdAt and profiles},
   {
     "sourceSegmentsDuration":30.266,
@@ -35,7 +35,7 @@ curl -H 'authorization: Bearer {api-key}' \
     "parentId":"nnnnnnnn-nnnn-nnnn-nnnn-nnnn",
     "recordingStatus":"ready",
     "recordingUrl":"https://livepeercdn.com/recordings/bbbbbbbb-bbbb-bbbb-bbbb-bbbb/index.m3u8",
-    "mp4URL":"https://mdw-cdn.livepeer.studio/recordings/eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee/2021_01_01_01_00_01-source.mp4",
+    "mp4URL":"https://mdw-cdn.livepeer.com/recordings/eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee/2021_01_01_01_00_01-source.mp4",
     {other asset object keys, like createdAt and profiles}
   }
 ]

--- a/packages/www/docs/api-reference/session/list-sessions.mdx
+++ b/packages/www/docs/api-reference/session/list-sessions.mdx
@@ -39,7 +39,7 @@ curl -H 'authorization: Bearer {api-key}' \
     "record":true,
     "parentId":"nnnnnnnn-nnnn-nnnn-nnnn-nnnn",
     "recordingStatus":"ready",
-    "recordingUrl":"https://fra-cdn.livepeer.studio/recordings/bbbbbbbb-bbbb-bbbb-bbbb-bbbb/index.m3u8",
+    "recordingUrl":"https://fra-cdn.livepeer.com/recordings/bbbbbbbb-bbbb-bbbb-bbbb-bbbb/index.m3u8",
     {other asset object keys, like createdAt and profiles}
   }
 ]

--- a/packages/www/docs/guides/application-development/custom-domain.mdx
+++ b/packages/www/docs/guides/application-development/custom-domain.mdx
@@ -8,8 +8,8 @@ metaDescription: Use a custom domain for live streaming with Livepeer Studio
 # Use a custom domain for live streaming
 
 The Livepeer Studio global-optimized ingest URL is
-`rtmp://rtmp.livepeer.studio/live/{stream-key}`.
+`rtmp://rtmp.livepeer.com/live/{stream-key}`.
 
-You can CNAME `rtmp.livepeer.studio` to customize that URL to something with
+You can CNAME `rtmp.livepeer.com` to customize that URL to something with
 your brand, for example `rtmp.companyname.io`. You can configure this with your
 DNS provider.

--- a/packages/www/docs/guides/application-development/custom-domain.mdx
+++ b/packages/www/docs/guides/application-development/custom-domain.mdx
@@ -10,6 +10,6 @@ metaDescription: Use a custom domain for live streaming with Livepeer Studio
 The Livepeer Studio global-optimized ingest URL is
 `rtmp://rtmp.livepeer.com/live/{stream-key}`.
 
-You can CNAME `rtmp.livepeer.com` to customize that URL to something with
-your brand, for example `rtmp.companyname.io`. You can configure this with your
-DNS provider.
+You can CNAME `rtmp.livepeer.com` to customize that URL to something with your
+brand, for example `rtmp.companyname.io`. You can configure this with your DNS
+provider.

--- a/packages/www/docs/guides/application-development/live-streaming-from-your-app.mdx
+++ b/packages/www/docs/guides/application-development/live-streaming-from-your-app.mdx
@@ -7,8 +7,7 @@ metaDescription: Live streaming from your app to Livepeer Studio
 
 # Live streaming from your app
 
-Livepeer Studio global-optimized ingest URL is
-`rtmp://rtmp.livepeer.com/live/`.
+Livepeer Studio global-optimized ingest URL is `rtmp://rtmp.livepeer.com/live/`.
 
 There are many 3rd party applications that allow streamers to push video in the
 RTMP protocol. These include:

--- a/packages/www/docs/guides/application-development/live-streaming-from-your-app.mdx
+++ b/packages/www/docs/guides/application-development/live-streaming-from-your-app.mdx
@@ -8,7 +8,7 @@ metaDescription: Live streaming from your app to Livepeer Studio
 # Live streaming from your app
 
 Livepeer Studio global-optimized ingest URL is
-`rtmp://rtmp.livepeer.studio/live/`.
+`rtmp://rtmp.livepeer.com/live/`.
 
 There are many 3rd party applications that allow streamers to push video in the
 RTMP protocol. These include:

--- a/packages/www/docs/guides/start-live-streaming/back-up-transcoding.mdx
+++ b/packages/www/docs/guides/start-live-streaming/back-up-transcoding.mdx
@@ -14,7 +14,7 @@ experience with the minimum latency Livepeer Studio can provide.
 These globally-optimized URLs are the best option for nearly all Livepeer Studio
 users.
 
-- Stream into: `rtmp://rtmp.livepeer.studio/live/[stream-key]`
+- Stream into: `rtmp://rtmp.livepeer.com/live/[stream-key]`
 - Playback from: `https://livepeercdn.com/hls/[playbackId]/index.m3u8`
 
 ## Back-up transcoding with regional ingest and playback URLs
@@ -31,7 +31,7 @@ ingest and playback URLs and selecting a regional URL pair.
   Studio routes the stream to that region's datacenter for ingest. Playback also
   originates in that datacenter. If the livestreamer is far away from that
   datacenter region, this will introduce latency that could have been avoided if
-  they streamed into the global ingest URL, `rtmp://rtmp.livepeer.studio/live/`.
+  they streamed into the global ingest URL, `rtmp://rtmp.livepeer.com/live/`.
   Additionally, very distant livestream viewers will have a more latent
   experience than if the stream was ingested via the global ingest URL.
 - **Riskier during unforseen outages**: On the rare occasional that a Livepeer
@@ -40,7 +40,7 @@ ingest and playback URLs and selecting a regional URL pair.
   different regional ingest URL ... and send all their livestream viewers a
   different regional playback URL. This could be a bad user experience for your
   stream viewers. the stream was ingested via the global ingest URL,
-  `rtmp://rtmp.livepeer.studio/live/`, the playback URL would stay the same even
+  `rtmp://rtmp.livepeer.com/live/`, the playback URL would stay the same even
   if the livestream had to reconnect.
 
 If you decide to opt out of the global ingest and playback URLs and use regional
@@ -49,7 +49,7 @@ URL pairs, here's what you need to know.
 1. You can not use the same stream key to connect to multiple regional ingest
    URLs simultaneously. For simultaneous, back-up stream transcoding, create
    multiple unique stream keys.
-2. Stream into: `rtmp://[region]-rtmp.livepeer.studio/live/[stream-key]`.
+2. Stream into: `rtmp://[region]-rtmp.livepeer.com/live/[stream-key]`.
 3. Playback from:
    `https://[region]-cdn.livepeer.studio/hls/[playbackId]/index.m3u8`.
 
@@ -73,7 +73,7 @@ And you should get results like this:
 ```bash
 [
   {
-    ingest: "rtmp://{nearbyRegion}-rtmp.livepeer.studio/live",
+    ingest: "rtmp://{nearbyRegion}-rtmp.livepeer.com/live",
     playback: "https://{nearbyRegion}-cdn.livepeer.studio/hls"
   }
 ];
@@ -94,17 +94,17 @@ And you should get a result similar to this:
 ```bash
 [
    {
-      "ingest":"rtmp://{region-1}-rtmp.livepeer.studio/live",
+      "ingest":"rtmp://{region-1}-rtmp.livepeer.com/live",
       "playback":"https://{region-1}-cdn.livepeer.studio/hls",
       "base":"https://{region-1}-cdn.livepeer.studio"
    },
    {
-      "ingest":"rtmp://{region-2}-rtmp.livepeer.studio/live",
+      "ingest":"rtmp://{region-2}-rtmp.livepeer.com/live",
       "playback":"https://{region-2}-cdn.livepeer.studio/hls",
       "base":"https://{region-2}-cdn.livepeer.studio"
    },
    {
-      "ingest":"rtmp://{region-3}-rtmp.livepeer.studio/live",
+      "ingest":"rtmp://{region-3}-rtmp.livepeer.com/live",
       "playback":"https://{region-3}-cdn.livepeer.studio/hls",
       "base":"https://{region-3}-cdn.livepeer.studio"
    }

--- a/packages/www/docs/guides/start-live-streaming/back-up-transcoding.mdx
+++ b/packages/www/docs/guides/start-live-streaming/back-up-transcoding.mdx
@@ -40,8 +40,8 @@ ingest and playback URLs and selecting a regional URL pair.
   different regional ingest URL ... and send all their livestream viewers a
   different regional playback URL. This could be a bad user experience for your
   stream viewers. the stream was ingested via the global ingest URL,
-  `rtmp://rtmp.livepeer.com/live/`, the playback URL would stay the same even
-  if the livestream had to reconnect.
+  `rtmp://rtmp.livepeer.com/live/`, the playback URL would stay the same even if
+  the livestream had to reconnect.
 
 If you decide to opt out of the global ingest and playback URLs and use regional
 URL pairs, here's what you need to know.

--- a/packages/www/docs/guides/start-live-streaming/back-up-transcoding.mdx
+++ b/packages/www/docs/guides/start-live-streaming/back-up-transcoding.mdx
@@ -51,7 +51,7 @@ URL pairs, here's what you need to know.
    multiple unique stream keys.
 2. Stream into: `rtmp://[region]-rtmp.livepeer.com/live/[stream-key]`.
 3. Playback from:
-   `https://[region]-cdn.livepeer.studio/hls/[playbackId]/index.m3u8`.
+   `https://[region]-cdn.livepeer.com/hls/[playbackId]/index.m3u8`.
 
 An RTMP ingest and playback URL pair references hardware in different parts of
 the world. Each region is three letters, the airport code of the server
@@ -74,7 +74,7 @@ And you should get results like this:
 [
   {
     ingest: "rtmp://{nearbyRegion}-rtmp.livepeer.com/live",
-    playback: "https://{nearbyRegion}-cdn.livepeer.studio/hls"
+    playback: "https://{nearbyRegion}-cdn.livepeer.com/hls"
   }
 ];
 ```
@@ -95,18 +95,18 @@ And you should get a result similar to this:
 [
    {
       "ingest":"rtmp://{region-1}-rtmp.livepeer.com/live",
-      "playback":"https://{region-1}-cdn.livepeer.studio/hls",
-      "base":"https://{region-1}-cdn.livepeer.studio"
+      "playback":"https://{region-1}-cdn.livepeer.com/hls",
+      "base":"https://{region-1}-cdn.livepeer.com"
    },
    {
       "ingest":"rtmp://{region-2}-rtmp.livepeer.com/live",
-      "playback":"https://{region-2}-cdn.livepeer.studio/hls",
-      "base":"https://{region-2}-cdn.livepeer.studio"
+      "playback":"https://{region-2}-cdn.livepeer.com/hls",
+      "base":"https://{region-2}-cdn.livepeer.com"
    },
    {
       "ingest":"rtmp://{region-3}-rtmp.livepeer.com/live",
-      "playback":"https://{region-3}-cdn.livepeer.studio/hls",
-      "base":"https://{region-3}-cdn.livepeer.studio"
+      "playback":"https://{region-3}-cdn.livepeer.com/hls",
+      "base":"https://{region-3}-cdn.livepeer.com"
    }
 ]
 ```

--- a/packages/www/docs/guides/start-live-streaming/broadcasting.mdx
+++ b/packages/www/docs/guides/start-live-streaming/broadcasting.mdx
@@ -21,16 +21,16 @@ Here are several ways to find your stream key:
   `streamKey` in the response.
 
 When configuring broadcast software to push streams, use the secret `streamKey`
-and the Livepeer Studio RTMP ingest URL, `rtmp://rtmp.livepeer.studio/live`.
+and the Livepeer Studio RTMP ingest URL, `rtmp://rtmp.livepeer.com/live`.
 
 Depending on the software used to push your RTMP stream, you’ll be prompted for
 the following:
 
 - Stream Key: In some cases, this is called a "Stream Name." Input your Livepeer
   Studio `streamKey` not the name of your stream.
-- Server URL: Input the RTMP ingest URL, `rtmp://rtmp.livepeer.studio/live`.
+- Server URL: Input the RTMP ingest URL, `rtmp://rtmp.livepeer.com/live`.
 - Location or URL: Input the ingest url with the `streamKey` appended. For
-  example, `rtmp://rtmp.livepeer.studio/live/[streamKey]`.
+  example, `rtmp://rtmp.livepeer.com/live/[streamKey]`.
 
 ## Optimization: Set keyframe intervals
 

--- a/packages/www/docs/guides/start-live-streaming/playback.mdx
+++ b/packages/www/docs/guides/start-live-streaming/playback.mdx
@@ -142,7 +142,7 @@ will show the current date and time and `isActive` will be `true` (Status row on
 the Livepeer Studio Dashboard will be Active).
 
 If this isn't the case, confirm the `streamKey` and RTMP ingest URL,
-`rtmp://rtmp.livepeer.studio/live`, are configured correctly in your broadcast
+`rtmp://rtmp.livepeer.com/live`, are configured correctly in your broadcast
 software.
 
 Lastly, check that your playback URL is correct.

--- a/packages/www/docs/guides/start-live-streaming/record.mdx
+++ b/packages/www/docs/guides/start-live-streaming/record.mdx
@@ -175,7 +175,7 @@ curl -H 'authorization: Bearer {api-key}' \
     "playbackId":"efghb2mxupongp5k",
     "recordingStatus":"ready",
     "recordingURL":"https://mdw-cdn.livepeer.monster/recordings/mnopa1c9-1775-4797-919e-40d21099d02b/index.m3u8",
-    "mp4URL":"https://mdw-cdn.livepeer.studio/recordings/mnopa1c9-1775-4797-919e-40d21099d02b/2021_05_04_02_00_31-source.mp4",
+    "mp4URL":"https://mdw-cdn.livepeer.com/recordings/mnopa1c9-1775-4797-919e-40d21099d02b/2021_05_04_02_00_31-source.mp4",
     {other asset object keys}
 }
 ```

--- a/packages/www/docs/guides/start-live-streaming/reducing-latency.mdx
+++ b/packages/www/docs/guides/start-live-streaming/reducing-latency.mdx
@@ -14,7 +14,7 @@ experience with the minimum latency Livepeer Studio can provide.
 These globally-optimized URLs are the best option for nearly all Livepeer Studio
 users.
 
-- Stream into: `rtmp://rtmp.livepeer.studio/live/{stream-key}`
+- Stream into: `rtmp://rtmp.livepeer.com/live/{stream-key}`
 - Playback from: `https://livepeercdn.com/hls/{playbackId}/index.m3u8`
 
 Also, If you created your stream via the Livepeer Studio API, confirm your

--- a/packages/www/docs/guides/start-live-streaming/srt-support.mdx
+++ b/packages/www/docs/guides/start-live-streaming/srt-support.mdx
@@ -10,7 +10,7 @@ metaDescription: SRT Ingest Supported
 SRT ingest is supported for all users and is currently in Beta. To stream in
 SRT, change your stream URL to:
 
-`srt://rtmp.livepeer.studio:2935?streamid={stream-key}`
+`srt://rtmp.livepeer.com:2935?streamid={stream-key}`
 
 The SRT ingest URL is also included in the Dashboard, making it easy to copy and
 paste. It can be found below the RTMP ingest URL on the Stream Detail page.

--- a/packages/www/docs/guides/start-live-streaming/tutorial.mdx
+++ b/packages/www/docs/guides/start-live-streaming/tutorial.mdx
@@ -73,7 +73,7 @@ centers.
 
 1. In the Setting sidebar menu, select Stream.
 2. At the top, select Custom from the Service dropdown menu.
-3. Input `rtmp://rtmp.livepeer.studio/live` in the Server text field.
+3. Input `rtmp://rtmp.livepeer.com/live` in the Server text field.
 4. Navigate to the stream detail page, click the “Reveal stream key” button, and
    copy the stream key.
 5. Navigate back to OBS, and paste your stream key into the Stream Key text
@@ -97,7 +97,7 @@ To use Streamyard with Livepeer:
 1. Pick "Destinations"
 2. Click "Add a destination"
 3. Pick "Custom RTMP"
-4. Input `rtmp://rtmp.livepeer.studio/live` in the "RTMP Server URL" text field.
+4. Input `rtmp://rtmp.livepeer.com/live` in the "RTMP Server URL" text field.
 5. Copy your stream key into the "Stream key" field
 6. Input a name for the stream in "Nickname"
 7. Click "Add RTMP server"
@@ -109,7 +109,7 @@ To use Restream.io studio with Livepeer:
 
 1. Click "Add channel"
 2. Pick "Custom RTMP"
-3. Input `rtmp://rtmp.livepeer.studio/live` in the "RTMP URL" text field.
+3. Input `rtmp://rtmp.livepeer.com/live` in the "RTMP URL" text field.
 4. Copy your stream key into the "Stream key" field
 5. Click "Enter Live Studio"
 6. When you are ready to start your live stream, click the "Go Live" button.

--- a/packages/www/layouts/streamDetail.tsx
+++ b/packages/www/layouts/streamDetail.tsx
@@ -489,7 +489,7 @@ const StreamDetail = ({
                           content={
                             <Box>
                               We changed our playback domain, but
-                              cdn.livepeer.studio is still working.
+                              cdn.livepeer.com is still working.
                             </Box>
                           }>
                           <Help />

--- a/packages/www/vercel.json
+++ b/packages/www/vercel.json
@@ -4,7 +4,7 @@
   "redirects": [
     {
       "source": "/tv",
-      "destination": "https://media.livepeer.org/play?url=https%3A%2F%2Fcdn.livepeer.studio%2Fhls%2F7062iaygm8eip421%2Findex.m3u8",
+      "destination": "https://media.livepeer.org/play?url=https%3A%2F%2Fcdn.livepeer.com%2Fhls%2F7062iaygm8eip421%2Findex.m3u8",
       "permanent": false
     },
     {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**

Updates RTMP and playback URLs in the docs to use livepeer.com instead of livepeer.studio because the latter does not work right now.

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
