### PR TITLE
api/auth: Allow authorization to be used for viewership metrics API

### DIFF
--- a/packages/api/src/controllers/auth.test.ts
+++ b/packages/api/src/controllers/auth.test.ts
@@ -1,0 +1,440 @@
+import { Response } from "node-fetch";
+
+import { ApiToken, User } from "../schema/types";
+import { db } from "../store";
+import {
+  AuxTestServer,
+  clearDatabase,
+  setupUsers,
+  TestClient,
+} from "../test-helpers";
+import serverPromise, { TestServer } from "../test-server";
+import { pathJoin2 } from "./helpers";
+
+let server: TestServer;
+let mockAdminUserInput: User;
+let mockNonAdminUserInput: User;
+
+let testServer: AuxTestServer;
+
+beforeAll(async () => {
+  server = await serverPromise;
+
+  mockAdminUserInput = {
+    email: "user_admin@gmail.com",
+    password: "x".repeat(64),
+  };
+
+  mockNonAdminUserInput = {
+    email: "user_non_admin@gmail.com",
+    password: "y".repeat(64),
+  };
+});
+
+afterEach(async () => {
+  await clearDatabase(server);
+});
+
+describe("controller/auth", () => {
+  describe("api token access rules", () => {
+    let adminUser: User;
+    let adminApiKey: string;
+    let nonAdminUser: User;
+    let nonAdminApiKey: string;
+    let client: TestClient;
+
+    const setAccess = (token: string, rules?: ApiToken["access"]["rules"]) =>
+      db.apiToken.update(token, { access: { rules } });
+
+    const fetchAuth = async (method: string, path: string) => {
+      const res = await client.fetch("/auth", {
+        method,
+        headers: {
+          "x-original-uri": pathJoin2("https://livepeer.studio/", path),
+        },
+      });
+      return res.status;
+    };
+
+    const expectStatus = (method: string, path: string) =>
+      expect(fetchAuth(method, path)).resolves;
+
+    beforeEach(async () => {
+      ({ client, adminUser, adminApiKey, nonAdminUser, nonAdminApiKey } =
+        await setupUsers(server, mockAdminUserInput, mockNonAdminUserInput));
+      client.apiKey = nonAdminApiKey;
+    });
+
+    it("should allow any route by default", async () => {
+      await expectStatus("get", "/whatever").toBe(204);
+
+      await setAccess(nonAdminApiKey, undefined);
+      await expectStatus("get", "/wherever").toBe(204);
+    });
+
+    it("should disallow any route for empty access rules", async () => {
+      await setAccess(nonAdminApiKey, []);
+      await expectStatus("get", "/whichever").toBe(403);
+      await expectStatus("get", "/bye").toBe(403);
+    });
+
+    describe("specific resource no methods", () => {
+      beforeEach(() => setAccess(nonAdminApiKey, [{ resources: ["foo"] }]));
+
+      it("should disallow other resources", async () => {
+        await expectStatus("delete", "/bar").toBe(403);
+        await expectStatus("get", "/zaz").toBe(403);
+      });
+
+      it("should allow any method", async () => {
+        await expectStatus("get", "/foo").toBe(204);
+        await expectStatus("post", "/foo").toBe(204);
+        await expectStatus("delete", "/foo").toBe(204);
+      });
+    });
+
+    describe("specific resources and methods", () => {
+      beforeEach(() =>
+        setAccess(nonAdminApiKey, [
+          { resources: ["foo"], methods: ["options"] },
+          { resources: ["foo/bar"], methods: ["get", "patch"] },
+          { resources: ["foo/bar/zaz"], methods: ["head", "post"] },
+        ])
+      );
+
+      it("should disallow other methods", async () => {
+        await expectStatus("patch", "/foo").toBe(403);
+        await expectStatus("post", "/foo").toBe(403);
+        await expectStatus("get", "/foo").toBe(403);
+
+        await expectStatus("delete", "/foo/bar").toBe(403);
+        await expectStatus("post", "/foo/bar").toBe(403);
+        await expectStatus("head", "/foo/bar").toBe(403);
+
+        await expectStatus("put", "/foo/bar/zaz").toBe(403);
+        await expectStatus("patch", "/foo/bar/zaz").toBe(403);
+        await expectStatus("get", "/foo/bar/zaz").toBe(403);
+      });
+
+      it("should allow specified methods", async () => {
+        await expectStatus("options", "/foo").toBe(204);
+        await expectStatus("get", "/foo/bar").toBe(204);
+        await expectStatus("patch", "/foo/bar").toBe(204);
+        await expectStatus("head", "/foo/bar/zaz").toBe(204);
+        await expectStatus("post", "/foo/bar/zaz").toBe(204);
+      });
+    });
+
+    describe("path parameters", () => {
+      beforeEach(() =>
+        setAccess(nonAdminApiKey, [
+          { resources: ["gus/:id"] },
+          { resources: ["gus/fra/*"] },
+        ])
+      );
+
+      it("should disallow other paths", async () => {
+        await expectStatus("get", "/foo").toBe(403);
+        await expectStatus("put", "/fra").toBe(403);
+        await expectStatus("post", "/bar").toBe(403);
+        await expectStatus("patch", "/gus").toBe(403);
+        await expectStatus("patch", "/gus/bar/fra").toBe(403);
+      });
+
+      it("should allow matching paths", async () => {
+        await expectStatus("get", "/gus/mad").toBe(204);
+        await expectStatus("put", "/gus/tim").toBe(204);
+        await expectStatus("head", "/gus/fra").toBe(204);
+        await expectStatus("patch", "/gus/fra/bar").toBe(204);
+        await expectStatus("options", "/gus/fra/bar/zaz").toBe(204);
+        await expectStatus("post", "/gus/fra/bar/zaz").toBe(204);
+      });
+    });
+
+    describe("alternative formats", () => {
+      it("should allow leading slash", async () => {
+        await setAccess(nonAdminApiKey, [{ resources: ["/gus/fra/bar"] }]);
+        await expectStatus("get", "/gus").toBe(403);
+        await expectStatus("put", "/fra").toBe(403);
+        await expectStatus("post", "/bar").toBe(403);
+        await expectStatus("patch", "/gus/fra/bar").toBe(204);
+      });
+
+      it("should allow explicit all methods and resources", async () => {
+        await setAccess(nonAdminApiKey, [{ resources: ["*"], methods: ["*"] }]);
+        await expectStatus("get", "/gus").toBe(204);
+        await expectStatus("put", "/fra").toBe(204);
+        await expectStatus("post", "/bar").toBe(204);
+        await expectStatus("patch", "/gus/fra/bar").toBe(204);
+      });
+    });
+
+    it("should block access on bad rules", async () => {
+      await setAccess(nonAdminApiKey, [{ resources: ["far", "far"] }]);
+      await expectStatus("post", "/far").toBe(403);
+
+      await setAccess(nonAdminApiKey, [{ resources: ["zuz/*zaz"] }]);
+      await expectStatus("get", "/zuz/123").toBe(403);
+
+      await setAccess(nonAdminApiKey, [{ resources: ["zuz/*/bar"] }]);
+      await expectStatus("put", "/zuz/123/s2e").toBe(403);
+
+      await setAccess(nonAdminApiKey, [
+        { resources: ["zzz/:param", "zzz/*confict"] },
+      ]);
+      await expectStatus("delete", "/zzz/abc").toBe(403);
+
+      await setAccess(nonAdminApiKey, [{ resources: ["gfb?path=only"] }]);
+      await expectStatus("get", "/gfb?path=only").toBe(403);
+      await expectStatus("get", "/gfb").toBe(403);
+    });
+
+    it("should support nested routers", async () => {
+      await setAccess(nonAdminApiKey, [
+        { resources: ["router/nested/zaz", "router/foo", "bar"] },
+      ]);
+      await expectStatus("get", "/zaz").toBe(403);
+      await expectStatus("get", "/router/bar").toBe(403);
+      await expectStatus("get", "/router/nested/bar").toBe(403);
+      await expectStatus("get", "/router/router/foo").toBe(403);
+      await expectStatus("post", "/foo").toBe(403);
+
+      await expectStatus("post", "/router/nested/zaz").toBe(204);
+      await expectStatus("post", "/router/foo").toBe(204);
+      await expectStatus("post", "/bar").toBe(204);
+    });
+
+    it("should handle query strings fine", async () => {
+      await setAccess(nonAdminApiKey, [{ resources: ["foo"] }]);
+      await expectStatus("post", "/foo?hello=query").toBe(204);
+    });
+  });
+
+  describe("cors", () => {
+    let adminUser: User;
+    let adminApiKey: string;
+    let adminToken: string;
+    let nonAdminUser: User;
+    let nonAdminApiKey: string;
+    let nonAdminToken: string;
+    let client: TestClient;
+
+    beforeEach(async () => {
+      ({
+        client,
+        adminUser,
+        adminApiKey,
+        adminToken,
+        nonAdminUser,
+        nonAdminApiKey,
+        nonAdminToken,
+      } = await setupUsers(server, mockAdminUserInput, mockNonAdminUserInput));
+    });
+
+    const testMethods = ["GET", "POST", "PUT", "PATCH", "DELETE"];
+
+    const testOrigins = [
+      "http://localhost:3000",
+      "http://localhost:3001",
+      "https://example.com",
+      "http://test.com",
+      "http://mydomain.io:420",
+      "https://other.domain.net:8989",
+      "https://staging.wetube.com",
+      "http://blockflix.io:69",
+    ];
+
+    const allowedOrigins = [
+      "http://localhost:3000",
+      "https://staging.wetube.com",
+      "http://blockflix.io:69",
+    ];
+
+    const fetchCors = async (method: string, path: string, origin: string) => {
+      const res = await client.fetch("/auth", {
+        method,
+        headers: {
+          "x-original-uri": pathJoin2("https://livepeer.studio/", path),
+          origin,
+        },
+      });
+      if (method === "OPTIONS") {
+        expect(res.status).toEqual(204);
+        expect(res.headers.get("access-control-allow-methods")).toEqual(
+          "GET,HEAD,PUT,PATCH,POST,DELETE"
+        );
+      }
+      expect(res.headers.get("access-control-allow-credentials")).toEqual(
+        "true"
+      );
+      const corsAllowed =
+        res.headers.get("access-control-allow-origin") === origin;
+      return {
+        corsAllowed,
+        status: res.status,
+        body: await res.json().catch((err) => null),
+      };
+    };
+
+    const isAllowed = async (method: string, path: string, origin: string) => {
+      const { corsAllowed, body } = await fetchCors(method, path, origin);
+      return corsAllowed;
+    };
+
+    const expectAllowed = (method: string, path: string, origin: string) =>
+      expect(isAllowed(method, path, origin)).resolves;
+
+    it("should NOT allow requests from custom origins on regular paths", async () => {
+      for (const method of testMethods) {
+        for (const origin of testOrigins) {
+          await expectAllowed(method, "/asset/upload", origin).toBe(false);
+          await expectAllowed(method, "/asset/request-upload", origin).toBe(
+            false
+          );
+          await expectAllowed(method, "/playback", origin).toBe(false);
+          await expectAllowed(method, "/stream", origin).toBe(false);
+          await expectAllowed(method, "/stream/abcd", origin).toBe(false);
+          await expectAllowed(method, "/user", origin).toBe(false);
+        }
+      }
+    });
+
+    it("should allow CORS from frontend domain", async () => {
+      client.jwtAuth = nonAdminToken;
+      for (const method of testMethods) {
+        await expectAllowed(method, "/stream", "https://livepeer.studio").toBe(
+          true
+        );
+        await expectAllowed(method, "/asset", "https://livepeer.studio").toBe(
+          true
+        );
+        await expectAllowed(
+          method,
+          "/api-token/1234",
+          "https://livepeer.studio"
+        ).toBe(true);
+      }
+    });
+
+    const createApiToken = async (cors: ApiToken["access"]["cors"]) => {
+      client.jwtAuth = nonAdminToken;
+      let res = await client.post("/api-token", {
+        name: "test",
+        access: { cors },
+      });
+      client.jwtAuth = null;
+      expect(res.status).toBe(201);
+      const apiKeyObj = await res.json();
+      expect(apiKeyObj).toMatchObject({
+        id: expect.any(String),
+        access: { cors },
+      });
+      return apiKeyObj.id;
+    };
+
+    it("should allow only the allowed origins", async () => {
+      client.apiKey = await createApiToken({ allowedOrigins });
+      for (const method of testMethods) {
+        for (const origin of testOrigins) {
+          const expected = allowedOrigins.includes(origin);
+
+          await expectAllowed(method, "/asset/request-upload", origin).toBe(
+            expected
+          );
+          await expectAllowed(method, "/asset", origin).toBe(expected);
+          await expectAllowed(method, "/asset/abcd", origin).toBe(expected);
+          await expectAllowed(method, "/stream", origin).toBe(expected);
+          await expectAllowed(method, "/stream/1234", origin).toBe(expected);
+          await expectAllowed(method, "/user", origin).toBe(expected);
+          await expectAllowed(method, "/api-token", origin).toBe(expected);
+        }
+      }
+    });
+
+    const forbiddenApis = [
+      ["GET", "/stream"],
+      ["DELETE", "/stream/1234"],
+      ["GET", "/user/1234"],
+      ["POST", "/object-store"],
+      ["GET", "/object-store/1234"],
+    ];
+
+    it("should allow only specific APIs to be called with CORS key", async () => {
+      client.apiKey = await createApiToken({ allowedOrigins });
+      // control case
+      await expect(
+        fetchCors("GET", "/stream/1234", allowedOrigins[0])
+      ).resolves.toMatchObject({
+        corsAllowed: true,
+        status: 204,
+      });
+      await expect(
+        fetchCors("GET", "/data/views/1234/total", allowedOrigins[0])
+      ).resolves.toMatchObject({
+        corsAllowed: true,
+        status: 204,
+      });
+
+      for (const [method, path] of forbiddenApis) {
+        await expect(
+          fetchCors(method, path, allowedOrigins[0])
+        ).resolves.toMatchObject({
+          corsAllowed: true,
+          status: 403,
+          body: {
+            errors: [
+              "access forbidden for CORS-enabled API key with restricted access",
+            ],
+          },
+        });
+      }
+    });
+
+    it("should allow any API to be called by a full access key", async () => {
+      client.apiKey = await createApiToken({
+        allowedOrigins,
+        fullAccess: true,
+      });
+      for (const [method, path] of forbiddenApis) {
+        const { corsAllowed, status, body } = await fetchCors(
+          method,
+          path,
+          allowedOrigins[0]
+        );
+        expect(corsAllowed).toBe(true);
+        expect(status).toBe(204);
+        if (status === 403) {
+          expect(body).toMatchObject({
+            errors: [
+              "user can only request information on their own user object",
+            ],
+          });
+        }
+      }
+    });
+
+    it("should actually block requests from a disallowed origin (not only a soft CORS block)", async () => {
+      client.apiKey = await createApiToken({ allowedOrigins });
+      const apis = [
+        ["POST", "/stream"],
+        ["GET", "/stream/1234"],
+        ["POST", "/asset/request-upload"],
+      ];
+      for (const [method, path] of apis) {
+        await expect(
+          fetchCors(method, path, "https://not.allowed.com")
+        ).resolves.toMatchObject({
+          corsAllowed: false,
+          status: 403,
+          body: {
+            errors: [
+              expect.stringMatching(
+                /credential disallows CORS access from origin .+/
+              ),
+            ],
+          },
+        });
+      }
+    });
+  });
+});

--- a/packages/api/src/controllers/auth.ts
+++ b/packages/api/src/controllers/auth.ts
@@ -18,10 +18,10 @@ async function checkUserOwned(
   headerName: string,
   table: Table<UserOwnedObj>
 ) {
-  const id = req.headers[headerName]?.toString();
-  if (!id) {
+  if (!(headerName in req.headers)) {
     return;
   }
+  const id = req.headers[headerName]?.toString();
   const obj = await table.get(id);
   if (!obj || obj.deleted) {
     throw new NotFoundError(`${table.name} not found`);

--- a/packages/api/src/controllers/auth.ts
+++ b/packages/api/src/controllers/auth.ts
@@ -10,6 +10,9 @@ import Table from "../store/table";
 
 type UserOwnedObj = { id: string; deleted?: boolean; userId?: string };
 
+// Grabs the ID from the provided request header, fetches the corresponding
+// object in the database table and checks that it is owned by the user making
+// the request. Throws a status code error if not.
 async function checkUserOwned(
   req: Request,
   headerName: string,

--- a/packages/api/src/controllers/auth.ts
+++ b/packages/api/src/controllers/auth.ts
@@ -18,10 +18,10 @@ async function checkUserOwned(
   headerName: string,
   table: Table<UserOwnedObj>
 ) {
-  if (!(headerName in req.headers)) {
+  const id = req.headers[headerName]?.toString();
+  if (!id) {
     return;
   }
-  const id = req.headers[headerName]?.toString();
   const obj = await table.get(id);
   if (!obj || obj.deleted) {
     throw new NotFoundError(`${table.name} not found`);

--- a/packages/api/src/controllers/auth.ts
+++ b/packages/api/src/controllers/auth.ts
@@ -2,7 +2,7 @@
  * Special controller for forwarding all incoming requests to a geolocated API region
  */
 
-import { Router } from "express";
+import { Request, Router } from "express";
 import { authorizer } from "../middleware";
 import { db } from "../store";
 import { ForbiddenError, NotFoundError } from "../store/errors";
@@ -10,31 +10,33 @@ import Table from "../store/table";
 
 type UserOwnedObj = { id: string; deleted?: boolean; userId?: string };
 
+async function checkUserOwned(
+  req: Request,
+  headerName: string,
+  table: Table<UserOwnedObj>
+) {
+  if (!(headerName in req.headers)) {
+    return;
+  }
+  const id = req.headers[headerName]?.toString();
+  const obj = await table.get(id);
+  if (!obj || obj.deleted) {
+    throw new NotFoundError(`${table.name} not found`);
+  }
+  const hasAccess = obj.userId === req.user.id || req.user.admin;
+  if (!hasAccess) {
+    throw new ForbiddenError(`access forbidden`);
+  }
+}
+
 const app = Router();
 
 app.all(
   "/",
   authorizer({ originalUriHeader: "x-original-uri" }),
   async (req, res) => {
-    const checkUserOwned = async (
-      headerName: string,
-      table: Table<UserOwnedObj>
-    ) => {
-      if (!(headerName in req.headers)) {
-        return;
-      }
-      const id = req.headers[headerName]?.toString();
-      const obj = await table.get(id);
-      if (!obj || obj.deleted) {
-        throw new NotFoundError(`${table.name} not found`);
-      }
-      const hasAccess = obj.userId === req.user.id || req.user.admin;
-      if (!hasAccess) {
-        throw new ForbiddenError(`access forbidden`);
-      }
-    };
-    await checkUserOwned("x-livepeer-stream-id", db.stream);
-    await checkUserOwned("x-livepeer-asset-id", db.asset);
+    await checkUserOwned(req, "x-livepeer-stream-id", db.stream);
+    await checkUserOwned(req, "x-livepeer-asset-id", db.asset);
     res.status(204).end();
   }
 );

--- a/packages/api/src/controllers/auth.ts
+++ b/packages/api/src/controllers/auth.ts
@@ -12,14 +12,27 @@ app.all(
   "/",
   authorizer({ originalUriHeader: "x-original-uri" }),
   async (req, res) => {
-    const streamId = req.headers["x-livepeer-stream-id"];
-    const stream = await db.stream.get(streamId?.toString() ?? "");
-    if (!stream) {
-      return res.status(404).json({ errors: ["stream not found"] });
+    const streamId = req.headers["x-livepeer-stream-id"]?.toString();
+    if (streamId) {
+      const stream = await db.stream.get(streamId);
+      if (!stream || stream.deleted) {
+        return res.status(404).json({ errors: ["stream not found"] });
+      }
+      const hasAccess = stream.userId === req.user.id || req.user.admin;
+      if (!hasAccess) {
+        return res.status(403).json({ errors: ["access forbidden"] });
+      }
     }
-    const hasAccess = stream.userId === req.user.id || req.user.admin;
-    if (!hasAccess) {
-      return res.status(403).json({ errors: ["access forbidden"] });
+    const assetId = req.headers["x-livepeer-asset-id"]?.toString();
+    if (assetId) {
+      const asset = await db.asset.get(assetId);
+      if (!asset || asset.deleted) {
+        return res.status(404).json({ errors: ["asset not found"] });
+      }
+      const hasAccess = asset.userId === req.user.id || req.user.admin;
+      if (!hasAccess) {
+        return res.status(403).json({ errors: ["access forbidden"] });
+      }
     }
     res.status(204).end();
   }

--- a/packages/api/src/middleware/auth.test.ts
+++ b/packages/api/src/middleware/auth.test.ts
@@ -576,6 +576,12 @@ describe("auth middleware", () => {
         corsAllowed: true,
         status: 404,
       });
+      await expect(
+        fetchCors("GET", "/data/views/1234/total", allowedOrigins[0])
+      ).resolves.toMatchObject({
+        corsAllowed: true,
+        status: 404,
+      });
 
       for (const [method, path] of forbiddenApis) {
         await expect(

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -298,13 +298,12 @@ function authorizer(params: AuthzParams): RequestHandler {
     }
     const accessRules = tokenAccessRules(token);
     if (accessRules) {
+      const { httpPrefix } = req.config;
       let fullPath = pathJoin2(req.baseUrl, req.path);
-      let { httpPrefix } = req.config;
       if (params.originalUriHeader) {
         const header = req.headers[params.originalUriHeader];
         const originalUri = new URL(header?.toString() ?? "");
         fullPath = originalUri.pathname;
-        httpPrefix = null;
       }
       if (!isAuthorized(req.method, fullPath, accessRules, httpPrefix)) {
         throw new ForbiddenError(

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -214,6 +214,11 @@ export const corsApiKeyAccessRules: AuthRule[] = [
       "/asset/:id/export",
     ],
   },
+  // Data
+  {
+    methods: ["get"],
+    resources: ["/data/views/:id/total"],
+  },
 ];
 
 function isRestrictedCors(token?: ApiToken) {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This allows the authorization API, currently used for stream health, to also
be used for the viewership API. This mostly means adding support for authorizing
access to a given asset as well, not only to a stream. Also adding CORS support
on the analyzer endpoint.

This goes together with https://github.com/livepeer/livepeer-data/pull/60

**Specific updates (required)**
 - Allow auth API to receive an asset ID not only a stream ID
 - Allow CORS on the viewership API

## -

- **How did you test each of these updates (required)**
 - `yarn test`
 - also deployed to staging to check functionality

**Does this pull request close any open issues?**
Closes #1278

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
