### PR TITLE
api: Create access-control API for signing keys

### DIFF
--- a/packages/api/src/controllers/access-control.ts
+++ b/packages/api/src/controllers/access-control.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import signingKeyApp from "./signing-key";
+
+const accessControl = Router();
+
+const app = Router();
+
+accessControl.use("/signing-key", signingKeyApp);
+app.use("/access-control", accessControl);
+
+export default accessControl;

--- a/packages/api/src/controllers/index.js
+++ b/packages/api/src/controllers/index.js
@@ -3,6 +3,7 @@ import auth from "./auth";
 import broadcaster from "./broadcaster";
 import ingest from "./ingest";
 import objectStore from "./object-store";
+import signingKey from "./signing-key";
 import multistream from "./multistream";
 import orchestrator from "./orchestrator";
 import stream from "./stream";
@@ -35,6 +36,7 @@ export default {
   webhook,
   asset,
   task,
+  "signing-key": signingKey,
   region,
   stripe,
   version,

--- a/packages/api/src/controllers/index.js
+++ b/packages/api/src/controllers/index.js
@@ -3,7 +3,7 @@ import auth from "./auth";
 import broadcaster from "./broadcaster";
 import ingest from "./ingest";
 import objectStore from "./object-store";
-import signingKey from "./signing-key";
+import accessControl from "./access-control";
 import multistream from "./multistream";
 import orchestrator from "./orchestrator";
 import stream from "./stream";
@@ -36,7 +36,7 @@ export default {
   webhook,
   asset,
   task,
-  "signing-key": signingKey,
+  "access-control": accessControl,
   region,
   stripe,
   version,

--- a/packages/api/src/controllers/signing-key.test.ts
+++ b/packages/api/src/controllers/signing-key.test.ts
@@ -99,6 +99,27 @@ describe("controllers/signing-key", () => {
       expect(res.status).toBe(204);
     });
 
+    it("should allow disable and enable the signing key & change the name", async () => {
+      let res = await client.patch(`/signing-key/${signingKey.id}`, {
+        disabled: true,
+        name: "My test signing key 1",
+      });
+      expect(res.status).toBe(204);
+      res = await client.get(`/signing-key/${signingKey.id}`);
+      let updated = await res.json();
+      expect(updated.disabled).toBe(true);
+      expect(updated.name).toBe("My test signing key 1");
+      res = await client.patch(`/signing-key/${signingKey.id}`, {
+        disabled: false,
+        name: "My test signing key 2",
+      });
+      expect(res.status).toBe(204);
+      res = await client.get(`/signing-key/${signingKey.id}`);
+      updated = await res.json();
+      expect(updated.disabled).toBe(false);
+      expect(updated.name).toBe("My test signing key 2");
+    });
+
     it("shoud delete the signing key", async () => {
       let res = await client.delete(`/signing-key/${signingKey.id}`);
       expect(res.status).toBe(204);

--- a/packages/api/src/controllers/signing-key.test.ts
+++ b/packages/api/src/controllers/signing-key.test.ts
@@ -1,0 +1,80 @@
+import serverPromise, { TestServer } from "../test-server";
+import { TestClient, clearDatabase, setupUsers } from "../test-helpers";
+import { v4 as uuid } from "uuid";
+import { SigningKey, SigningKeyResponsePayload, User } from "../schema/types";
+import { db } from "../store";
+import { WithID } from "../store/types";
+
+// includes auth file tests
+
+let server: TestServer;
+let mockAdminUserInput: User;
+let mockNonAdminUserInput: User;
+
+// jest.setTimeout(70000)
+
+beforeAll(async () => {
+  server = await serverPromise;
+
+  mockAdminUserInput = {
+    email: "user_admin@gmail.com",
+    password: "x".repeat(64),
+  };
+
+  mockNonAdminUserInput = {
+    email: "user_non_admin@gmail.com",
+    password: "y".repeat(64),
+  };
+});
+
+afterEach(async () => {
+  await clearDatabase(server);
+});
+
+describe("controllers/multistream-target", () => {
+  describe("basic CRUD with JWT authorization", () => {
+    let client: TestClient;
+    let adminUser: User;
+    let adminToken: string;
+    let nonAdminUser: User;
+    let nonAdminToken: string;
+    let signingKey: WithID<SigningKey>;
+
+    beforeEach(async () => {
+      ({ client, adminUser, adminToken, nonAdminUser, nonAdminToken } =
+        await setupUsers(server, mockAdminUserInput, mockNonAdminUserInput));
+      client.jwtAuth = nonAdminToken;
+      let signingKey: WithID<SigningKey>;
+      let created: SigningKeyResponsePayload = await (
+        await client.post("/signing-key")
+      ).json();
+      let res = await client.get(`/signing-key/${created.publicKey.id}`);
+      signingKey = await res.json();
+    });
+
+    it("should create a signing key and display the private key only on creation", async () => {
+      const preCreationTime = Date.now();
+      let res = await client.post("/signing-key");
+      expect(res.status).toBe(201);
+      const created = (await res.json()) as SigningKeyResponsePayload;
+      expect(created.privateKey).toBeDefined();
+      expect(created.publicKey).toBeDefined();
+      expect(created.publicKey.id).toBeDefined();
+      expect(created.publicKey.createdAt).toBeGreaterThanOrEqual(
+        preCreationTime
+      );
+      res = await client.get(`/signing-key/${created.publicKey.id}`);
+      expect(res.status).toBe(200);
+      const getResponse = await res.json();
+      expect(getResponse.privateKey).toBeUndefined();
+      expect(getResponse.publicKey).toEqual(created.publicKey.publicKey);
+    });
+
+    /* it("shoud delete the signing key", async () => {
+      let res = await client.delete(`/signing-key/${signingKey.id}`);
+      expect(res.status).toBe(204);
+      res = await client.get(`/signing-key/${signingKey.id}`);
+      expect(res.status).toBe(404);
+    });*/
+  });
+});

--- a/packages/api/src/controllers/signing-key.test.ts
+++ b/packages/api/src/controllers/signing-key.test.ts
@@ -106,6 +106,12 @@ describe("controllers/signing-key", () => {
       };
       const token = jwt.sign(payload, samplePrivateKey, { algorithm: "ES256" });
 
+      const decoded = verifyJwt(token, decodedPublicKey, {
+        complete: true,
+      });
+
+      expect(decoded.payload["exp"]).toEqual(expiration);
+
       expect(() => jwt.verify(token, decodedPublicKey)).not.toThrow();
       expect(() => jwt.verify(token, otherPublicKey)).toThrow(
         JsonWebTokenError

--- a/packages/api/src/controllers/signing-key.test.ts
+++ b/packages/api/src/controllers/signing-key.test.ts
@@ -54,15 +54,15 @@ describe("controllers/signing-key", () => {
         await setupUsers(server, mockAdminUserInput, mockNonAdminUserInput));
       client.jwtAuth = nonAdminToken;
       let created: SigningKeyResponsePayload = await client
-        .post("/signing-key")
+        .post("/access-control/signing-key")
         .then((res) => res.json());
       samplePrivateKey = created.privateKey;
-      let res = await client.get(`/signing-key/${created.id}`);
+      let res = await client.get(`/access-control/signing-key/${created.id}`);
       signingKey = await res.json();
       // decoded public key is decoded b64 of signingKey.publicKey parsed as json
       decodedPublicKey = Buffer.from(signingKey.publicKey, "base64").toString();
-      created = await (await client.post("/signing-key")).json();
-      res = await client.get(`/signing-key/${created.id}`);
+      created = await (await client.post("/access-control/signing-key")).json();
+      res = await client.get(`/access-control/signing-key/${created.id}`);
       let otherSigningKey = await res.json();
       otherPublicKey = Buffer.from(
         otherSigningKey.publicKey,
@@ -72,7 +72,7 @@ describe("controllers/signing-key", () => {
 
     it("should create a signing key and display the private key only on creation", async () => {
       const preCreationTime = Date.now();
-      let res = await client.post("/signing-key");
+      let res = await client.post("/access-control/signing-key");
       expect(res.status).toBe(201);
       const created = (await res.json()) as SigningKeyResponsePayload;
       expect(created).toMatchObject({
@@ -82,7 +82,7 @@ describe("controllers/signing-key", () => {
         createdAt: expect.any(Number),
       });
       expect(created.createdAt).toBeGreaterThanOrEqual(preCreationTime);
-      res = await client.get(`/signing-key/${created.id}`);
+      res = await client.get(`/access-control/signing-key/${created.id}`);
       expect(res.status).toBe(200);
       const getResponse = await res.json();
       const { privateKey, ...withoutPvtk } = created;
@@ -90,7 +90,7 @@ describe("controllers/signing-key", () => {
     });
 
     it("should list all user signing keys", async () => {
-      const res = await client.get(`/signing-key`);
+      const res = await client.get(`/access-control/signing-key`);
       expect(res.status).toBe(200);
     });
 
@@ -119,30 +119,35 @@ describe("controllers/signing-key", () => {
     });
 
     it("should allow disable and enable the signing key & change the name", async () => {
-      let res = await client.patch(`/signing-key/${signingKey.id}`, {
-        disabled: true,
-        name: "My test signing key 1",
-      });
+      let res = await client.patch(
+        `/access-control/signing-key/${signingKey.id}`,
+        {
+          disabled: true,
+          name: "My test signing key 1",
+        }
+      );
       expect(res.status).toBe(204);
-      res = await client.get(`/signing-key/${signingKey.id}`);
+      res = await client.get(`/access-control/signing-key/${signingKey.id}`);
       let updated = await res.json();
       expect(updated.disabled).toBe(true);
       expect(updated.name).toBe("My test signing key 1");
-      res = await client.patch(`/signing-key/${signingKey.id}`, {
+      res = await client.patch(`/access-control/signing-key/${signingKey.id}`, {
         disabled: false,
         name: "My test signing key 2",
       });
       expect(res.status).toBe(204);
-      res = await client.get(`/signing-key/${signingKey.id}`);
+      res = await client.get(`/access-control/signing-key/${signingKey.id}`);
       updated = await res.json();
       expect(updated.disabled).toBe(false);
       expect(updated.name).toBe("My test signing key 2");
     });
 
     it("should delete the signing key", async () => {
-      let res = await client.delete(`/signing-key/${signingKey.id}`);
+      let res = await client.delete(
+        `/access-control/signing-key/${signingKey.id}`
+      );
       expect(res.status).toBe(204);
-      res = await client.get(`/signing-key/${signingKey.id}`);
+      res = await client.get(`/access-control/signing-key/${signingKey.id}`);
       expect(res.status).toBe(404);
       let deletedSigningKey = await db.signingKey.get(signingKey.id);
       expect(deletedSigningKey.deleted).toBe(true);

--- a/packages/api/src/controllers/signing-key.test.ts
+++ b/packages/api/src/controllers/signing-key.test.ts
@@ -31,7 +31,7 @@ afterEach(async () => {
   await clearDatabase(server);
 });
 
-describe("controllers/multistream-target", () => {
+describe("controllers/signing-key", () => {
   describe("basic CRUD with JWT authorization", () => {
     let client: TestClient;
     let adminUser: User;
@@ -44,11 +44,10 @@ describe("controllers/multistream-target", () => {
       ({ client, adminUser, adminToken, nonAdminUser, nonAdminToken } =
         await setupUsers(server, mockAdminUserInput, mockNonAdminUserInput));
       client.jwtAuth = nonAdminToken;
-      let signingKey: WithID<SigningKey>;
       let created: SigningKeyResponsePayload = await (
         await client.post("/signing-key")
       ).json();
-      let res = await client.get(`/signing-key/${created.publicKey.id}`);
+      let res = await client.get(`/signing-key/${created.id}`);
       signingKey = await res.json();
     });
 
@@ -59,22 +58,22 @@ describe("controllers/multistream-target", () => {
       const created = (await res.json()) as SigningKeyResponsePayload;
       expect(created.privateKey).toBeDefined();
       expect(created.publicKey).toBeDefined();
-      expect(created.publicKey.id).toBeDefined();
-      expect(created.publicKey.createdAt).toBeGreaterThanOrEqual(
-        preCreationTime
-      );
-      res = await client.get(`/signing-key/${created.publicKey.id}`);
+      expect(created.id).toBeDefined();
+      expect(created.createdAt).toBeGreaterThanOrEqual(preCreationTime);
+      res = await client.get(`/signing-key/${created.id}`);
       expect(res.status).toBe(200);
       const getResponse = await res.json();
       expect(getResponse.privateKey).toBeUndefined();
-      expect(getResponse.publicKey).toEqual(created.publicKey.publicKey);
+      expect(getResponse.publicKey).toEqual(created.publicKey);
     });
 
-    /* it("shoud delete the signing key", async () => {
+    it("shoud delete the signing key", async () => {
       let res = await client.delete(`/signing-key/${signingKey.id}`);
       expect(res.status).toBe(204);
       res = await client.get(`/signing-key/${signingKey.id}`);
       expect(res.status).toBe(404);
-    });*/
+    });
+
+    // Create JWT and verify it
   });
 });

--- a/packages/api/src/controllers/signing-key.test.ts
+++ b/packages/api/src/controllers/signing-key.test.ts
@@ -8,6 +8,7 @@ import {
 import { SigningKey, SigningKeyResponsePayload, User } from "../schema/types";
 import { WithID } from "../store/types";
 import jwt, { JsonWebTokenError, JwtPayload } from "jsonwebtoken";
+import { db } from "../store";
 
 // includes auth file tests
 
@@ -81,7 +82,7 @@ describe("controllers/signing-key", () => {
       expect(getResponse).toEqual(withoutPvtk);
     });
 
-    it("should list all signing keys", async () => {
+    it("should list all user signing keys", async () => {
       const res = await client.get(`/signing-key`);
       expect(res.status).toBe(200);
     });
@@ -104,8 +105,6 @@ describe("controllers/signing-key", () => {
       expect(() => jwt.verify(token, otherSigningKey.publicKey)).toThrow(
         JsonWebTokenError
       );
-      let res = await client.delete(`/signing-key/${signingKey.id}`);
-      expect(res.status).toBe(204);
     });
 
     it("should allow disable and enable the signing key & change the name", async () => {
@@ -134,6 +133,8 @@ describe("controllers/signing-key", () => {
       expect(res.status).toBe(204);
       res = await client.get(`/signing-key/${signingKey.id}`);
       expect(res.status).toBe(404);
+      let deletedSigningKey = await db.signingKey.get(signingKey.id);
+      expect(deletedSigningKey.deleted).toBe(true);
     });
   });
 });

--- a/packages/api/src/controllers/signing-key.ts
+++ b/packages/api/src/controllers/signing-key.ts
@@ -42,9 +42,9 @@ function generateSigningKeys() {
   return keypair;
 }
 
-const app = Router();
+const signingKeyApp = Router();
 
-app.get("/", authorizer({}), async (req, res) => {
+signingKeyApp.get("/", authorizer({}), async (req, res) => {
   let { limit, cursor, all, allUsers, order, filters, count } = toStringValues(
     req.query
   );
@@ -124,7 +124,7 @@ app.get("/", authorizer({}), async (req, res) => {
   return res.json(output);
 });
 
-app.get("/:id", authorizer({}), async (req, res) => {
+signingKeyApp.get("/:id", authorizer({}), async (req, res) => {
   const signingKey = await db.signingKey.get(req.params.id);
 
   if (
@@ -141,7 +141,7 @@ app.get("/:id", authorizer({}), async (req, res) => {
   res.json(signingKey);
 });
 
-app.post(
+signingKeyApp.post(
   "/",
   validatePost("new-signing-key-payload"),
   authorizer({}),
@@ -191,7 +191,7 @@ app.post(
   }
 );
 
-app.delete("/:id", authorizer({}), async (req, res) => {
+signingKeyApp.delete("/:id", authorizer({}), async (req, res) => {
   const { id } = req.params;
   const signingKey = await db.signingKey.get(id);
   if (!signingKey || signingKey.deleted) {
@@ -205,7 +205,7 @@ app.delete("/:id", authorizer({}), async (req, res) => {
   res.end();
 });
 
-app.patch(
+signingKeyApp.patch(
   "/:id",
   validatePost("signing-key-patch-payload"),
   authorizer({}),
@@ -231,4 +231,4 @@ app.patch(
   }
 );
 
-export default app;
+export default signingKeyApp;

--- a/packages/api/src/controllers/signing-key.ts
+++ b/packages/api/src/controllers/signing-key.ts
@@ -10,7 +10,7 @@ import {
 import { db } from "../store";
 import sql from "sql-template-strings";
 import { v4 as uuid } from "uuid";
-import { generateKeyPairSync } from "crypto";
+import { generateKeyPairSync, generateKeyPair } from "crypto";
 import { ForbiddenError, NotFoundError } from "../store/errors";
 import {
   SigningKey,
@@ -29,10 +29,10 @@ const fieldsMap: FieldsMap = {
 
 function generateSigningKeys() {
   const keypair = generateKeyPairSync("ec", {
-    namedCurve: "P-521",
+    namedCurve: "P-256",
     publicKeyEncoding: {
       type: "spki",
-      format: "jwk",
+      format: "pem",
     },
     privateKeyEncoding: {
       type: "pkcs8",
@@ -169,9 +169,7 @@ app.post(
     const id = uuid();
     const keypair = generateSigningKeys();
 
-    let b64PublicKey = Buffer.from(JSON.stringify(keypair.publicKey)).toString(
-      "base64"
-    );
+    let b64PublicKey = Buffer.from(keypair.publicKey).toString("base64");
 
     var doc: WithID<SigningKey> = {
       id,

--- a/packages/api/src/controllers/signing-key.ts
+++ b/packages/api/src/controllers/signing-key.ts
@@ -12,6 +12,8 @@ import sql from "sql-template-strings";
 import { v4 as uuid } from "uuid";
 import { generateKeyPairSync } from "crypto";
 import { ForbiddenError, NotFoundError } from "../store/errors";
+import { SigningKey, SigningKeyResponsePayload } from "../schema/types";
+import { WithID } from "../store/types";
 
 const fieldsMap: FieldsMap = {
   id: `signing_key.ID`,
@@ -164,17 +166,17 @@ app.post("/", authorizer({}), async (req, res) => {
   const id = uuid();
   const keypair = generateSigningKeys();
 
-  var doc = {
+  var doc: WithID<SigningKey> = {
     id,
     userId: req.user.id,
     createdAt: Date.now(),
-    publickey: keypair.publicKey,
+    publicKey: keypair.publicKey,
   };
 
   await db.signingKey.create(doc);
 
-  var createdSigningKey = {
-    ...doc,
+  var createdSigningKey: SigningKeyResponsePayload = {
+    publicKey: doc,
     privateKey: keypair.privateKey,
   };
 

--- a/packages/api/src/controllers/signing-key.ts
+++ b/packages/api/src/controllers/signing-key.ts
@@ -1,0 +1,199 @@
+import { authorizer } from "../middleware";
+import { Router } from "express";
+import {
+  FieldsMap,
+  makeNextHREF,
+  parseFilters,
+  parseOrder,
+  toStringValues,
+} from "./helpers";
+import { db } from "../store";
+import sql from "sql-template-strings";
+import { v4 as uuid } from "uuid";
+import { generateKeyPairSync } from "crypto";
+import { ForbiddenError, NotFoundError } from "../store/errors";
+
+const fieldsMap: FieldsMap = {
+  id: `signing_key.ID`,
+  name: { val: `signing_key.data->>'name'`, type: "full-text" },
+  deleted: { val: `signing_key.data->'deleted'`, type: "boolean" },
+  createdAt: { val: `signing_key.data->'createdAt'`, type: "int" },
+  userId: `signing_key.data->>'userId'`,
+};
+
+function generateSigningKeys() {
+  const keypair = generateKeyPairSync("rsa", {
+    modulusLength: 4096,
+    publicKeyEncoding: {
+      type: "spki",
+      format: "pem",
+    },
+    privateKeyEncoding: {
+      type: "pkcs8",
+      format: "pem",
+    },
+  });
+  return keypair;
+}
+
+const app = Router();
+
+app.get("/", authorizer({}), async (req, res) => {
+  let { limit, cursor, all, allUsers, order, filters, count } = toStringValues(
+    req.query
+  );
+  if (isNaN(parseInt(limit))) {
+    limit = undefined;
+  }
+  if (!order) {
+    order = "updatedAt-true,createdAt-true";
+  }
+
+  if (req.user.admin && allUsers && allUsers !== "false") {
+    const query = parseFilters(fieldsMap, filters);
+    if (!all || all === "false") {
+      query.push(sql`signing_key.data->>'deleted' IS NULL`);
+    }
+
+    let fields =
+      " signing_key.id as id, signing_key.data as data, users.id as usersId, users.data as usersdata";
+    if (count) {
+      fields = fields + ", count(*) OVER() AS count";
+    }
+    const from = `signing_key left join users on signing_key.data->>'userId' = users.id`;
+    const [output, newCursor] = await db.signingKey.find(query, {
+      limit,
+      cursor,
+      fields,
+      from,
+      order: parseOrder(fieldsMap, order),
+      process: ({ data, usersdata, count: c }) => {
+        if (count) {
+          res.set("X-Total-Count", c);
+        }
+        return {
+          data,
+          user: db.user.cleanWriteOnlyResponse(usersdata),
+        };
+      },
+    });
+
+    res.status(200);
+
+    if (output.length > 0 && newCursor) {
+      res.links({ next: makeNextHREF(req, newCursor) });
+    }
+    return res.json(output);
+  }
+
+  const query = parseFilters(fieldsMap, filters);
+  query.push(sql`signing_key.data->>'userId' = ${req.user.id}`);
+
+  if (!all || all === "false") {
+    query.push(sql`signing_key.data->>'deleted' IS NULL`);
+  }
+
+  let fields = " signing_key.id as id, signing_key.data as data";
+  if (count) {
+    fields = fields + ", count(*) OVER() AS count";
+  }
+  const from = `signing_key`;
+  const [output, newCursor] = await db.signingKey.find(query, {
+    limit,
+    cursor,
+    fields,
+    from,
+    order: parseOrder(fieldsMap, order),
+    process: ({ data, count: c }) => {
+      if (count) {
+        res.set("X-Total-Count", c);
+      }
+      return data;
+    },
+  });
+
+  res.status(200);
+
+  if (output.length > 0) {
+    res.links({ next: makeNextHREF(req, newCursor) });
+  }
+
+  return res.json(output);
+});
+
+app.get("/:id", authorizer({}), async (req, res) => {
+  const signingKey = await db.signingKey.get(req.params.id);
+  if (!signingKey) {
+    res.status(404);
+    return res.json({
+      errors: ["not found"],
+    });
+  }
+
+  if (req.user.admin !== true && req.user.id !== signingKey.userId) {
+    res.status(403);
+    return res.json({
+      errors: ["user can only request information on their own signingKeys"],
+    });
+  }
+
+  res.json(signingKey);
+});
+
+app.post("/", authorizer({}), async (req, res) => {
+  const query = parseFilters(fieldsMap, "");
+  query.push(sql`signing_key.data->>'userId' = ${req.user.id}`);
+  query.push(sql`signing_key.data->>'deleted' IS NULL`);
+  const [output] = await db.signingKey.find(query, {
+    limit: 100,
+    fields: " signing_key.id as id, signing_key.data as data",
+    from: `signing_key`,
+    order: parseOrder(fieldsMap, "createdAt-true"),
+    process: ({ data }) => {
+      return data;
+    },
+  });
+
+  if (output.length > 10) {
+    res.status(403);
+    return res.json({
+      errors: ["user can only have up to 10 signing keys, delete some first"],
+    });
+  }
+
+  const id = uuid();
+  const keypair = generateSigningKeys();
+
+  var doc = {
+    id,
+    userId: req.user.id,
+    createdAt: Date.now(),
+    publickey: keypair.publicKey,
+  };
+
+  await db.signingKey.create(doc);
+
+  var createdSigningKey = {
+    ...doc,
+    privateKey: keypair.privateKey,
+  };
+
+  res.status(201);
+  res.json(createdSigningKey);
+});
+
+app.delete("/:id", authorizer({}), async (req, res) => {
+  const { id } = req.params;
+  const signingKey = await db.signingKey.get(id);
+  if (!signingKey) {
+    throw new NotFoundError(`signing key not found`);
+  }
+  if (!req.user.admin && req.user.id !== signingKey.userId) {
+    throw new ForbiddenError(`users may only delete their own signing keys`);
+  }
+  await db.signingKey.markDeleted(signingKey.id);
+  res.status(204);
+  res.end();
+});
+
+export default app;

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1552,6 +1552,15 @@ components:
           type: boolean
           default: false
 
+    signing-key-response-payload:
+      type: object
+      required: [publicKey, privateKey]
+      properties:
+        publicKey:
+          $ref: "#/components/schemas/signing-key"
+        privateKey:
+          type: string
+
     api-token:
       type: object
       additionalProperties: false

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1530,9 +1530,18 @@ components:
       properties:
         id:
           type: string
+          readOnly: true
+          index: true
           example: 78df0075-b5f3-4683-a618-1086faca35dc
+        createdAt:
+          type: number
+          readOnly: true
+          description: Timestamp (in milliseconds) at which task was created
+          example: 1587667174725
         userId:
           type: string
+          readOnly: true
+          index: true
           example: 78df0075-b5f3-4683-a618-1086faca35dc
         publicKey:
           type: string

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -696,6 +696,15 @@ components:
       required: []
       table: null
 
+    signing-key-patch-payload:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          $ref: "#/components/schemas/signing-key/properties/name"
+        disabled:
+          $ref: "#/components/schemas/signing-key/properties/disabled"
+
     webhook-patch-payload:
       type: object
       additionalProperties: false
@@ -1214,6 +1223,13 @@ components:
           readOnly: true
           description: URL to access file via HTTP through an IPFS gateway
 
+    new-signing-key-payload:
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          description: Name of the signing key
+
     new-asset-payload:
       additionalProperties: false
       required:
@@ -1536,6 +1552,9 @@ components:
           readOnly: true
           index: true
           example: 78df0075-b5f3-4683-a618-1086faca35dc
+        name:
+          type: string
+          description: Name of the signing key
         createdAt:
           type: number
           readOnly: true
@@ -1552,6 +1571,9 @@ components:
         deleted:
           type: boolean
           default: false
+        disabled:
+          type: boolean
+          description: Disable the signing key to allow rotation safely
 
     signing-key-response-payload:
       type: object

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1561,6 +1561,12 @@ components:
           description:
             Timestamp (in milliseconds) at which the signing-key was created
           example: 1587667174725
+        lastUsedAt:
+          type: number
+          readOnly: true
+          description:
+            Timestamp (in milliseconds) at which the signing-key was last used
+          example: 1587667174725
         userId:
           type: string
           readOnly: true

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1523,6 +1523,23 @@ components:
                           description:
                             Will be added to the pinata_secret_api_key header.
 
+    signing-key:
+      type: object
+      additionalProperties: false
+      table: signing-keys
+      properties:
+        id:
+          type: string
+          example: 78df0075-b5f3-4683-a618-1086faca35dc
+        userId:
+          type: string
+          example: 78df0075-b5f3-4683-a618-1086faca35dc
+        publicKey:
+          type: string
+        deleted:
+          type: boolean
+          default: false
+
     api-token:
       type: object
       additionalProperties: false

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1528,6 +1528,7 @@ components:
     signing-key:
       type: object
       additionalProperties: false
+      required: [publicKey]
       table: signing_key
       properties:
         id:
@@ -1556,8 +1557,7 @@ components:
       type: object
       required: [publicKey, privateKey]
       properties:
-        publicKey:
-          $ref: "#/components/schemas/signing-key"
+        $ref: "#/components/schemas/signing-key/properties"
         privateKey:
           type: string
 

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1536,7 +1536,8 @@ components:
         createdAt:
           type: number
           readOnly: true
-          description: Timestamp (in milliseconds) at which task was created
+          description:
+            Timestamp (in milliseconds) at which the signing-key was created
           example: 1587667174725
         userId:
           type: string

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -28,6 +28,8 @@ tags:
     description: Asset Endpoints
   - name: task
     description: Task Endpoints
+  - name: signing-key
+    description: Signing Key Endpoints
   - name: webhook-response
     description: webhook client responses
   - name: verify-email
@@ -1526,7 +1528,7 @@ components:
     signing-key:
       type: object
       additionalProperties: false
-      table: signing-keys
+      table: signing_key
       properties:
         id:
           type: string

--- a/packages/api/src/store/db.ts
+++ b/packages/api/src/store/db.ts
@@ -16,6 +16,7 @@ import {
   WebhookResponse,
   Session,
   CdnUsageLast,
+  SigningKey,
 } from "../schema/types";
 import BaseTable, { TableOptions } from "./table";
 import StreamTable, { DBStreamFields } from "./stream-table";
@@ -64,6 +65,7 @@ export class DB {
   multistreamTarget: MultistreamTargetTable;
   asset: AssetTable;
   task: Table<Task>;
+  signingKey: Table<SigningKey>;
   apiToken: Table<ApiToken>;
   user: Table<User>;
   usage: Table<Usage>;
@@ -152,6 +154,10 @@ export class DB {
     this.task = makeTable<Task>({
       db: this,
       schema: schemas["task"],
+    });
+    this.signingKey = makeTable<SigningKey>({
+      db: this,
+      schema: schemas["signing-key"],
     });
     this.user = makeTable<User>({ db: this, schema: schemas["user"] });
     this.usage = makeTable<Usage>({ db: this, schema: schemas["usage"] });

--- a/packages/api/src/test-helpers.ts
+++ b/packages/api/src/test-helpers.ts
@@ -6,6 +6,7 @@ import schema from "./schema/schema.json";
 import { User } from "./schema/types";
 import { TestServer } from "./test-server";
 import fs from "fs";
+import jwt, { VerifyOptions } from "jsonwebtoken";
 
 const vhostUrl = (vhost: string) =>
   `http://guest:guest@localhost:15672/api/vhosts/${vhost}`;
@@ -23,6 +24,18 @@ export async function clearDatabase(server: TestServer) {
     .map((s) => ("table" in s ? s.table : null))
     .filter((t) => !!t);
   await Promise.all(tables.map((t) => server.db.query(`TRUNCATE TABLE ${t}`)));
+}
+
+export function verifyJwt(
+  token: string,
+  publicKey: string,
+  verifyOptions?: VerifyOptions
+) {
+  try {
+    return jwt.verify(token, publicKey, verifyOptions);
+  } catch (e) {
+    return e;
+  }
 }
 
 export interface AuxTestServer {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Creates a set of API for signing keys, as first milestone toward access control

**Specific updates (required)**

- Create signing key schema
- POST create up to 10 signing keys, retrieving the private key if the keypair only on creation
- GET retrieve a list of your existing signing keys, with only the public key
- DELETE a signing key
- UPDATE a signing key, disabling it
- Create a EC P-256 keypair in `pem` format for JWT generations
- Tests

**How did you test each of these updates (required)**

yarn test - postman

**Does this pull request close any open issues?**

Fixes #1284 

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
