### PR TITLE
Website UX fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -375,3 +375,5 @@ tags
 # .pnp.*
 
 # End of https://www.toptal.com/developers/gitignore/api/nextjs,emacs,macos,vim,intellij+all,node,yarn
+
+.vscode/*

--- a/packages/www/components/Dashboard/AllSessionsTable/index.tsx
+++ b/packages/www/components/Dashboard/AllSessionsTable/index.tsx
@@ -246,7 +246,9 @@ const AllSessionsTable = ({ title = "Sessions" }: { title?: string }) => {
       <Text variant="gray" css={{ lineHeight: 1.5, mb: "$3" }}>
         Stream sessions belong to parent streams.
       </Text>
-      <Link href="https://docs.livepeer.studio/references/session/" passHref>
+      <Link
+        href="https://docs.livepeer.studio/reference/api/get-session"
+        passHref>
         <A
           target="_blank"
           variant="primary"

--- a/packages/www/components/Dashboard/AssetsTable/index.tsx
+++ b/packages/www/components/Dashboard/AssetsTable/index.tsx
@@ -194,7 +194,9 @@ const AssetsTable = ({
               display: "flex",
             },
           }}>
-          <Link href="/docs/api-reference/vod/import" passHref>
+          <Link
+            href="https://docs.livepeer.studio/category/on-demand "
+            passHref>
             <A
               target="_blank"
               variant="primary"

--- a/packages/www/components/Dashboard/AssetsTable/index.tsx
+++ b/packages/www/components/Dashboard/AssetsTable/index.tsx
@@ -179,10 +179,10 @@ const AssetsTable = ({
           maxWidth: 450,
         }}>
         <Heading css={{ fontWeight: 500, mb: "$3" }}>
-          Upload your first Video on Demand asset
+          Upload your first On Demand asset
         </Heading>
         <Text variant="gray" css={{ lineHeight: 1.5, mb: "$3" }}>
-          Livepeer Studio supports Video on Demand which allows you to import
+          Livepeer Studio supports video on demand which allows you to import
           video assets, store them on decentralized storage, and easily mint a
           video NFT.
         </Text>

--- a/packages/www/components/Dashboard/GettingStarted/index.tsx
+++ b/packages/www/components/Dashboard/GettingStarted/index.tsx
@@ -40,7 +40,7 @@ const GettingStarted = ({ firstName = "" }) => {
                 <Link passHref href="https://streamlabs.com/">
                   <A target="_blank">streamlabs</A>
                 </Link>
-                . Here’s how.
+                . Here’s how:
               </Text>
               <Text
                 variant="gray"
@@ -63,7 +63,7 @@ const GettingStarted = ({ firstName = "" }) => {
               </Text>
             </Box>
             <Link
-              href="https://docs.livepeer.studio/guides/livestreaming/"
+              href="https://docs.livepeer.studio/guides/live/create-a-livestream"
               passHref>
               <Button
                 as="a"
@@ -109,7 +109,7 @@ const GettingStarted = ({ firstName = "" }) => {
               </Link>
               .
             </Text>
-            <Link href="https://docs.livepeer.studio/references" passHref>
+            <Link href="https://docs.livepeer.studio/category/api" passHref>
               <Button
                 as="a"
                 target="_blank"
@@ -142,9 +142,7 @@ const GettingStarted = ({ firstName = "" }) => {
               and at scale. Get started by reviewing and cloning one of our
               sample apps.
             </Text>
-            <Link
-              href="https://docs.livepeer.studio/guides/sampleslib"
-              passHref>
+            <Link href="https://docs.livepeer.studio/category/api" passHref>
               <Button
                 as="a"
                 target="_blank"

--- a/packages/www/components/Dashboard/GettingStarted/index.tsx
+++ b/packages/www/components/Dashboard/GettingStarted/index.tsx
@@ -142,7 +142,9 @@ const GettingStarted = ({ firstName = "" }) => {
               and at scale. Get started by reviewing and cloning one of our
               sample apps.
             </Text>
-            <Link href="https://docs.livepeer.studio/category/api" passHref>
+            <Link
+              href="https://docs.livepeer.studio/reference/examples"
+              passHref>
               <Button
                 as="a"
                 target="_blank"

--- a/packages/www/components/Dashboard/Header/index.tsx
+++ b/packages/www/components/Dashboard/Header/index.tsx
@@ -290,7 +290,7 @@ const Header = ({ breadcrumbs = [] }) => {
               <Box css={{ position: "absolute", right: "6px", top: "-12px" }}>
                 <StyledPolygonIcon />
               </Box>
-              <Text size="2" css={{ mb: "$3", color: "$primary9" }}>
+              <Text size="2" css={{ mb: "$3", color: "$hiContrast" }}>
                 HELP
               </Text>
               <Link href="https://docs.livepeer.studio" passHref>

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/SaveTargetDialog.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/SaveTargetDialog.tsx
@@ -239,7 +239,7 @@ const SaveTargetDialog = ({
           <Heading size="1">
             {`${action} multistream target`}
             {action === Action.Create ? (
-              <Badge size="2" variant="primary" css={{ ml: "$2" }}>
+              <Badge size="2" variant="neutral" css={{ ml: "$2" }}>
                 Beta
               </Badge>
             ) : null}

--- a/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
+++ b/packages/www/components/Dashboard/MultistreamTargetsTable/index.tsx
@@ -53,7 +53,9 @@ const defaultEmptyState = (
     <Text variant="gray" css={{ lineHeight: 1.5, mb: "$3" }}>
       Multistream targets are sent the live media from the stream.
     </Text>
-    <Link href="https://docs.livepeer.studio/references/session/" passHref>
+    <Link
+      href="https://docs.livepeer.studio/reference/api/get-session"
+      passHref>
       <A
         target="_blank"
         variant="primary"

--- a/packages/www/components/Dashboard/Player/index.tsx
+++ b/packages/www/components/Dashboard/Player/index.tsx
@@ -22,6 +22,7 @@ export default function Player({
       autoPlay={autoPlay}
       controls={controls}
       width={width}
+      style={{ display: "flex" }}
     />
   );
 }

--- a/packages/www/components/Dashboard/SessionsTable/index.tsx
+++ b/packages/www/components/Dashboard/SessionsTable/index.tsx
@@ -100,7 +100,9 @@ const defaultEmptyState = (
     <Text variant="gray" css={{ lineHeight: 1.5, mb: "$3" }}>
       Sessions belong to parent streams.
     </Text>
-    <Link href="https://docs.livepeer.studio/references/session/" passHref>
+    <Link
+      href="https://docs.livepeer.studio/reference/api/get-session"
+      passHref>
       <A
         target="_blank"
         variant="primary"

--- a/packages/www/components/Dashboard/StreamsTable/index.tsx
+++ b/packages/www/components/Dashboard/StreamsTable/index.tsx
@@ -318,7 +318,7 @@ const StreamsTable = ({
         Create a unique stream object, broadcast live video content and playback
         your live stream with Livepeer Studio.
       </Text>
-      <Link href="https://docs.livepeer.studio/guides" passHref>
+      <Link href="https://docs.livepeer.studio/category/live" passHref>
         <A
           target="_blank"
           variant="primary"

--- a/packages/www/components/Dashboard/TokenTable/CreateTokenDialog.tsx
+++ b/packages/www/components/Dashboard/TokenTable/CreateTokenDialog.tsx
@@ -256,7 +256,7 @@ const CreateTokenDialog = ({
                       align="center">
                       <Label htmlFor="allowCors">Allow CORS access</Label>
                       <Link
-                        href="https://docs.livepeer.studio/guides/livestreaming/api-key#cors"
+                        href="https://docs.livepeer.studio/quickstart/#create-api-key"
                         target="_blank">
                         <Warning />
                       </Link>

--- a/packages/www/components/Dashboard/TokenTable/index.tsx
+++ b/packages/www/components/Dashboard/TokenTable/index.tsx
@@ -232,7 +232,7 @@ const TokenTable = ({
       <Text variant="gray" css={{ lineHeight: 1.5, mb: "$3" }}>
         API keys allow you to authenticate API requests in your app
       </Text>
-      <Link href="https://docs.livepeer.studio/references" passHref>
+      <Link href="https://docs.livepeer.studio/category/api" passHref>
         <A
           target="_blank"
           variant="primary"

--- a/packages/www/components/Dashboard/UsageSummary/index.tsx
+++ b/packages/www/components/Dashboard/UsageSummary/index.tsx
@@ -46,7 +46,7 @@ const UsageCard = ({ title, usage, limit, loading = false }) => {
         </Box>
       ) : (
         <>
-          <Box css={{ mb: "$2", color: "$primary9" }}>{title}</Box>
+          <Box css={{ mb: "$2", color: "$hiContrast" }}>{title}</Box>
           <Flex align="center" css={{ fontSize: "$6" }}>
             <Box css={{ fontWeight: 700 }}>{usage}</Box>
             {limit && <Box css={{ mx: "$1" }}>/</Box>}
@@ -123,7 +123,7 @@ const UsageSummary = () => {
             </Box>
             <Badge
               size="1"
-              variant="primary"
+              variant="neutral"
               css={{ letterSpacing: 0, mt: "7px" }}>
               {user?.stripeProductId
                 ? products[user.stripeProductId].name
@@ -132,7 +132,7 @@ const UsageSummary = () => {
             </Badge>
           </Flex>
         </Heading>
-        <Flex css={{ fontSize: "$3", color: "$primary9" }}>
+        <Flex css={{ fontSize: "$3", color: "$hiContrast" }}>
           Current billing period (
           {subscription && (
             <Flex>

--- a/packages/www/layouts/assetDetail.tsx
+++ b/packages/www/layouts/assetDetail.tsx
@@ -339,17 +339,17 @@ const AssetDetail = ({
                           fontSize: "$2",
                           position: "relative",
                         }}>
-                        <Cell css={{ color: "$primary11" }}>Name</Cell>
+                        <Cell css={{ color: "$hiContrast" }}>Name</Cell>
                         <Cell>{asset.name}</Cell>
                         {asset?.playbackUrl && (
                           <>
-                            <Cell css={{ color: "$primary11" }}>
+                            <Cell css={{ color: "$hiContrast" }}>
                               Playback ID
                             </Cell>
                             <Cell>
                               <ClipBut text={asset.playbackId} />
                             </Cell>
-                            <Cell css={{ color: "$primary11" }}>
+                            <Cell css={{ color: "$hiContrast" }}>
                               Playback URL
                             </Cell>
                             <Cell css={{ cursor: "pointer" }}>
@@ -364,11 +364,11 @@ const AssetDetail = ({
                             </Cell>
                           </>
                         )}
-                        <Cell css={{ color: "$primary11" }}>Asset ID</Cell>
+                        <Cell css={{ color: "$hiContrast" }}>Asset ID</Cell>
                         <Cell>
                           <ClipBut text={asset.id} />
                         </Cell>
-                        <Cell css={{ color: "$primary11" }}>Created at</Cell>
+                        <Cell css={{ color: "$hiContrast" }}>Created at</Cell>
                         <Cell>
                           <RelativeTime
                             id="cat"
@@ -379,19 +379,23 @@ const AssetDetail = ({
                         </Cell>
                         {videoTrack?.codec && (
                           <>
-                            <Cell css={{ color: "$primary11" }}>Codec</Cell>
+                            <Cell css={{ color: "$hiContrast" }}>Codec</Cell>
                             <Cell>{videoTrack.codec}</Cell>
                           </>
                         )}
                         {asset?.videoSpec?.format && (
                           <>
-                            <Cell css={{ color: "$primary11" }}>Container</Cell>
+                            <Cell css={{ color: "$hiContrast" }}>
+                              Container
+                            </Cell>
                             <Cell>{asset.videoSpec.format}</Cell>
                           </>
                         )}
                         {asset.size && (
                           <>
-                            <Cell css={{ color: "$primary11" }}>File size</Cell>
+                            <Cell css={{ color: "$hiContrast" }}>
+                              File size
+                            </Cell>
                             <Cell>
                               {numeral(asset.size)
                                 .format("0,0.00 b")
@@ -402,7 +406,7 @@ const AssetDetail = ({
 
                         {(asset?.videoSpec?.format ?? videoTrack?.bitrate) && (
                           <>
-                            <Cell css={{ color: "$primary11" }}>Bitrate</Cell>
+                            <Cell css={{ color: "$hiContrast" }}>Bitrate</Cell>
                             <Cell>
                               {numeral(
                                 asset?.videoSpec?.bitrate ?? videoTrack?.bitrate
@@ -415,7 +419,7 @@ const AssetDetail = ({
                         )}
                         {videoTrack?.width && videoTrack?.height && (
                           <>
-                            <Cell css={{ color: "$primary11" }}>
+                            <Cell css={{ color: "$hiContrast" }}>
                               Resolution
                             </Cell>
                             <Cell>

--- a/packages/www/layouts/streamDetail.tsx
+++ b/packages/www/layouts/streamDetail.tsx
@@ -361,13 +361,13 @@ const StreamDetail = ({
                         fontSize: "$2",
                         position: "relative",
                       }}>
-                      <Cell css={{ color: "$primary11" }}>Stream name</Cell>
+                      <Cell css={{ color: "$hiContrast" }}>Stream name</Cell>
                       <Cell>{stream.name}</Cell>
-                      <Cell css={{ color: "$primary11" }}>Stream ID</Cell>
+                      <Cell css={{ color: "$hiContrast" }}>Stream ID</Cell>
                       <Cell>
                         <ClipBut text={stream.id} />
                       </Cell>
-                      <Cell css={{ color: "$primary11" }}>Stream key</Cell>
+                      <Cell css={{ color: "$hiContrast" }}>Stream key</Cell>
                       <Cell>
                         {keyRevealed ? (
                           <Flex>
@@ -382,11 +382,13 @@ const StreamDetail = ({
                           </Button>
                         )}
                       </Cell>
-                      <Cell css={{ color: "$primary11" }}>RTMP ingest URL</Cell>
+                      <Cell css={{ color: "$hiContrast" }}>
+                        RTMP ingest URL
+                      </Cell>
                       <Cell css={{ cursor: "pointer" }}>
                         <ShowURL url={globalIngestUrl} anchor={false} />
                       </Cell>
-                      <Cell css={{ color: "$primary11" }}>SRT ingest URL</Cell>
+                      <Cell css={{ color: "$hiContrast" }}>SRT ingest URL</Cell>
                       <Cell css={{ cursor: "pointer" }}>
                         <ShowURL
                           url={globalSrtIngestUrl}
@@ -397,11 +399,11 @@ const StreamDetail = ({
                           anchor={false}
                         />
                       </Cell>
-                      <Cell css={{ color: "$primary11" }}>Playback ID</Cell>
+                      <Cell css={{ color: "$hiContrast" }}>Playback ID</Cell>
                       <Cell>
                         <ClipBut text={stream.playbackId} />
                       </Cell>
-                      <Cell css={{ color: "$primary11" }}>Playback URL</Cell>
+                      <Cell css={{ color: "$hiContrast" }}>Playback URL</Cell>
                       <Cell css={{ cursor: "pointer" }}>
                         <ShowURL
                           url={globalPlaybackUrl}
@@ -412,7 +414,9 @@ const StreamDetail = ({
                           anchor={false}
                         />
                       </Cell>
-                      <Cell css={{ color: "$primary11" }}>Record sessions</Cell>
+                      <Cell css={{ color: "$hiContrast" }}>
+                        Record sessions
+                      </Cell>
                       <Cell>
                         <Flex css={{ position: "relative", top: "2px" }}>
                           <Box css={{ mr: "$2" }}>
@@ -436,7 +440,7 @@ const StreamDetail = ({
                           </Tooltip>
                         </Flex>
                       </Cell>
-                      <Cell css={{ color: "$primary11" }}>Created at</Cell>
+                      <Cell css={{ color: "$hiContrast" }}>Created at</Cell>
                       <Cell>
                         <RelativeTime
                           id="cat"
@@ -445,7 +449,7 @@ const StreamDetail = ({
                           swap={true}
                         />
                       </Cell>
-                      <Cell css={{ color: "$primary11" }}>Last seen</Cell>
+                      <Cell css={{ color: "$hiContrast" }}>Last seen</Cell>
                       <Cell>
                         <RelativeTime
                           id="last"
@@ -454,9 +458,9 @@ const StreamDetail = ({
                           swap={true}
                         />
                       </Cell>
-                      <Cell css={{ color: "$primary11" }}>Status</Cell>
+                      <Cell css={{ color: "$hiContrast" }}>Status</Cell>
                       <Cell>{stream.isActive ? "Active" : "Idle"}</Cell>
-                      <Cell css={{ color: "$primary11" }}>Suspended</Cell>
+                      <Cell css={{ color: "$hiContrast" }}>Suspended</Cell>
                       <Cell>{stream.suspended ? "Suspended" : "Normal"}</Cell>
                     </Box>
                   </Flex>

--- a/packages/www/next.config.js
+++ b/packages/www/next.config.js
@@ -23,7 +23,7 @@ const config = {
       },
       {
         source: "/docs/api",
-        destination: "https://docs.livepeer.studio/references",
+        destination: "https://docs.livepeer.studio/category/api",
         permanent: false,
       },
       {

--- a/packages/www/pages/dashboard/billing/index.tsx
+++ b/packages/www/pages/dashboard/billing/index.tsx
@@ -112,7 +112,7 @@ const Billing = () => {
                 </Box>
               </Flex>
             </Heading>
-            <Flex css={{ fontSize: "$3", color: "$primary9" }}>
+            <Flex css={{ fontSize: "$3", color: "$hiContrast" }}>
               Current billing period (
               {subscription && (
                 <Flex>
@@ -167,7 +167,7 @@ const Billing = () => {
               You are currently on the
               <Badge
                 size="1"
-                variant="primary"
+                variant="neutral"
                 css={{ mx: "$1", fontWeight: 700, letterSpacing: 0 }}>
                 {user?.stripeProductId
                   ? products[user.stripeProductId]?.name


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Addressed a series of UX issues on Dashboard part of the app.

**Specific updates (required)**

- Fixes the rounded corners issue described [here](https://github.com/livepeer/studio/pull/1260#pullrequestreview-1102606855)
- On https://livepeer.studio/dashboard, under the "Create your own live stream", where it says "like OBS Studio or streamlabs. Here’s how.", there should be a colon after "here's how:"
- On all dashboard pages, links/button use blue text, but so do some of the headings. Can we use different colors to make it clear what’s clickable and what’s not? (If the brand guide / design allows it.)
- On https://livepeer.studio/dashboard/assets, the "Learn more -->" button leads to a 404.
Same thing for the other Docs links on the main dashboard page,
- On https://livepeer.studio/dashboard/assets, "Upload your first Video on Demand asset" should become "Upload your first On Demand asset", to align with the feature's brand.
- On https://livepeer.studio/dashboard/assets, "Video on Demand" shouldn't be capitalized, because it's describing the On Demand feature, which is capitalized because it's a branded feature term. The same is true for video on demand vs On Demand elsewhere on the dashboard or docs.

## -

- **How did you test each of these updates (required)**

Before and after making the change I took a screenshot of the element affected and manually testing with Light and Dark mode.

**Does this pull request close any open issues?**

Fixes #1255 

**Screenshots (optional):**

### Asset (before, after light, after dark)
![asset before](https://user-images.githubusercontent.com/161903/189697722-2f37783e-9c3d-4170-bc5a-d644ae86d46d.png)
![asset after light](https://user-images.githubusercontent.com/161903/189697718-297518fe-a256-459f-88c6-ddaa01b38048.png)
![asset after dark](https://user-images.githubusercontent.com/161903/189697713-ae0e7ea3-1666-4c22-a6c1-4943087e4b6e.png)

### Billing (before, after light, after dark)
![billing before](https://user-images.githubusercontent.com/161903/189697728-dfdef4aa-a28e-40fa-b509-bc0bce0ebb4f.png)
![billing after light](https://user-images.githubusercontent.com/161903/189697727-ca4f4523-630c-46b1-b232-7a8523a0440f.png)
![billing after dark](https://user-images.githubusercontent.com/161903/189697725-239721c8-307e-4bef-91b7-afa6716a26f3.png)


### Help (before, after light, after dark)
![help before](https://user-images.githubusercontent.com/161903/189697734-d08e6b98-50c4-4c4f-9601-e0cd6db67f4e.png)
![help after light](https://user-images.githubusercontent.com/161903/189697733-66404756-ce18-47a7-8962-2b180293444c.png)
![help after dark](https://user-images.githubusercontent.com/161903/189697729-f37c16cf-78c3-4d0a-943d-34a06f012dad.png)


### Multistream dialog (before, after light, after dark)
![multistream dialog before](https://user-images.githubusercontent.com/161903/189697743-2dcb18a8-4802-426e-b00b-041afa3e6bb4.png)
![multistream dialog after light](https://user-images.githubusercontent.com/161903/189697741-4922740c-02e0-41d0-8e96-d45b220a8d7d.png)
![multistream dialog after dark](https://user-images.githubusercontent.com/161903/189697736-a5d3627b-75f8-4e6b-9ac3-62b0ba591af4.png)


### Stream (before, after light, after dark)
![stream before](https://user-images.githubusercontent.com/161903/189697748-6eb1b18f-355a-4f34-946d-396aa7e42509.png)
![stream after light](https://user-images.githubusercontent.com/161903/189697747-0b4e10d9-9d20-4727-ba10-60d9349ae7f8.png)
![stream after dark](https://user-images.githubusercontent.com/161903/189697745-58ad6012-f789-4f84-86b8-d780eb7847d0.png)


### Usage (before, after light, after dark)
![usage before](https://user-images.githubusercontent.com/161903/189697755-5e84344e-9baa-4ebc-8d5b-d8737918c2e3.png)
![usage after light](https://user-images.githubusercontent.com/161903/189697754-4967b935-8027-4bc0-8cc7-f46d27df1caa.png)
![usage after dark](https://user-images.githubusercontent.com/161903/189697751-fc38595a-f157-4544-855a-acd52eabfa70.png)
