### PR TITLE
api: Allow finding an asset by CID (of video or metadata)

### DIFF
--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -274,8 +274,7 @@ app.get("/", authorizer({}), async (req, res) => {
   if (playbackId) {
     query.push(sql`asset.data->>'playbackId' = ${playbackId}`);
   }
-  if (!all || all === "false") {
-    // TODO: Consider keeping this flag as admin-only
+  if (!req.user.admin || !all || all === "false") {
     query.push(sql`asset.data->>'deleted' IS NULL`);
   }
 

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -256,6 +256,8 @@ const fieldsMap: FieldsMap = {
   playbackId: `asset.data->>'playbackId'`,
   "user.email": { val: `users.data->>'email'`, type: "full-text" },
   meta: `asset.data->>'meta'`,
+  ipfsVideoFileCid: `asset.data->'status'->'storage'->'ipfs'->'data'->'videoFileCid'`,
+  ipfsNftMetadataCid: `asset.data->'status'->'storage'->'ipfs'->'data'->'nftMetadataCid'`,
 };
 
 app.get("/", authorizer({}), async (req, res) => {

--- a/packages/api/src/controllers/playback.test.ts
+++ b/packages/api/src/controllers/playback.test.ts
@@ -144,6 +144,37 @@ describe("controllers/playback", () => {
           },
         });
       });
+
+      it("should return playback URL assets from CID", async () => {
+        const cid = "bafyfoobar";
+        await db.asset.update(asset.id, {
+          playbackRecordingId: "mock_recording_id_2",
+          status: {
+            phase: "ready",
+            storage: {
+              ipfs: {
+                data: {
+                  videoFileCid: cid,
+                },
+              },
+            },
+          },
+        });
+        const res = await client.get(`/playback/${cid}`);
+        expect(res.status).toBe(200);
+        await expect(res.json()).resolves.toMatchObject({
+          type: "vod",
+          meta: {
+            source: [
+              {
+                hrn: "HLS (TS)",
+                type: "html5/application/vnd.apple.mpegurl",
+                url: `${ingest}/recordings/mock_recording_id_2/index.m3u8`,
+              },
+            ],
+          },
+        });
+      });
     });
 
     describe("for recordings", () => {

--- a/packages/api/src/controllers/playback.ts
+++ b/packages/api/src/controllers/playback.ts
@@ -41,6 +41,33 @@ const newPlaybackInfo = (
   },
 });
 
+const getAssetPlaybackUrl = async (
+  ingest: string,
+  id: string,
+  cid: boolean
+) => {
+  const asset = cid
+    ? await db.asset.getByIpfsCid(id)
+    : await db.asset.getByPlaybackId(id);
+  if (!asset || asset.deleted) {
+    return null;
+  }
+  return assetPlaybackUrl(ingest, asset);
+};
+
+const getRecordingPlaybackUrl = async (
+  ingest: string,
+  id: string,
+  table: Table<DBSession>
+) => {
+  const session = await table.get(id);
+  if (!session || session.deleted) {
+    return null;
+  }
+  const { recordingUrl } = getRecordingFields(ingest, session, false);
+  return recordingUrl;
+};
+
 async function getPlaybackInfo(
   ingest: string,
   id: string
@@ -53,32 +80,16 @@ async function getPlaybackInfo(
       stream.isActive ? 1 : 0
     );
   }
-  const getAssetPlaybackUrl = async (cid: boolean) => {
-    const asset = cid
-      ? await db.asset.getByIpfsCid(id)
-      : await db.asset.getByPlaybackId(id);
-    if (!asset || asset.deleted) {
-      return null;
-    }
-    return assetPlaybackUrl(ingest, asset);
-  };
   const assetUrl =
-    (await getAssetPlaybackUrl(false)) ?? (await getAssetPlaybackUrl(true));
+    (await getAssetPlaybackUrl(ingest, id, false)) ??
+    (await getAssetPlaybackUrl(ingest, id, true));
   if (assetUrl) {
     return newPlaybackInfo("vod", assetUrl);
   }
 
-  const getRecordingPlaybackUrl = async (table: Table<DBSession>) => {
-    const session = await table.get(id);
-    if (!session || session.deleted) {
-      return null;
-    }
-    const { recordingUrl } = getRecordingFields(ingest, session, false);
-    return recordingUrl;
-  };
   const recordingUrl =
-    (await getRecordingPlaybackUrl(db.session)) ??
-    (await getRecordingPlaybackUrl(db.stream));
+    (await getRecordingPlaybackUrl(ingest, id, db.session)) ??
+    (await getRecordingPlaybackUrl(ingest, id, db.stream));
   if (recordingUrl) {
     return newPlaybackInfo("recording", recordingUrl);
   }

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -993,7 +993,17 @@ components:
                           type: string
                           description: ID of the last task to fail execution.
                     data:
-                      $ref: "#/components/schemas/task/properties/output/properties/export/properties/ipfs"
+                      type: object
+                      additionalProperties: false
+                      required: [videoFileCid]
+                      properties:
+                        $ref: "#/components/schemas/task/properties/output/properties/export/properties/ipfs/properties"
+                        videoFileCid:
+                          $ref: "#/components/schemas/task/properties/output/properties/export/properties/ipfs/properties/videoFileCid"
+                          index: true
+                        nftMetadataCid:
+                          $ref: "#/components/schemas/task/properties/output/properties/export/properties/ipfs/properties/nftMetadataCid"
+                          index: true
         name:
           type: string
           description:

--- a/packages/api/src/store/asset-table.ts
+++ b/packages/api/src/store/asset-table.ts
@@ -110,4 +110,19 @@ export default class AssetTable extends Table<DBAsset> {
     }
     return assetStatusCompat(res.rows[0].data as WithID<Asset>);
   }
+
+  async getByIpfsCid(cid: string): Promise<WithID<Asset>> {
+    const query = [
+      sql`asset.data->'status'->'storage'->'ipfs'->'data'->>'videoFileCid' = ${cid}`,
+      sql`asset.data->>'deleted' IS NULL`,
+    ];
+    const [assets] = await this.find(query, {
+      limit: 2,
+      order: "coalesce((asset.data->'createdAt')::bigint, 0) ASC",
+    });
+    if (!assets || assets.length < 1) {
+      return null;
+    }
+    return assets[0];
+  }
 }

--- a/packages/api/src/store/table.ts
+++ b/packages/api/src/store/table.ts
@@ -361,7 +361,7 @@ export default class Table<T extends DBObject> {
     const parentsAcc = parents.map((p) => `->'${p}'`).join("");
     const propAccessor = `data${parentsAcc}->>'${propName}'`;
     try {
-      await this.db.query(`
+      await this.db.query(sql`
           CREATE ${unique} INDEX "${indexName}" ON "${this.name}" USING BTREE ((${propAccessor}));
         `);
     } catch (e) {

--- a/packages/api/src/store/table.ts
+++ b/packages/api/src/store/table.ts
@@ -357,10 +357,9 @@ export default class Table<T extends DBObject> {
     if (prop.unique) {
       unique = "unique";
     }
-    const fullPropName = (prefix: string, finalPrefix = prefix) =>
-      parents.map((p) => prefix + p).join("") + finalPrefix + propName;
-    const indexName = `${this.name}${fullPropName("_")}`;
-    const propAccessor = `data${fullPropName("->", "->>")}`;
+    const indexName = `${this.name}_${[...parents, propName].join("_")}`;
+    const parentsAcc = parents.map((p) => `->'${p}'`).join("");
+    const propAccessor = `data${parentsAcc}->>'${propName}'`;
     try {
       await this.db.query(`
           CREATE ${unique} INDEX "${indexName}" ON "${this.name}" USING BTREE ((${propAccessor}));

--- a/packages/api/src/store/table.ts
+++ b/packages/api/src/store/table.ts
@@ -338,7 +338,7 @@ export default class Table<T extends DBObject> {
 
   // on startup: auto-create indices if they don't exist
   async ensureIndex(propName: string, prop: FieldSpec, parents: string[] = []) {
-    if (process.env.NODE_ENV !== "test") {
+    if (process.env.NODE_ENV !== "test" && this.name !== "asset") {
       // avoid creating indexes in production right now...
       return;
     }

--- a/packages/api/src/store/table.ts
+++ b/packages/api/src/store/table.ts
@@ -344,7 +344,7 @@ export default class Table<T extends DBObject> {
     }
 
     if (!prop.index && !prop.unique) {
-      if (prop.properties) {
+      if (prop.properties && this.name === "asset") {
         return Promise.all(
           Object.entries(prop.properties).map(([childName, childProp]) =>
             this.ensureIndex(childName, childProp, [...parents, propName])

--- a/packages/api/src/store/table.ts
+++ b/packages/api/src/store/table.ts
@@ -337,23 +337,33 @@ export default class Table<T extends DBObject> {
   }
 
   // on startup: auto-create indices if they don't exist
-  async ensureIndex(propName, prop) {
+  async ensureIndex(propName: string, prop: FieldSpec, parents: string[] = []) {
     if (process.env.NODE_ENV !== "test") {
       // avoid creating indexes in production right now...
       return;
     }
 
     if (!prop.index && !prop.unique) {
+      if (prop.properties) {
+        return Promise.all(
+          Object.entries(prop.properties).map(([childName, childProp]) =>
+            this.ensureIndex(childName, childProp, [...parents, propName])
+          )
+        );
+      }
       return;
     }
     let unique = "";
     if (prop.unique) {
       unique = "unique";
     }
-    const indexName = `${this.name}_${propName}`;
+    const fullPropName = (prefix: string, finalPrefix = prefix) =>
+      parents.map((p) => prefix + p).join("") + finalPrefix + propName;
+    const indexName = `${this.name}${fullPropName("_")}`;
+    const propAccessor = `data${fullPropName("->", "->>")}`;
     try {
       await this.db.query(`
-          CREATE ${unique} INDEX "${indexName}" ON "${this.name}" USING BTREE ((data->>'${propName}'));
+          CREATE ${unique} INDEX "${indexName}" ON "${this.name}" USING BTREE ((${propAccessor}));
         `);
     } catch (e) {
       if (!e.message.includes("already exists")) {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This is to allow finding an asset from its CID (of video or metadata).

It will allow clean-up of pins in any IPFS provider, so that we only actually delete
the Pin when there are no more assets pointing to that same file.

Will also allow unpinning of previous metadata when the NFT metadata changes,
following that same principle/api.

**Specific updates (required)**
 - Allow indexes of nested properties
 - Add index to CID fields
 - Allow filtering by them on the `/asset` API

## -

- **How did you test each of these updates (required)**
 - `yarn test`
 - to-do: Query for an asset using its CIDs and check it's findable

**Does this pull request close any open issues?**
Not really, but it's related to the current Piñata incident that we're having. Gotta create an issue for that.

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
