### PR TITLE
api: Decode username and password from OS URLs

### DIFF
--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -140,8 +140,8 @@ export async function getObjectStoreS3Config(
   }
   const [region, bucket] = segs;
   const credentials = {
-    accessKeyId: url.username,
-    secretAccessKey: url.password,
+    accessKeyId: decodeURIComponent(url.username),
+    secretAccessKey: decodeURIComponent(url.password),
   };
   return {
     ...credentials, // inline credentials for tus config


### PR DESCRIPTION
We weren't decoding them so the AWS client broke.