### PR TITLE
api: Soft deletion of object store objects

### DIFF
--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -92,9 +92,9 @@ async function validateAssetPayload(
       );
     }
     const os = await db.objectStore.get(payload.objectStoreId);
-    if (os.userId !== userId) {
+    if (!os || os.deleted || os.userId !== userId || os.disabled) {
       throw new ForbiddenError(
-        `the provided objectStoreId is not owned by the user`
+        `object store ${payload.objectStoreId} not found or disabled`
       );
     }
   }
@@ -527,8 +527,10 @@ const transcodeAssetHandler: RequestHandler = async (req, res) => {
   }
 
   const os = await db.objectStore.get(inputAsset.objectStoreId);
-  if (!os) {
-    throw new UnprocessableEntityError("Asset has invalid objectStoreId");
+  if (!os || os.deleted || os.disabled) {
+    throw new UnprocessableEntityError(
+      "Asset object store not found or disabled"
+    );
   }
   const id = uuid();
   const playbackId = await generateUniquePlaybackId(id);

--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -124,8 +124,11 @@ export type OSS3Config = S3ClientConfig &
 export async function getObjectStoreS3Config(
   osId: string
 ): Promise<OSS3Config> {
-  const store = await db.objectStore.get(osId);
-  const url = new URL(store.url);
+  const os = await db.objectStore.get(osId);
+  if (!os || os.deleted || os.disabled) {
+    throw new Error("Object store not found or disabled");
+  }
+  const url = new URL(os.url);
   let protocol = url.protocol;
   if (protocol !== "s3+http:" && protocol !== "s3+https:") {
     throw new Error(`Unsupported OS URL protocol: ${protocol}`);

--- a/packages/api/src/controllers/object-store.ts
+++ b/packages/api/src/controllers/object-store.ts
@@ -1,13 +1,19 @@
 import { authorizer } from "../middleware";
 import { validatePost } from "../middleware";
-import Router from "express/lib/router";
-import { makeNextHREF, parseFilters, parseOrder } from "./helpers";
-import uuid from "uuid/v4";
+import { Router } from "express";
+import {
+  FieldsMap,
+  makeNextHREF,
+  parseFilters,
+  parseOrder,
+  toStringValues,
+} from "./helpers";
+import { v4 as uuid } from "uuid";
 import { db } from "../store";
 
 const app = Router();
 
-const fieldsMap = {
+const fieldsMap: FieldsMap = {
   id: `object_store.ID`,
   name: { val: `object_store.data->>'name'`, type: "full-text" },
   url: `object_store.data->>'url'`,
@@ -19,7 +25,7 @@ const fieldsMap = {
 };
 
 app.get("/", authorizer({}), async (req, res) => {
-  let { limit, cursor, userId, order, filters } = req.query;
+  let { limit, cursor, userId, order, filters } = toStringValues(req.query);
   if (isNaN(parseInt(limit))) {
     limit = undefined;
   }

--- a/packages/api/src/controllers/object-store.ts
+++ b/packages/api/src/controllers/object-store.ts
@@ -68,7 +68,7 @@ app.get("/", authorizer({}), async (req, res) => {
   query.push(sql`object_store.data->>'userId' = ${userId}`);
   query.push(sql`object_store.data->>'deleted' IS NULL`);
 
-  let [data, newCursor] = await db.objectStore.find([query], {
+  let [data, newCursor] = await db.objectStore.find(query, {
     cursor,
     limit,
   });
@@ -93,7 +93,7 @@ app.get("/:id", authorizer({}), async (req, res) => {
 
   if (req.user.admin !== true && req.user.id !== os.userId) {
     return res.status(403).json({
-      errors: ["user can only request information on their own object stores"],
+      errors: ["user can only request information on their own user object"],
     });
   }
 

--- a/packages/api/src/controllers/object-store.ts
+++ b/packages/api/src/controllers/object-store.ts
@@ -132,19 +132,16 @@ app.post(
 app.delete("/:id", authorizer({}), async (req, res) => {
   const { id } = req.params;
   const objectStore = await db.objectStore.get(id);
-  if (!objectStore) {
-    res.status(404);
-    return res.json({ errors: ["not found"] });
+  if (!objectStore || objectStore.deleted) {
+    return res.status(404).json({ errors: ["not found"] });
   }
   if (!req.user.admin && req.user.id !== objectStore.userId) {
-    res.status(403);
-    return res.json({
+    return res.status(403).json({
       errors: ["users may only delete their own object stores"],
     });
   }
   await db.objectStore.markDeleted(id);
-  res.status(204);
-  res.end();
+  res.status(204).end();
 });
 
 app.patch(

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -858,6 +858,9 @@ components:
           description:
             If true then these object store will not be used for recording even
             if it is configured in the API command line.
+        deleted:
+          type: boolean
+          description: Set to true when the object store is deleted
         id:
           type: string
           example: 09F8B46C-61A0-4254-9875-F71F4C605BC7

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -676,6 +676,19 @@ components:
         multistream:
           $ref: "#/components/schemas/stream/properties/multistream"
 
+    object-store-patch-payload:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          $ref: "#/components/schemas/object-store/properties/name"
+        disabled:
+          $ref: "#/components/schemas/object-store/properties/disabled"
+        url:
+          $ref: "#/components/schemas/object-store/properties/url"
+        publicUrl:
+          $ref: "#/components/schemas/object-store/properties/publicUrl"
+
     suspend-user-payload:
       type: object
       additionalProperties: false


### PR DESCRIPTION

**What does this pull request do? Explain your changes. (required)**
Differently from other APIs, we were not only soft deleting Object Stores when their
deletion was requested. This is bad because the references to ObjectStore objects are
made in other objects like assets and stream recordings, so we don't really want to lose
all data regarding those deleted OSes.

**Specific updates (required)**
 - Migrate `object-store` controller to TypeScript
 - Starting using `markDeleted` instead of `delete` on object store for soft deletion behavior
 - Fix usage of object store by always checking `deleted` field (and `disabled`)

## -

- **How did you test each of these updates (required)**
`yarn test`

**Does this pull request close any open issues?**
No.

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
