### PR TITLE
IPFS export date

### DIFF
--- a/packages/api/src/controllers/asset.test.ts
+++ b/packages/api/src/controllers/asset.test.ts
@@ -233,6 +233,7 @@ describe("controllers/asset", () => {
             spec: {},
             ...withIpfsUrls({ cid: "QmX" }),
             nftMetadata: withIpfsUrls({ cid: "QmY" }),
+            updatedAt: expect.any(Number),
           },
           status: {
             phase: "ready",

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -999,7 +999,9 @@ components:
                 updatedAt:
                   type: number
                   readOnly: true
-                  description: Timestamp (in milliseconds) at which IPFS export task was updated
+                  description:
+                    Timestamp (in milliseconds) at which IPFS export task was
+                    updated
                   example: 1587667174725
             status:
               readOnly: true

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1211,6 +1211,11 @@ components:
           type: string
           readOnly: true
           description: URL to access file via HTTP through an IPFS gateway
+        createdAt:
+          type: number
+          readOnly: true
+          description: Timestamp (in milliseconds) at which IPFS export task was created
+          example: 1587667174725
 
     new-asset-payload:
       additionalProperties: false

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -996,6 +996,11 @@ components:
                 $ref: "#/components/schemas/ipfs-file-info/properties"
                 nftMetadata:
                   $ref: "#/components/schemas/ipfs-file-info"
+                updatedAt:
+                  type: number
+                  readOnly: true
+                  description: Timestamp (in milliseconds) at which IPFS export task was updated
+                  example: 1587667174725
             status:
               readOnly: true
               additionalProperties: false
@@ -1211,11 +1216,6 @@ components:
           type: string
           readOnly: true
           description: URL to access file via HTTP through an IPFS gateway
-        createdAt:
-          type: number
-          readOnly: true
-          description: Timestamp (in milliseconds) at which IPFS export task was created
-          example: 1587667174725
 
     new-asset-payload:
       additionalProperties: false

--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -152,6 +152,7 @@ export class TaskScheduler {
               ipfs: {
                 spec: inputAsset.storage.ipfs.spec,
                 ...taskOutputToIpfsStorage(event.output.export.ipfs),
+                createdAt: task.createdAt,
               },
               status: {
                 phase: "ready",

--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -152,7 +152,7 @@ export class TaskScheduler {
               ipfs: {
                 spec: inputAsset.storage.ipfs.spec,
                 ...taskOutputToIpfsStorage(event.output.export.ipfs),
-                createdAt: task.createdAt,
+                updatedAt: Date.now(),
               },
               status: {
                 phase: "ready",

--- a/packages/www/components/Dashboard/AssetDetails/AssetOverviewTab.tsx
+++ b/packages/www/components/Dashboard/AssetDetails/AssetOverviewTab.tsx
@@ -146,8 +146,8 @@ const AssetOverviewTab = ({
               <Text size="3">IPFS</Text>
             </Flex>
 
-            {asset?.storage?.ipfs?.createdAt && (
-              <Text size="3" variant="gray">Uploaded on {moment.unix(asset?.storage?.ipfs?.createdAt / 1000).format("LLL")}</Text>
+            {asset?.storage?.ipfs?.updatedAt && (
+              <Text size="3" variant="gray">Uploaded on {moment.unix(asset?.storage?.ipfs?.updatedAt / 1000).format("LLL")}</Text>
             )}
 
             {!asset?.storage?.ipfs?.cid && (

--- a/packages/www/components/Dashboard/AssetDetails/AssetOverviewTab.tsx
+++ b/packages/www/components/Dashboard/AssetDetails/AssetOverviewTab.tsx
@@ -68,8 +68,6 @@ const AssetOverviewTab = ({
     [asset?.meta]
   );
 
-  console.log(asset)
-
   return (
     <>
       <Box>

--- a/packages/www/components/Dashboard/AssetDetails/AssetOverviewTab.tsx
+++ b/packages/www/components/Dashboard/AssetDetails/AssetOverviewTab.tsx
@@ -20,6 +20,7 @@ import CurlyBracesIcon from "../../../public/img/icons/curly-braces.svg";
 import DatabaseIcon from "../../../public/img/icons/database.svg";
 import { useApi } from "hooks";
 import Spinner from "../Spinner";
+import moment from "moment";
 
 const StyledIpfsIcon = styled(IpfsIcon, {
   color: "$gray",
@@ -66,6 +67,8 @@ const AssetOverviewTab = ({
     () => (asset?.meta ? JSON.stringify(asset.meta, null, 4) : ""),
     [asset?.meta]
   );
+
+  console.log(asset)
 
   return (
     <>
@@ -144,6 +147,10 @@ const AssetOverviewTab = ({
               <StyledIpfsIcon />
               <Text size="3">IPFS</Text>
             </Flex>
+
+            {asset?.storage?.ipfs?.createdAt && (
+              <Text size="3" variant="gray">Uploaded on {moment.unix(asset?.storage?.ipfs?.createdAt / 1000).format("LLL")}</Text>
+            )}
 
             {!asset?.storage?.ipfs?.cid && (
               <>

--- a/packages/www/components/Dashboard/AssetDetails/AssetOverviewTab.tsx
+++ b/packages/www/components/Dashboard/AssetDetails/AssetOverviewTab.tsx
@@ -147,7 +147,12 @@ const AssetOverviewTab = ({
             </Flex>
 
             {asset?.storage?.ipfs?.updatedAt && (
-              <Text size="3" variant="gray">Uploaded on {moment.unix(asset?.storage?.ipfs?.updatedAt / 1000).format("LLL")}</Text>
+              <Text size="3" variant="gray">
+                Uploaded on{" "}
+                {moment
+                  .unix(asset?.storage?.ipfs?.updatedAt / 1000)
+                  .format("LLL")}
+              </Text>
             )}
 
             {!asset?.storage?.ipfs?.cid && (


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Added the IPFS export date to the Asset page.

**Specific updates (required)**
- Added `createdAt` property to the `asset.storage.ipfs` object in schemas
- If present, shows the formatted date in the IPFS storage box in the Asset page

**How did you test each of these updates (required)**
Simulating locally the date being present.

**Does this pull request close any open issues?**
Fixes #1253

**Screenshots (optional):**
![Screenshot 2022-09-15 at 12 37 48](https://user-images.githubusercontent.com/161903/190394523-aa5de1ef-ec61-40f8-8cf6-748e840bdd38.png)

![Screenshot 2022-09-15 at 12 37 56](https://user-images.githubusercontent.com/161903/190394530-2bd4e432-cb0b-4b63-abd8-a8a2e660fa36.png)

