### PR TITLE
api/asset: Keep storage spec and status in the same place

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -84,6 +84,7 @@
     "isomorphic-webcrypto": "^2.3.8",
     "js-yaml": "^3.13.1",
     "jsonwebtoken": "^8.5.1",
+    "lodash": "^4.17.21",
     "m3u8-parser": "^4.4.0",
     "minio": "^7.0.12",
     "morgan": "^1.9.1",

--- a/packages/api/src/controllers/asset.test.ts
+++ b/packages/api/src/controllers/asset.test.ts
@@ -121,15 +121,15 @@ describe("controllers/asset", () => {
       res = await client.patch(`/asset/${asset.id}`, { storage: { ipfs: {} } });
       expect(res.status).toBe(200);
       asset = await res.json();
-      expect(asset).toMatchObject({ id: expect.any(String) });
       const expected = {
+        id: expect.any(String),
         storage: {
           ipfs: {
             spec: {},
-            status: {
-              phase: "waiting",
-              tasks: { pending: expect.any(String) },
-            },
+          },
+          status: {
+            phase: "waiting",
+            tasks: { pending: expect.any(String) },
           },
         },
       };
@@ -209,16 +209,16 @@ describe("controllers/asset", () => {
         storage: {
           ipfs: {
             spec: { nftMetadata: { a: "b" } },
-            status: {
-              phase: "waiting",
-              tasks: { pending: expect.any(String) },
-            },
+          },
+          status: {
+            phase: "waiting",
+            tasks: { pending: expect.any(String) },
           },
         },
         status: { ...asset.status, updatedAt: expect.any(Number) },
       });
 
-      const taskId = patched.storage.ipfs.status.tasks.pending;
+      const taskId = patched.storage.status.tasks.pending;
       res = await client.get("/task/" + taskId);
       expect(res.status).toBe(200);
       expect(res.json()).resolves.toMatchObject({
@@ -254,8 +254,8 @@ describe("controllers/asset", () => {
         storage: {
           ipfs: {
             spec: { nftMetadata: { a: "b" } },
-            status: { tasks: { pending: task.id } },
           },
+          status: { tasks: { pending: task.id } },
         },
         status: {
           ...asset.status,
@@ -270,7 +270,7 @@ describe("controllers/asset", () => {
       });
       expect(res.status).toBe(200);
       const patched = await res.json();
-      const taskId = patched.storage.ipfs.status.tasks.pending;
+      const taskId = patched.storage.status.tasks.pending;
       await server.taskScheduler.processTaskEvent({
         id: uuid(),
         type: "task_result",
@@ -316,7 +316,7 @@ describe("controllers/asset", () => {
       });
       expect(res.status).toBe(200);
       const patched = await res.json();
-      const taskId = patched.storage.ipfs.status.tasks.pending;
+      const taskId = patched.storage.status.tasks.pending;
       await server.taskScheduler.processTaskEvent({
         id: uuid(),
         type: "task_result",
@@ -340,12 +340,12 @@ describe("controllers/asset", () => {
         storage: {
           ipfs: {
             spec: {},
-            status: {
-              phase: "failed",
-              errorMessage: "oh no it failed!",
-              tasks: {
-                failed: taskId,
-              },
+          },
+          status: {
+            phase: "failed",
+            errorMessage: "oh no it failed!",
+            tasks: {
+              failed: taskId,
             },
           },
         },

--- a/packages/api/src/controllers/asset.test.ts
+++ b/packages/api/src/controllers/asset.test.ts
@@ -6,6 +6,7 @@ import { db } from "../store";
 import { WithID } from "../store/types";
 import Table from "../store/table";
 import schema from "../schema/schema.json";
+import { withIpfsUrls } from "./asset";
 
 // repeat the type here so we don't need to export it from store/asset-table.ts
 type DBAsset =
@@ -300,7 +301,10 @@ describe("controllers/asset", () => {
             status: {
               phase: "ready",
               tasks: { last: taskId },
-              addresses: { videoFileCid: "QmX", nftMetadataCid: "QmY" },
+              addresses: withIpfsUrls({
+                videoFileCid: "QmX",
+                nftMetadataCid: "QmY",
+              }),
             },
           },
         },

--- a/packages/api/src/controllers/asset.test.ts
+++ b/packages/api/src/controllers/asset.test.ts
@@ -361,7 +361,7 @@ describe("controllers/asset", () => {
       });
       const data = await res.json();
       if (!expectedErrors) {
-        // expect(res.status).toBe(200);
+        expect(res.status).toBe(200);
         expect(data).toMatchObject({
           ...asset,
           ...(expectedStorage === undefined
@@ -409,6 +409,9 @@ describe("controllers/asset", () => {
         }
       );
       await testStoragePatch({ ipfs: null }, undefined, [
+        "Cannot remove asset from IPFS",
+      ]);
+      await testStoragePatch({ ipfs: { spec: null } }, undefined, [
         "Cannot remove asset from IPFS",
       ]);
     });

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -611,7 +611,7 @@ app.patch(
         ipfs:
           typeof ipfs === "boolean"
             ? { spec: ipfs ? {} : null }
-            : { spec: ipfs.spec ?? {} },
+            : { spec: !ipfs ? null : ipfs.spec ?? {} },
       };
     }
     if (storage?.ipfs?.spec?.pinata) {

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -138,8 +138,8 @@ async function reconcileAssetStorage(
   let { storage } = asset;
   const ipfsParamsEq =
     JSON.stringify(newStorage.ipfs?.spec) ===
-    JSON.stringify(storage?.ipfs?.spec);
-  if (!ipfsParamsEq) {
+    JSON.stringify(storage?.ipfs?.spec ?? null);
+  if ("ipfs" in newStorage && !ipfsParamsEq) {
     let newSpec = newStorage.ipfs?.spec;
     if (!newSpec) {
       throw new BadRequestError("Cannot remove asset from IPFS");
@@ -604,7 +604,7 @@ app.patch(
     let { name, meta, storage: storageInput } = req.body as AssetPatchPayload;
     validateAssetMeta(meta);
     let storage: Asset["storage"];
-    if (storageInput?.ipfs) {
+    if (storageInput?.ipfs !== undefined) {
       const { ipfs } = storageInput;
       storage = {
         ...storageInput,

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -653,11 +653,6 @@ app.patch(
       }
       storage = { ...storageInput, ipfs };
     }
-    if (storage?.ipfs?.spec?.pinata) {
-      throw new BadRequestError(
-        "Custom pinata not allowed in asset storage. Call /export API explicitly instead"
-      );
-    }
 
     // update a specific asset
     const { id } = req.params;

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -460,7 +460,7 @@ const transcodeAssetHandler: RequestHandler = async (req, res) => {
       name: req.body.name ?? inputAsset.name,
     }
   );
-  outputAsset.sourceAssetId = inputAsset.id;
+  outputAsset.sourceAssetId = inputAsset.sourceAssetId ?? inputAsset.id;
   outputAsset = await createAsset(outputAsset, req.queue);
 
   const task = await req.taskScheduler.scheduleTask(

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -137,15 +137,18 @@ async function reconcileAssetStorage(
 ): Promise<Asset["storage"]> {
   let { storage } = asset;
   const ipfsParamsEq =
-    JSON.stringify(newStorage?.ipfs) === JSON.stringify(storage?.ipfs);
+    JSON.stringify(newStorage.ipfs?.spec) ===
+    JSON.stringify(storage?.ipfs?.spec);
   if (!ipfsParamsEq) {
-    if (!newStorage.ipfs) {
+    let newIpfs = newStorage.ipfs;
+    if (!newIpfs) {
       throw new BadRequestError("Cannot remove asset from IPFS");
     }
+    newIpfs = { spec: {}, ...newIpfs };
     if (!task) {
       task = await taskScheduler.scheduleTask(
         "export",
-        { export: { ipfs: newStorage.ipfs.spec } },
+        { export: { ipfs: newIpfs.spec } },
         asset
       );
     }
@@ -153,7 +156,7 @@ async function reconcileAssetStorage(
       ...storage,
       ipfs: {
         ...storage?.ipfs,
-        ...newStorage.ipfs,
+        ...newIpfs,
         status: {
           ...storage?.ipfs?.status,
           phase: "waiting",
@@ -611,7 +614,7 @@ app.patch(
     validateAssetMeta(meta);
     if (storage?.ipfs?.spec.pinata) {
       throw new BadRequestError(
-        "Custom pinata not allowed in asset storage. Call export API explicitly instead"
+        "Custom pinata not allowed in asset storage. Call /export API explicitly instead"
       );
     }
 

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -4,6 +4,7 @@ import { Request, RequestHandler, Router } from "express";
 import jwt, { JwtPayload } from "jsonwebtoken";
 import { v4 as uuid } from "uuid";
 import mung from "express-mung";
+import _ from "lodash";
 import {
   makeNextHREF,
   parseFilters,
@@ -136,9 +137,10 @@ async function reconcileAssetStorage(
   task?: WithID<Task>
 ): Promise<Asset["storage"]> {
   let { storage } = asset;
-  const ipfsParamsEq =
-    JSON.stringify(newStorage.ipfs?.spec) ===
-    JSON.stringify(storage?.ipfs?.spec ?? null);
+  const ipfsParamsEq = _.isEqual(
+    newStorage.ipfs?.spec,
+    storage?.ipfs?.spec ?? null
+  );
   if ("ipfs" in newStorage && !ipfsParamsEq) {
     let newSpec = newStorage.ipfs?.spec;
     if (!newSpec) {

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -603,16 +603,16 @@ app.patch(
     // these are the only updateable fields
     let { name, meta, storage: storageInput } = req.body as AssetPatchPayload;
     validateAssetMeta(meta);
+
     let storage: Asset["storage"];
     if (storageInput?.ipfs !== undefined) {
-      const { ipfs } = storageInput;
-      storage = {
-        ...storageInput,
-        ipfs:
-          typeof ipfs === "boolean"
-            ? { spec: ipfs ? {} : null }
-            : { spec: !ipfs ? null : ipfs.spec ?? {} },
-      };
+      let { ipfs } = storageInput;
+      if (typeof ipfs === "boolean" || !ipfs) {
+        ipfs = { spec: ipfs ? {} : null };
+      } else if (typeof ipfs.spec === "undefined") {
+        ipfs = { spec: {} };
+      }
+      storage = { ...storageInput, ipfs };
     }
     if (storage?.ipfs?.spec?.pinata) {
       throw new BadRequestError(

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -247,8 +247,8 @@ const fieldsMap: FieldsMap = {
   playbackId: `asset.data->>'playbackId'`,
   "user.email": { val: `users.data->>'email'`, type: "full-text" },
   meta: `asset.data->>'meta'`,
-  ipfsVideoFileCid: `asset.data->'status'->'storage'->'ipfs'->'data'->'videoFileCid'`,
-  ipfsNftMetadataCid: `asset.data->'status'->'storage'->'ipfs'->'data'->'nftMetadataCid'`,
+  ipfsVideoFileCid: `asset.data->'storage'->'ipfs'->'status'->'addresses'->>'videoFileCid'`,
+  ipfsNftMetadataCid: `asset.data->'storage'->'ipfs'->'status'->'addresses'->>'nftMetadataCid'`,
 };
 
 app.get("/", authorizer({}), async (req, res) => {

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -139,19 +139,15 @@ function assetWithIpfsUrls(asset: WithID<Asset>): WithID<Asset> {
   if (!asset?.storage?.ipfs?.status?.addresses) {
     return asset;
   }
-  return {
-    ...asset,
+  return _.merge({}, asset, {
     storage: {
-      ...asset.storage,
       ipfs: {
-        ...asset.storage.ipfs,
         status: {
-          ...asset.storage.ipfs.status,
           addresses: withIpfsUrls(asset.storage.ipfs.status.addresses),
         },
       },
     },
-  };
+  });
 }
 
 export async function createAsset(asset: WithID<Asset>, queue: Queue) {

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -284,8 +284,8 @@ const fieldsMap: FieldsMap = {
   playbackId: `asset.data->>'playbackId'`,
   "user.email": { val: `users.data->>'email'`, type: "full-text" },
   meta: `asset.data->>'meta'`,
-  ipfsVideoFileCid: `asset.data->'storage'->'ipfs'->'status'->'addresses'->>'videoFileCid'`,
-  ipfsNftMetadataCid: `asset.data->'storage'->'ipfs'->'status'->'addresses'->>'nftMetadataCid'`,
+  cid: `asset.data->'storage'->'ipfs'->>'cid'`,
+  nftMetadataCid: `asset.data->'storage'->'ipfs'->'nftMetadataCid'->>'cid'`,
 };
 
 app.get("/", authorizer({}), async (req, res) => {

--- a/packages/api/src/controllers/playback.test.ts
+++ b/packages/api/src/controllers/playback.test.ts
@@ -149,11 +149,12 @@ describe("controllers/playback", () => {
         const cid = "bafyfoobar";
         await db.asset.update(asset.id, {
           playbackRecordingId: "mock_recording_id_2",
-          status: {
-            phase: "ready",
-            storage: {
-              ipfs: {
-                data: {
+          storage: {
+            ipfs: {
+              status: {
+                phase: "ready",
+                tasks: {},
+                addresses: {
                   videoFileCid: cid,
                 },
               },

--- a/packages/api/src/controllers/playback.test.ts
+++ b/packages/api/src/controllers/playback.test.ts
@@ -151,13 +151,11 @@ describe("controllers/playback", () => {
           playbackRecordingId: "mock_recording_id_2",
           storage: {
             ipfs: {
-              status: {
-                phase: "ready",
-                tasks: {},
-                addresses: {
-                  videoFileCid: cid,
-                },
-              },
+              cid: cid,
+            },
+            status: {
+              phase: "ready",
+              tasks: {},
             },
           },
         });

--- a/packages/api/src/controllers/task.ts
+++ b/packages/api/src/controllers/task.ts
@@ -3,13 +3,13 @@ import { validatePost } from "../middleware";
 import { Router } from "express";
 import mung from "express-mung";
 import { v4 as uuid } from "uuid";
+import _ from "lodash";
 import {
   makeNextHREF,
   parseFilters,
   parseOrder,
   toStringValues,
   FieldsMap,
-  pathJoin,
 } from "./helpers";
 import { db } from "../store";
 import sql from "sql-template-strings";
@@ -38,16 +38,13 @@ function taskWithIpfsUrls(task: WithID<Task>): WithID<Task> {
   if (task?.type !== "export" || !task?.output?.export?.ipfs) {
     return task;
   }
-  return {
-    ...task,
+  return _.merge({}, task, {
     output: {
-      ...task.output,
       export: {
-        ...task.output.export,
         ipfs: withIpfsUrls(task.output.export.ipfs),
       },
     },
-  };
+  });
 }
 
 const fieldsMap: FieldsMap = {

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -199,7 +199,11 @@ export const corsApiKeyAccessRules: AuthRule[] = [
   // VOD
   {
     methods: ["get"],
-    resources: ["/asset/:id", "/task/:id"],
+    resources: ["/task/:id"],
+  },
+  {
+    methods: ["get", "patch"],
+    resources: ["/asset/:id"],
   },
   {
     methods: ["post"],

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -945,7 +945,6 @@ components:
           properties:
             ipfs:
               type: object
-              required: [spec]
               additionalProperties: false
               properties:
                 spec:
@@ -963,6 +962,7 @@ components:
                         - waiting
                         - ready
                         - failed
+                        - reverted
                     errorMessage:
                       type: string
                       description:

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -953,7 +953,7 @@ components:
                 status:
                   readOnly: true
                   additionalProperties: false
-                  required: [taskIds]
+                  required: [tasks]
                   properties:
                     phase:
                       type: string
@@ -966,7 +966,7 @@ components:
                       type: string
                       description:
                         Error message if the last storage changed failed.
-                    taskIds:
+                    tasks:
                       type: object
                       additionalProperties: false
                       properties:

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -651,10 +651,10 @@ components:
             ipfs:
               oneOf:
                 - $ref: "#/components/schemas/asset/properties/storage/properties/ipfs"
-                - type: boolean
+                - type: [boolean, "null"]
                   description:
-                    Set to true to make default export to IPFS. False means to
-                    unpin from IPFS, but is unsupported right now.
+                    Set to true to make default export to IPFS. False or null
+                    means to unpin from IPFS, but is unsupported right now.
 
     stream-patch-payload:
       type: object

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -964,55 +964,42 @@ components:
                 spec:
                   $ref: "#/components/schemas/export-task-params/oneOf/1/properties/ipfs"
                   default: {}
-                status:
-                  readOnly: true
+                $ref: "#/components/schemas/ipfs-file-info/properties"
+                nftMetadata:
+                  $ref: "#/components/schemas/ipfs-file-info"
+            status:
+              readOnly: true
+              additionalProperties: false
+              required: [phase, tasks]
+              properties:
+                phase:
+                  type: string
+                  description: Phase of the asset storage
+                  enum:
+                    - waiting
+                    - ready
+                    - failed
+                    - reverted
+                errorMessage:
+                  type: string
+                  description: Error message if the last storage changed failed.
+                tasks:
+                  type: object
                   additionalProperties: false
-                  required: [phase, tasks]
                   properties:
-                    phase:
-                      type: string
-                      description: Phase of the asset storage
-                      enum:
-                        - waiting
-                        - ready
-                        - failed
-                        - reverted
-                    errorMessage:
+                    pending:
                       type: string
                       description:
-                        Error message if the last storage changed failed.
-                    tasks:
-                      type: object
-                      additionalProperties: false
-                      properties:
-                        pending:
-                          type: string
-                          description:
-                            ID of any currently running task that is exporting
-                            this asset to IPFS.
-                        last:
-                          type: string
-                          description:
-                            ID of the last task to run successfully, that
-                            created the currently saved data.
-                        failed:
-                          type: string
-                          description: ID of the last task to fail execution.
-                    addresses:
-                      type: object
+                        ID of any currently running task that is exporting this
+                        asset to IPFS.
+                    last:
+                      type: string
                       description:
-                        Addresses of the asset in IPFS from the last successful
-                        task execution.
-                      additionalProperties: false
-                      required: [videoFileCid]
-                      properties:
-                        $ref: "#/components/schemas/task/properties/output/properties/export/properties/ipfs/properties"
-                        videoFileCid:
-                          $ref: "#/components/schemas/task/properties/output/properties/export/properties/ipfs/properties/videoFileCid"
-                          index: true
-                        nftMetadataCid:
-                          $ref: "#/components/schemas/task/properties/output/properties/export/properties/ipfs/properties/nftMetadataCid"
-                          index: true
+                        ID of the last task to run successfully, that created
+                        the currently saved data.
+                    failed:
+                      type: string
+                      description: ID of the last task to fail execution.
         status:
           type: object
           additionalProperties: false
@@ -1168,6 +1155,23 @@ components:
           description:
             ID of the source asset (root) - If missing, this is a root asset
           example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
+
+    ipfs-file-info:
+      type: object
+      required: [cid]
+      additionalProperties: false
+      properties:
+        cid:
+          type: string
+          description: CID of the file on IPFS
+        url:
+          type: string
+          readOnly: true
+          description: URL with IPFS scheme for the file
+        gatewayUrl:
+          type: string
+          readOnly: true
+          description: URL to access file via HTTP through an IPFS gateway
 
     new-asset-payload:
       additionalProperties: false

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -944,7 +944,60 @@ components:
           additionalProperties: false
           properties:
             ipfs:
-              $ref: "#/components/schemas/export-task-params/oneOf/1/properties/ipfs"
+              type: object
+              required: [spec]
+              additionalProperties: false
+              properties:
+                spec:
+                  $ref: "#/components/schemas/export-task-params/oneOf/1/properties/ipfs"
+                status:
+                  readOnly: true
+                  additionalProperties: false
+                  required: [taskIds]
+                  properties:
+                    phase:
+                      type: string
+                      description: Phase of the asset storage
+                      enum:
+                        - waiting
+                        - ready
+                        - failed
+                    errorMessage:
+                      type: string
+                      description:
+                        Error message if the last storage changed failed.
+                    taskIds:
+                      type: object
+                      additionalProperties: false
+                      properties:
+                        pending:
+                          type: string
+                          description:
+                            ID of any currently running task that is exporting
+                            this asset to IPFS.
+                        last:
+                          type: string
+                          description:
+                            ID of the last task to run successfully, that
+                            created the currently saved data.
+                        failed:
+                          type: string
+                          description: ID of the last task to fail execution.
+                    addresses:
+                      type: object
+                      description:
+                        Addresses of the asset in IPFS from the last successful
+                        task execution.
+                      additionalProperties: false
+                      required: [videoFileCid]
+                      properties:
+                        $ref: "#/components/schemas/task/properties/output/properties/export/properties/ipfs/properties"
+                        videoFileCid:
+                          $ref: "#/components/schemas/task/properties/output/properties/export/properties/ipfs/properties/videoFileCid"
+                          index: true
+                        nftMetadataCid:
+                          $ref: "#/components/schemas/task/properties/output/properties/export/properties/ipfs/properties/nftMetadataCid"
+                          index: true
         status:
           type: object
           additionalProperties: false
@@ -967,43 +1020,6 @@ components:
             errorMessage:
               type: string
               description: Error message if the asset creation failed.
-            storage:
-              type: object
-              additionalProperties: false
-              properties:
-                ipfs:
-                  additionalProperties: false
-                  required: [taskIds]
-                  properties:
-                    taskIds:
-                      type: object
-                      additionalProperties: false
-                      properties:
-                        pending:
-                          type: string
-                          description:
-                            ID of any currently running task that is exporting
-                            this asset to IPFS.
-                        last:
-                          type: string
-                          description:
-                            ID of the last task to run successfully, that
-                            created the currently saved data.
-                        failed:
-                          type: string
-                          description: ID of the last task to fail execution.
-                    data:
-                      type: object
-                      additionalProperties: false
-                      required: [videoFileCid]
-                      properties:
-                        $ref: "#/components/schemas/task/properties/output/properties/export/properties/ipfs/properties"
-                        videoFileCid:
-                          $ref: "#/components/schemas/task/properties/output/properties/export/properties/ipfs/properties/videoFileCid"
-                          index: true
-                        nftMetadataCid:
-                          $ref: "#/components/schemas/task/properties/output/properties/export/properties/ipfs/properties/nftMetadataCid"
-                          index: true
         name:
           type: string
           description:

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -646,7 +646,15 @@ components:
         meta:
           $ref: "#/components/schemas/asset/properties/meta"
         storage:
-          $ref: "#/components/schemas/asset/properties/storage"
+          additionalProperties: false
+          properties:
+            ipfs:
+              oneOf:
+                - $ref: "#/components/schemas/asset/properties/storage/properties/ipfs"
+                - type: boolean
+                  description:
+                    Set to true to make default export to IPFS. False means to
+                    unpin from IPFS, but is unsupported right now.
 
     stream-patch-payload:
       type: object

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -650,7 +650,13 @@ components:
           properties:
             ipfs:
               oneOf:
-                - $ref: "#/components/schemas/asset/properties/storage/properties/ipfs"
+                - type: object
+                  additionalProperties: false
+                  properties:
+                    spec:
+                      oneOf:
+                        - type: "null"
+                        - $ref: "#/components/schemas/asset/properties/storage/properties/ipfs/properties/spec"
                 - type: [boolean, "null"]
                   description:
                     Set to true to make default export to IPFS. False or null

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -962,8 +962,24 @@ components:
               additionalProperties: false
               properties:
                 spec:
-                  $ref: "#/components/schemas/export-task-params/oneOf/1/properties/ipfs"
+                  type: object
+                  additionalProperties: false
                   default: {}
+                  properties:
+                    nftMetadataTemplate:
+                      type: string
+                      enum: [player, file]
+                      default: player
+                      description:
+                        Name of the NFT metadata template to export. 'player'
+                        will embed the Livepeer Player on the NFT while 'file'
+                        will reference only the immutable MP4 files.
+                    nftMetadata:
+                      type: object
+                      description:
+                        Additional data to add to the NFT metadata exported to
+                        IPFS. Will be deep merged with the default metadata
+                        exported.
                 $ref: "#/components/schemas/ipfs-file-info/properties"
                 nftMetadata:
                   $ref: "#/components/schemas/ipfs-file-info"
@@ -1447,6 +1463,7 @@ components:
               type: object
               additionalProperties: false
               properties:
+                $ref: "#/components/schemas/asset/properties/storage/properties/ipfs/properties/spec/properties"
                 pinata:
                   description:
                     Custom credentials for the Piñata service. Must have either
@@ -1475,19 +1492,6 @@ components:
                           writeOnly: true
                           description:
                             Will be added to the pinata_secret_api_key header.
-                nftMetadataTemplate:
-                  type: string
-                  enum: [player, file]
-                  default: player
-                  description:
-                    Name of the NFT metadata template to export. 'player' will
-                    embed the Livepeer Player on the NFT while 'file' will
-                    reference only the immutable MP4 files.
-                nftMetadata:
-                  type: object
-                  description:
-                    Additional data to add to the NFT metadata exported to IPFS.
-                    Will be deep merged with the default metadata exported.
 
     api-token:
       type: object

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -950,10 +950,11 @@ components:
               properties:
                 spec:
                   $ref: "#/components/schemas/export-task-params/oneOf/1/properties/ipfs"
+                  default: {}
                 status:
                   readOnly: true
                   additionalProperties: false
-                  required: [tasks]
+                  required: [phase, tasks]
                   properties:
                     phase:
                       type: string

--- a/packages/api/src/store/asset-table.ts
+++ b/packages/api/src/store/asset-table.ts
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import { QueryResult } from "pg";
 import sql, { SQLStatement } from "sql-template-strings";
 import { Asset } from "../schema/types";
@@ -64,13 +65,11 @@ const assetStatusCompat = (asset: DBAsset): WithID<Asset> =>
         ...asset,
         storage: {
           ipfs: {
-            spec: { ...asset.storage.ipfs },
+            spec: _.cloneDeep(asset.storage.ipfs),
             status: ipfsStatusCompat(asset.status.storage.ipfs),
           },
         },
-        status: {
-          ...{ ...asset.status, storage: undefined },
-        },
+        status: _.omit(asset.status, "storage"),
       };
 
 type FieldOf<T> = T[keyof T];

--- a/packages/api/src/store/asset-table.ts
+++ b/packages/api/src/store/asset-table.ts
@@ -34,7 +34,11 @@ type DBAsset =
     });
 
 const isUpdatedSchema = (asset: DBAsset): asset is WithID<Asset> => {
-  return !asset?.storage?.ipfs || "spec" in asset.storage.ipfs;
+  return (
+    !asset?.storage?.ipfs ||
+    "spec" in asset.storage.ipfs ||
+    "status" in asset.storage.ipfs
+  );
 };
 
 const ipfsStatusCompat = (
@@ -135,7 +139,7 @@ export default class AssetTable extends Table<DBAsset> {
 
   async getByIpfsCid(cid: string): Promise<WithID<Asset>> {
     const query = [
-      sql`asset.data->'status'->'storage'->'ipfs'->'data'->>'videoFileCid' = ${cid}`,
+      sql`asset.data->'storage'->'ipfs'->'status'->'addresses'->>'videoFileCid' = ${cid}`,
       sql`asset.data->>'deleted' IS NULL`,
     ];
     const [assets] = await this.find(query, {

--- a/packages/api/src/store/asset-table.ts
+++ b/packages/api/src/store/asset-table.ts
@@ -15,50 +15,72 @@ import {
 // Ideally this type should never be used outside of this file. It's only here
 // to fix some backward incompatible change we made on the asset.status field.
 type DBAsset =
-  | Omit<Asset, "status"> & {
+  | WithID<Asset>
+  | (Omit<Asset, "status" | "storage"> & {
       id: string;
 
-      // These are deprecated fields from when we didn't have the top-level
-      // status object in the asset resources.
-      updatedAt?: Asset["status"]["updatedAt"];
-      status?: Asset["status"] | Asset["status"]["phase"];
-    };
+      // These are deprecated fields from when we had a separate status.storage field.
+      status: Asset["status"] & {
+        storage: {
+          ipfs: {
+            taskIds: Asset["storage"]["ipfs"]["status"]["tasks"];
+            data?: Asset["storage"]["ipfs"]["status"]["addresses"];
+          };
+        };
+      };
+      storage: {
+        ipfs: Asset["storage"]["ipfs"]["spec"];
+      };
+    });
+
+const isUpdatedSchema = (asset: DBAsset): asset is WithID<Asset> => {
+  return !asset?.storage?.ipfs || "spec" in asset.storage.ipfs;
+};
+
+const ipfsStatusCompat = (
+  status: Exclude<DBAsset, WithID<Asset>>["status"]["storage"]["ipfs"]
+): StorageStatus => ({
+  phase: status.taskIds.pending
+    ? "waiting"
+    : status.taskIds.last
+    ? "ready"
+    : "failed",
+  tasks: status.taskIds,
+  addresses: status.data,
+});
 
 // Receives an asset from database and returns it in the new status schema.
 //
 // TODO: Update existing objects in DB with the new schema to remove this
 // compatibility code.
 const assetStatusCompat = (asset: DBAsset): WithID<Asset> =>
-  !asset || typeof asset.status === "object"
-    ? (asset as WithID<Asset>)
+  isUpdatedSchema(asset)
+    ? asset
     : {
-        ...{ ...asset, updatedAt: undefined },
+        ...asset,
+        storage: {
+          ipfs: {
+            spec: { ...asset.storage.ipfs },
+            status: ipfsStatusCompat(asset.status.storage.ipfs),
+          },
+        },
         status: {
-          phase: asset.status,
-          updatedAt: asset.updatedAt,
+          ...{ ...asset.status, storage: undefined },
         },
       };
 
-export const mergeAssetStatus = (
-  s1: Asset["status"],
-  s2: Partial<Asset["status"]>,
-  updatedAt: number = Date.now()
-): Asset["status"] => ({
+type FieldOf<T> = T[keyof T];
+type StorageStatus = FieldOf<Asset["storage"]>["status"];
+
+export const mergeStorageStatus = <S extends StorageStatus>(
+  s1: S,
+  s2: Partial<S>
+): S => ({
   ...s1,
   ...s2,
-  updatedAt,
-  storage: {
-    ...s1?.storage,
-    ...s2?.storage,
-    ipfs: {
-      ...s1?.storage?.ipfs,
-      ...s2?.storage?.ipfs,
-      taskIds: {
-        ...s1?.storage?.ipfs?.taskIds,
-        ...s2?.storage?.ipfs?.taskIds,
-      },
-      // data is not mergeable, just keep the result of the spread above (s2>s1)
-    },
+  tasks: {
+    ...s1?.tasks,
+    ...s2?.tasks,
   },
 });
 

--- a/packages/api/src/store/asset-table.ts
+++ b/packages/api/src/store/asset-table.ts
@@ -45,18 +45,21 @@ const isUpdatedSchema = (asset: DBAsset): asset is WithID<Asset> => {
 
 export const taskOutputToIpfsStorage = (
   out: Task["output"]["export"]["ipfs"]
-): Omit<Asset["storage"]["ipfs"], "spec"> => ({
-  cid: out.videoFileCid,
-  url: out.videoFileUrl,
-  gatewayUrl: out.videoFileGatewayUrl,
-  nftMetadata: !out.nftMetadataCid
-    ? undefined
+): Omit<Asset["storage"]["ipfs"], "spec"> =>
+  !out
+    ? null
     : {
-        cid: out.nftMetadataCid,
-        url: out.nftMetadataUrl,
-        gatewayUrl: out.nftMetadataGatewayUrl,
-      },
-});
+        cid: out.videoFileCid,
+        url: out.videoFileUrl,
+        gatewayUrl: out.videoFileGatewayUrl,
+        nftMetadata: !out.nftMetadataCid
+          ? undefined
+          : {
+              cid: out.nftMetadataCid,
+              url: out.nftMetadataUrl,
+              gatewayUrl: out.nftMetadataGatewayUrl,
+            },
+      };
 
 const ipfsStatusCompat = (
   status: Exclude<DBAsset, WithID<Asset>>["status"]["storage"]["ipfs"]
@@ -153,7 +156,7 @@ export default class AssetTable extends Table<DBAsset> {
 
   async getByIpfsCid(cid: string): Promise<WithID<Asset>> {
     const query = [
-      sql`asset.data->'storage'->'ipfs'->'status'->'addresses'->>'videoFileCid' = ${cid}`,
+      sql`asset.data->'storage'->'ipfs'->>'cid' = ${cid}`,
       sql`asset.data->>'deleted' IS NULL`,
     ];
     const [assets] = await this.find(query, {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

This is to make the `storage` API from assets a little easier to understand, reason and use
by moving the `status` of the storage exports to inside the `storage` fields itself. This avoids
repeating the same storage types in different places and having to parse through the whole
object to find the result of something you patched somewhere else.

With this change, there are now 3 ways of adding an IPFS storage to an app:
 - `PATCH /asset/:id {"storage": { "ipfs": true } }`
 - `PATCH /asset/:id {"storage": { "ipfs": {} } }` (backward compatibility)
 - `PATCH /asset/:id {"storage": { "ipfs": { spec: {} } } }`

After doing so, the `status` of the `ipfs` storage will be shown in the same place, sth like:
```yaml
{ 
  "id": "...", 
  "storage": { 
    "ipfs": { 
      "spec": {}, 
      "status": { 
        phase: "waiting", 
        tasks: { last: "abc" }, 
        addresses: { videoFileCid: ... ... } 
    } 
  } 
}
```

To save to IPFS with custom options, like a custom `nftMetadata`, the API is:
 - `PATCH /asset/:id {"storage": { "ipfs": { spec: { nftMetadata: { "a": "example" } } } } }`

And the `storage` object in the `asset` is updated in a similar manner, keeping the provided `spec`.
If the task fails, it reverts to the previous task spec + addresses.


**Specific updates (required)**
 - Change schame of asset with the new setup
 - Implement a migration logic from old format to the new. This includes:
   - A logic to transform the objects on-demand when reading them from DB (if old format)
   - And an API to actually change the objects in the DB, to be called manually until all are migrated

## -

- **How did you test each of these updates (required)**
Wrote a bunch of tests and `yarn test`ed'em out.

**Does this pull request close any open issues?**
Implements #1167


**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
