### PR TITLE
api: Improve reliability of AMQP publishes

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -56,7 +56,7 @@
     "@types/cors": "^2.8.12",
     "ajv": "^6.10.0",
     "ajv-cli": "^3.1.0",
-    "amqp-connection-manager": "3.2.2",
+    "amqp-connection-manager": "^4.1.6",
     "amqplib": "^0.8.0",
     "analytics-node": "^3.4.0-beta.1",
     "any-base": "^1.1.0",

--- a/packages/api/src/store/queue.ts
+++ b/packages/api/src/store/queue.ts
@@ -95,6 +95,7 @@ export class RabbitQueue implements Queue {
     this.connection = amqp.connect([url]);
     this.channel = this.connection.createChannel({
       json: true,
+      publishTimeout: 10_000, // 10s
       setup: async (channel: Channel) => {
         await Promise.all([
           channel.assertQueue(QUEUES.events, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7782,12 +7782,12 @@ alphanum-sort@^1.0.0:
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
   integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
 
-amqp-connection-manager@3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/amqp-connection-manager/-/amqp-connection-manager-3.2.2.tgz#73c820b6ed440b451de24c1eb9cf3541a10635d9"
-  integrity sha512-o+6Kb4p+xFYwU8MuFxnrPQzhefCE2dcCd8dnevWLTRgQCtOTVC9AQ434hQyjB+Bpq6Vl9cDMWTOZT11ajB6ZSg==
+amqp-connection-manager@^4.1.6:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/amqp-connection-manager/-/amqp-connection-manager-4.1.6.tgz#63e932b642d67d27119bf769cd71e6fd08007a8e"
+  integrity sha512-RFbVdA6COw+968HpZAeR4KJtgcBeKR626MTQjgHRwolaHry4Gg4Z7dJHwHerqlYbv5dAP8VB29AXYwu+XZP3JQ==
   dependencies:
-    promise-breaker "^5.0.0"
+    promise-breaker "^6.0.0"
 
 amqplib@^0.8.0:
   version "0.8.0"
@@ -22291,10 +22291,10 @@ prom-client@^14.0.1:
   dependencies:
     tdigest "^0.1.1"
 
-promise-breaker@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/promise-breaker/-/promise-breaker-5.0.0.tgz#58e8541f1619554057da95a211794d7834d30c1d"
-  integrity sha512-mgsWQuG4kJ1dtO6e/QlNDLFtMkMzzecsC69aI5hlLEjGHFNpHrvGhFi4LiK5jg2SMQj74/diH+wZliL9LpGsyA==
+promise-breaker@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/promise-breaker/-/promise-breaker-6.0.0.tgz#107d2b70f161236abdb4ac5a736c7eb8df489d0f"
+  integrity sha512-BthzO9yTPswGf7etOBiHCVuugs2N01/Q/94dIPls48z2zCmrnDptUUZzfIb+41xq0MnYZ/BzmOd6ikDR4ibNZA==
 
 promise-inflight@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This bumps the `amqp-connection-manager` lib version to get a couple
of new features and hopefully bug fixes.

We can now define a publish timeout, so we'll get an exception instead 
of hanging forever when a message publish fails.

We were also more than a major behind, so we'll hopefully get a couple of 
bug fixes and improvements as well.

**Specific updates (required)**
 - Bump lib
 - Fix usage
 - Add default `publishTimeout`

## -

- **How did you test each of these updates (required)**
`yarn test`, staging

**Does this pull request close any open issues?**
Many bug reports where tasks simply hang. This will hopefully turn them at least into an explicit error instead.

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
