### PR TITLE
www: Fix asset details page viewership components

### DIFF
--- a/packages/www/hooks/use-api.tsx
+++ b/packages/www/hooks/use-api.tsx
@@ -169,15 +169,7 @@ const makeContext = (
       if (state.token && !headers.has("authorization")) {
         headers.set("authorization", `JWT ${state.token}`);
       }
-
-      // TODO: remove conditional once we add a route for /api/data
-      if (url.includes("/data")) {
-        url = `${endpoint}${url}`;
-      } else {
-        url = `${endpoint}/api${url}`;
-      }
-
-      const res = await fetch(url, {
+      const res = await fetch(`${endpoint}/api${url}`, {
         ...opts,
         headers,
       });

--- a/packages/www/hooks/use-api.tsx
+++ b/packages/www/hooks/use-api.tsx
@@ -1241,9 +1241,9 @@ const makeContext = (
       return { tag: "unknown", commit: "unknowm" };
     },
 
-    async getTotalViews(playbackId): Promise<number> {
+    async getTotalViews(assetId: string): Promise<number> {
       const [res, totalViews] = await context.fetch(
-        `/data/views/${playbackId}/total`
+        `/data/views/${assetId}/total`
       );
       if (res.status !== 200) {
         throw totalViews && typeof totalViews === "object"

--- a/packages/www/layouts/assetDetail.tsx
+++ b/packages/www/layouts/assetDetail.tsx
@@ -184,7 +184,7 @@ const AssetDetail = ({
       />
       <Layout id="assets" breadcrumbs={breadcrumbs}>
         <Box css={{ px: "$6", py: "$7" }}>
-          {asset != undefined && totalViews != undefined ? (
+          {asset != undefined ? (
             <>
               <Flex>
                 <Box
@@ -212,19 +212,23 @@ const AssetDetail = ({
                       </Flex>
                     </Heading>
                     <Flex align="center">
-                      <Tooltip
-                        css={{ bc: "$neutral3", color: "$neutral3" }}
-                        content={
-                          <Box css={{ color: "$hiContrast" }}>
-                            Views are defined as at least 1 second of watch
-                            time.
-                          </Box>
-                        }>
-                        <Flex align="center" css={{ mr: "$3", fontSize: "$2" }}>
-                          <Box as={PlayIcon} css={{ mr: "$1" }} /> {totalViews}{" "}
-                          views
-                        </Flex>
-                      </Tooltip>
+                      {totalViews != undefined ? (
+                        <Tooltip
+                          css={{ bc: "$neutral3", color: "$neutral3" }}
+                          content={
+                            <Box css={{ color: "$hiContrast" }}>
+                              Views are defined as at least 1 second of watch
+                              time.
+                            </Box>
+                          }>
+                          <Flex
+                            align="center"
+                            css={{ mr: "$3", fontSize: "$2" }}>
+                            <Box as={PlayIcon} css={{ mr: "$1" }} />{" "}
+                            {totalViews} views
+                          </Flex>
+                        </Tooltip>
+                      ) : null}
                       <Flex align="center" css={{ fontSize: "$2" }}>
                         <Box as={CalendarIcon} css={{ mr: "$1" }} />
                         <RelativeTime

--- a/packages/www/pages/dashboard/assets/[id]/index.tsx
+++ b/packages/www/pages/dashboard/assets/[id]/index.tsx
@@ -28,14 +28,10 @@ const AssetDetails = () => {
     }
   );
 
-  const { data: totalViews } = useQuery(
-    [asset?.playbackId],
-    () => getTotalViews(asset?.playbackId),
-    {
-      refetchInterval,
-      enabled: Boolean(asset?.playbackId),
-    }
-  );
+  const { data: totalViews } = useQuery([id], () => getTotalViews(id), {
+    refetchInterval,
+    enabled: Boolean(id),
+  });
 
   return (
     <AssetDetail

--- a/packages/www/pages/dashboard/assets/[id]/index.tsx
+++ b/packages/www/pages/dashboard/assets/[id]/index.tsx
@@ -20,7 +20,7 @@ const AssetDetails = () => {
   const id = query.id as string;
 
   const { data: asset, refetch: refetchAsset } = useQuery(
-    [id],
+    ["asset", id],
     () => getAsset(id),
     {
       refetchInterval,
@@ -28,10 +28,14 @@ const AssetDetails = () => {
     }
   );
 
-  const { data: totalViews } = useQuery([id], () => getTotalViews(id), {
-    refetchInterval,
-    enabled: Boolean(id),
-  });
+  const { data: totalViews } = useQuery(
+    ["totalViews", id],
+    () => getTotalViews(id),
+    {
+      refetchInterval,
+      enabled: Boolean(id),
+    }
+  );
 
   return (
     <AssetDetail


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This is to fix the frontend for the viewership API, which broke after the last change,
but more importantly than that, shouldn't break the asset detail page anyhow.

**Specific updates (required)**
 - Make views an optional component in the page, only if available
 - Fetch views by asset ID instead of playback ID

## -

- **How did you test each of these updates (required)**
Access viewership page and ensure it works again.

**Does this pull request close any open issues?**
Fixes issue just found on deploy.

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
