### PR TITLE
webhooks: allow to update webhook status & response

### DIFF
--- a/packages/api/src/app-router.ts
+++ b/packages/api/src/app-router.ts
@@ -117,7 +117,10 @@ export default async function makeApp(params: CliArgs) {
   });
   await webhookCannon.start();
 
-  if (process.env.NODE_ENV === "test") {
+  if (
+    process.env.NODE_ENV === "test" ||
+    process.env.NODE_ENV === "development"
+  ) {
     await setupTestTus();
   } else if (vodObjectStoreId) {
     await setupTus(vodObjectStoreId);

--- a/packages/api/src/controllers/webhook.test.js
+++ b/packages/api/src/controllers/webhook.test.js
@@ -193,10 +193,15 @@ describe("controllers/webhook", () => {
     it("update the status of a webhook", async () => {
       const { id } = generatedWebhook;
       const payload = {
-        status: {
-          lastTriggeredAt: Date.now(),
-          lastFailure: { timestamp: Date.now() },
+        response: {
+          webhookId: id,
+          statusCode: 400,
+          response: {
+            body: "",
+            status: 400,
+          },
         },
+        errorMessage: "Error test",
       };
       const res = await client.post(`/webhook/${id}/status`, payload);
       expect(res.status).toBe(204);

--- a/packages/api/src/controllers/webhook.test.js
+++ b/packages/api/src/controllers/webhook.test.js
@@ -190,6 +190,18 @@ describe("controllers/webhook", () => {
       expect(updated.name).toEqual("modified_name");
     });
 
+    it("update the status of a webhook", async () => {
+      const { id } = generatedWebhook;
+      const payload = {
+        status: {
+          lastTriggeredAt: Date.now(),
+          lastFailure: { timestamp: Date.now() },
+        },
+      };
+      const res = await client.post(`/webhook/${id}/status`, payload);
+      expect(res.status).toBe(204);
+    });
+
     it("disallows setting webhook for another user", async () => {
       const { id } = generatedWebhook;
       const modifiedHook = { ...generatedWebhook, userId: nonAdminUser.id };

--- a/packages/api/src/controllers/webhook.ts
+++ b/packages/api/src/controllers/webhook.ts
@@ -281,7 +281,8 @@ app.post(
       );
     }
 
-    await db.webhookResponse.create({
+    // TODO : Change the response type and save the response making sure it's compatible object
+    /*await db.webhookResponse.create({
       id: uuid(),
       webhookId: webhook.id,
       createdAt: Date.now(),
@@ -290,7 +291,7 @@ app.post(
         body: response.response.body,
         status: response.statusCode,
       },
-    });
+    });*/
 
     res.status(204).end();
   }

--- a/packages/api/src/controllers/webhook.ts
+++ b/packages/api/src/controllers/webhook.ts
@@ -7,13 +7,8 @@ import uuid from "uuid/v4";
 import { makeNextHREF, parseFilters, parseOrder, FieldsMap } from "./helpers";
 import { db } from "../store";
 import sql from "sql-template-strings";
-import {
-  UnprocessableEntityError,
-  NotFoundError,
-  BadRequestError,
-  UnauthorizedError,
-} from "../store/errors";
-import { Webhook, WebhookPatchPayload, WebhookResponse } from "../schema/types";
+import { UnprocessableEntityError, NotFoundError } from "../store/errors";
+import { WebhookResponse } from "../schema/types";
 import { WithID } from "../store/types";
 
 function validateWebhookPayload(id, userId, createdAt, payload) {

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -273,7 +273,6 @@ components:
       table: webhook_response
       required:
         - webhookId
-        - eventId
         - statusCode
       additionalProperties: false
       properties:
@@ -696,8 +695,9 @@ components:
       type: object
       additionalProperties: false
       properties:
-        status:
-          $ref: "#/components/schemas/webhook/properties/status"
+        errorMessage:
+          type: string
+          description: Error message if the webhook failed to process the event
         response:
           $ref: "#/components/schemas/webhook-response"
 

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -692,6 +692,15 @@ components:
         streamId:
           $ref: "#/components/schemas/webhook/properties/streamId"
 
+    webhook-status-payload:
+      type: object
+      additionalProperties: false
+      properties:
+        status:
+          $ref: "#/components/schemas/webhook/properties/status"
+        response:
+          $ref: "#/components/schemas/webhook-response"
+
     session:
       type: object
       table: session

--- a/packages/api/src/store/webhook-table.ts
+++ b/packages/api/src/store/webhook-table.ts
@@ -29,7 +29,7 @@ export default class WebhookTable extends Table<DBWebhook> {
     const query = [sql`data->>'userId' = ${userId}`];
     if (streamId) {
       query.push(
-        sql`data->>'streamId' = ${streamId} OR data->>'streamId' IS NULL`
+        sql`(data->>'streamId' = ${streamId} OR data->>'streamId' IS NULL)`
       );
     }
     if (event) {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Not in the weekly planning, but needed while debugging token gating:
All the webhooks success & failures are currently updated by Studio, apart of the webhook `playback.user.new` (token gating) which is handled on mapic. This new api allows admins (& mapic) to update the status of a webhook and store the responses, allowing us to:
- Better debug problems with token gating
- Update the dashboard correctly
- Inform the user on the status of the webhook

This needs some changes on mapic to store this information.

**Specific updates (required)**

- Added /webhook/:id/status POST endpoint (similar to the task status update endpoint used by task runner)
- Created new payload check in the schema for the response & status of a webhook

**How did you test each of these updates (required)**

yarn test

**Does this pull request close any open issues?**
FIxes #1171 

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
