### PR TITLE
api: FIx object store URL parsing

### DIFF
--- a/packages/api/src/controllers/asset.test.ts
+++ b/packages/api/src/controllers/asset.test.ts
@@ -79,7 +79,7 @@ describe("controllers/asset", () => {
   beforeEach(async () => {
     await db.objectStore.create({
       id: "mock_vod_store",
-      url: "http://user:password@localhost:8080/us-east-1/vod",
+      url: "s3+http://user:password@localhost:8080/us-east-1/vod",
     });
     ({ client, adminUser, adminApiKey, nonAdminUser, nonAdminToken } =
       await setupUsers(server, mockAdminUserInput, mockNonAdminUserInput));

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -629,7 +629,7 @@ export const setupTus = async (objectStoreId: string): Promise<void> => {
 
 async function createTusServer(objectStoreId: string) {
   const s3config = await getObjectStoreS3Config(objectStoreId);
-  const opts: tus.S3StoreOptions | S3ClientConfig = {
+  const opts: tus.S3StoreOptions & S3ClientConfig = {
     ...s3config,
     path: "/upload/tus",
     partSize: 8 * 1024 * 1024,
@@ -637,7 +637,7 @@ async function createTusServer(objectStoreId: string) {
     namingFunction,
   };
   const tusServer = new tus.Server();
-  tusServer.datastore = new tus.S3Store(opts as tus.S3StoreOptions);
+  tusServer.datastore = new tus.S3Store(opts);
   tusServer.on(tus.EVENTS.EVENT_UPLOAD_COMPLETE, onTusUploadComplete(false));
   return tusServer;
 }

--- a/packages/api/src/controllers/generate-keys.test.ts
+++ b/packages/api/src/controllers/generate-keys.test.ts
@@ -65,7 +65,7 @@ describe("controllers/generate-keys", () => {
   beforeEach(async () => {
     await db.objectStore.create({
       id: "mock_vod_store",
-      url: "http://user:password@localhost:8080/us-east-1/vod",
+      url: "s3+http://user:password@localhost:8080/us-east-1/vod",
     });
     ({ client, adminUser, adminApiKey, nonAdminUser, nonAdminToken } =
       await setupUsers(server, mockAdminUserInput, mockNonAdminUserInput));

--- a/packages/api/src/controllers/helpers.test.ts
+++ b/packages/api/src/controllers/helpers.test.ts
@@ -1,0 +1,69 @@
+import serverPromise, { TestServer } from "../test-server";
+import { clearDatabase } from "../test-helpers";
+import { ObjectStore, User } from "../schema/types";
+import { db } from "../store";
+import { v4 as uuid } from "uuid";
+import { getS3PresignedUrl } from "./helpers";
+
+let server: TestServer;
+
+// jest.setTimeout(70000)
+
+beforeAll(async () => {
+  server = await serverPromise;
+});
+
+afterEach(async () => {
+  await clearDatabase(server);
+});
+
+describe("helpers/osS3Urls", () => {
+  const makePresignedUrl = async (url: string, file = "test.txt") => {
+    const os = await db.objectStore.create({
+      id: uuid(),
+      name: "test",
+      url,
+    });
+    return getS3PresignedUrl(os.id, file);
+  };
+
+  it("should support old object store URLs with region", async () => {
+    const presignedUrl = await makePresignedUrl(
+      "s3+http://localhost:8000/test-region/test-bucket"
+    );
+    expect(presignedUrl).toMatch(
+      /^http:\/\/localhost:8000\/test-bucket\/test\.txt.+test-region.+$/
+    );
+  });
+
+  it("should support new object store URLs without region", async () => {
+    const presignedUrl = await makePresignedUrl(
+      "s3+https://localhost:8000/test-bucket"
+    );
+    expect(presignedUrl).toMatch(
+      /^https:\/\/localhost:8000\/test-bucket\/test\.txt.+ignored.+$/
+    );
+  });
+
+  it("should support access credentials", async () => {
+    const presignedUrl = await makePresignedUrl(
+      "s3+https://poweruser:secretpwd@localhost:8000/test-bucket"
+    );
+    expect(presignedUrl).toMatch(
+      /^https:\/\/localhost:8000\/test-bucket\/test\.txt.+poweruser.+$/
+    );
+    expect(presignedUrl).not.toContain("secretpwd");
+  });
+
+  it("should NOT support invalid object store URLs", async () => {
+    await expect(
+      makePresignedUrl("not-s3://localhost:8000/test-bucket")
+    ).rejects.toThrow(/not-s3:/);
+    await expect(
+      makePresignedUrl("s3+https://localhost:8000/")
+    ).rejects.toThrow(/"\/"/);
+    await expect(
+      makePresignedUrl("s3+https://localhost:8000/region/bucket/path")
+    ).rejects.toThrow(/"\/region\/bucket\/path"/);
+  });
+});

--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -163,7 +163,7 @@ export async function getS3PresignedUrl(
     Bucket: config.bucket,
     Key: objectKey,
   });
-  const expiresIn = 3 * 60 * 60; // 3h in seconds
+  const expiresIn = 12 * 60 * 60; // 12h in seconds
   return getSignedUrl(s3, putCommand, { expiresIn });
 }
 

--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -132,9 +132,9 @@ export async function getObjectStoreS3Config(
   }
   protocol = protocol.substring(3);
 
-  const segs = url.pathname.split("/").slice(1);
+  const segs = url.pathname.split("/").filter((s, i) => i > 0 && !!s);
   if (!segs.length || segs.length > 2) {
-    throw new Error(`Invalid OS URL path: ${url.pathname}`);
+    throw new Error(`Invalid OS URL path: "${url.pathname}"`);
   }
   const [region, bucket] = segs.length === 1 ? ["ignored", segs[0]] : segs;
 
@@ -146,7 +146,7 @@ export async function getObjectStoreS3Config(
     region,
     bucket,
     signingRegion: region,
-    endpoint: `${protocol}//${url.hostname}`,
+    endpoint: `${protocol}//${url.host}`,
     forcePathStyle: true,
   };
 }

--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -127,7 +127,7 @@ export async function getObjectStoreS3Config(
   const store = await db.objectStore.get(osId);
   const url = new URL(store.url);
   let protocol = url.protocol;
-  if (protocol !== "s3+http" && protocol !== "s3+https") {
+  if (protocol !== "s3+http:" && protocol !== "s3+https:") {
     throw new Error(`Unsupported OS URL protocol: ${protocol}`);
   }
   protocol = protocol.substring(3);

--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -161,9 +161,8 @@ export async function getS3PresignedUrl(
     Bucket: config.bucket,
     Key: objectKey,
   });
-  const url = await getSignedUrl(s3, putCommand, { expiresIn: 15 * 60 }); // expires in seconds
-  console.log(`Signed URL: ${url}`);
-  return url;
+  const expiresIn = 3 * 60 * 60; // 3h in seconds
+  return getSignedUrl(s3, putCommand, { expiresIn });
 }
 
 type EmailParams = {

--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -128,19 +128,24 @@ export async function getObjectStoreS3Config(
   const url = new URL(store.url);
   let protocol = url.protocol;
   if (protocol !== "s3+http" && protocol !== "s3+https") {
-    throw new Error(`Unsupported OS protocol: ${protocol}`);
+    throw new Error(`Unsupported OS URL protocol: ${protocol}`);
   }
   protocol = protocol.substring(3);
-  const [_, vodRegion, vodBucket] = url.pathname.split("/");
+
+  const segs = url.pathname.split("/").slice(1);
+  if (!segs.length || segs.length > 2) {
+    throw new Error(`Invalid OS URL path: ${url.pathname}`);
+  }
+  const [region, bucket] = segs.length === 1 ? ["ignored", segs[0]] : segs;
 
   return {
     credentials: {
       accessKeyId: url.username,
       secretAccessKey: url.password,
     },
-    region: vodRegion,
-    bucket: vodBucket,
-    signingRegion: vodRegion,
+    region,
+    bucket,
+    signingRegion: region,
     endpoint: `${protocol}//${url.hostname}`,
     forcePathStyle: true,
   };

--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -132,11 +132,13 @@ export async function getObjectStoreS3Config(
   }
   protocol = protocol.substring(3);
 
-  const segs = url.pathname.split("/").filter((s, i) => i > 0 && !!s);
-  if (!segs.length || segs.length > 2) {
+  let segs = url.pathname.split("/").filter((s, i) => i > 0 && !!s);
+  if (segs.length === 1) {
+    segs = ["ignored", ...segs];
+  } else if (segs.length !== 2) {
     throw new Error(`Invalid OS URL path: "${url.pathname}"`);
   }
-  const [region, bucket] = segs.length === 1 ? ["ignored", segs[0]] : segs;
+  const [region, bucket] = segs;
 
   return {
     credentials: {

--- a/packages/api/src/controllers/object-store.js
+++ b/packages/api/src/controllers/object-store.js
@@ -158,12 +158,16 @@ app.patch("/:id", authorizer({}), async (req, res) => {
       errors: ["users may change only their own object stores"],
     });
   }
-  if (req.body.disabled === undefined) {
+  const { disabled, url } = req.body;
+  if (
+    (disabled === undefined && url === undefined) ||
+    typeof url !== "string"
+  ) {
     res.status(400);
-    return res.json({ errors: ["disabled field required"] });
+    return res.json({ errors: ["disabled or url fields required"] });
   }
-  console.log(`set object store ${id} disabled=${req.body.disabled}`);
-  await db.objectStore.update(id, { disabled: !!req.body.disabled });
+  console.log(`set object store ${id} disabled=${disabled} url=${url}`);
+  await db.objectStore.update(id, { disabled: !!disabled, url });
   res.status(204);
   res.end();
 });

--- a/packages/api/src/controllers/playback.test.ts
+++ b/packages/api/src/controllers/playback.test.ts
@@ -45,7 +45,7 @@ describe("controllers/playback", () => {
     beforeEach(async () => {
       await db.objectStore.create({
         id: "mock_vod_store",
-        url: "http://user:password@localhost:8080/us-east-1/vod",
+        url: "s3+http://user:password@localhost:8080/us-east-1/vod",
       });
 
       ({ client, nonAdminToken } = await setupUsers(

--- a/packages/api/src/middleware/auth.test.ts
+++ b/packages/api/src/middleware/auth.test.ts
@@ -451,14 +451,10 @@ describe("auth middleware", () => {
       );
       const corsAllowed =
         res.headers.get("access-control-allow-origin") === origin;
-      let body = await res.text();
-      try {
-        body = JSON.parse(body);
-      } catch (e) {}
       return {
         corsAllowed,
         status: res.status,
-        body,
+        body: await res.json().catch((err) => null),
       };
     };
 
@@ -486,13 +482,11 @@ describe("auth middleware", () => {
     it("should allow requests from any origin on always-allowed paths", async () => {
       for (const method of testMethods) {
         for (const origin of testOrigins) {
-          const cors = await fetchCors(
+          await expectAllowed(
             method,
             "/asset/upload/direct?token=eyJhbG.eyJzdWI.SflKx",
             origin
-          );
-          expect(cors.body).toBe({});
-          expect(cors.corsAllowed).toBe(true);
+          ).toBe(true);
           await expectAllowed(method, "/playback/1234", origin).toBe(true);
         }
       }

--- a/packages/api/src/middleware/auth.test.ts
+++ b/packages/api/src/middleware/auth.test.ts
@@ -451,10 +451,14 @@ describe("auth middleware", () => {
       );
       const corsAllowed =
         res.headers.get("access-control-allow-origin") === origin;
+      let body = await res.text();
+      try {
+        body = JSON.parse(body);
+      } catch (e) {}
       return {
         corsAllowed,
         status: res.status,
-        body: await res.json().catch((err) => null),
+        body,
       };
     };
 
@@ -482,11 +486,13 @@ describe("auth middleware", () => {
     it("should allow requests from any origin on always-allowed paths", async () => {
       for (const method of testMethods) {
         for (const origin of testOrigins) {
-          await expectAllowed(
+          const cors = await fetchCors(
             method,
             "/asset/upload/direct?token=eyJhbG.eyJzdWI.SflKx",
             origin
-          ).toBe(true);
+          );
+          expect(cors.body).toBe({});
+          expect(cors.corsAllowed).toBe(true);
           await expectAllowed(method, "/playback/1234", origin).toBe(true);
         }
       }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Fixes the API logic for parsing Object Store URLs, currently used only for the 
VOD APIs for uploading files (both `direct` and `tus`).

The fix is necessary because the [Go library](https://github.com/livepeer/go-tools) for parsing these URLs changed
in an incompatible way for the Catalyst VOD work to flow through. Specifically, it does
not support having regions in the URLs anymore because it now supports specifying a path
prefix after the bucket name.

**Specific updates (required)**
 - Create a helper function to parse these URLs so we don't need to keep repeating the logic
 - Update it to allow URLs to be specified without the region
 - Fix and add some tests

## -

- **How did you test each of these updates (required)**
 - [x] `yarn test`
 - [x] Deploy on staging, update OS URLs and ensure upload works

**Does this pull request close any open issues?**
Implements #1205 

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
