### PR TITLE
Added instructions to start the RabbitMQ container

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -8,10 +8,16 @@ Ensure Docker is running.
 
 ### Step 2
 
-Start the postgres database.
+Start the postgres database:
 
 ```bash
 yarn run postgres:start
+```
+
+Then start RabbitMQ:
+
+```bash
+yarn run rabbitmq:start
 ```
 
 ### Step 3


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
I added the instructions to start the RabbitMQ container when starting the `/api` package locally.

**Specific updates (required)**

In the `package/api/README.md` I added a few line to start the RabbitMQ docker image.

## -

- **How did you test each of these updates (required)**

Before, I was receiving an error the the RabbitMQ container was not replying when starting the package with `yarn dev`. Then when I started manually the RabbitMQ container, the error disappeared. The `www` package also was able to run properly and I was able to register a new user.

**Does this pull request close any open issues?**

No

**Checklist:**

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
