### PR TITLE
accessControl: Add /gate endpoint for Catalyst integration

### DIFF
--- a/packages/api/src/controllers/access-control.test.ts
+++ b/packages/api/src/controllers/access-control.test.ts
@@ -75,7 +75,7 @@ describe("controllers/signing-key", () => {
         pub: signingKey.publicKey,
         type: "jwt",
       });
-      expect(res2.status).toBe(200);
+      expect(res2.status).toBe(204);
     });
 
     it("should not allow playback on not existing streams or public keys", async () => {
@@ -122,7 +122,7 @@ describe("controllers/signing-key", () => {
         stream: `video+${publicPlaybackId}`,
         type: "jwt",
       });
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(204);
     });
 
     it("should allow playback if playbackPolicy is not specified", async () => {
@@ -135,7 +135,7 @@ describe("controllers/signing-key", () => {
         type: "jwt",
         pub: signingKey.publicKey,
       });
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(204);
     });
   });
 });

--- a/packages/api/src/controllers/access-control.test.ts
+++ b/packages/api/src/controllers/access-control.test.ts
@@ -40,7 +40,6 @@ describe("controllers/signing-key", () => {
     let adminToken: string;
     let nonAdminUser: User;
     let nonAdminToken: string;
-    let otherUserToken: string;
     let signingKey: WithID<SigningKey>;
     let gatedPlaybackId: string;
     let publicPlaybackId: string;

--- a/packages/api/src/controllers/access-control.test.ts
+++ b/packages/api/src/controllers/access-control.test.ts
@@ -58,7 +58,7 @@ describe("controllers/signing-key", () => {
       const res2 = await client.post("/stream", {
         name: "test",
         playbackPolicy: {
-          type: "signed",
+          type: "jwt",
         },
       });
       const stream = await res2.json();
@@ -78,7 +78,7 @@ describe("controllers/signing-key", () => {
         createdAt: Date.now(),
         playbackId: await generateUniquePlaybackId(id),
         playbackPolicy: {
-          type: "signed",
+          type: "jwt",
         },
         status: {
           phase: "ready",
@@ -129,7 +129,7 @@ describe("controllers/signing-key", () => {
       const otherStream = await client.post("/stream", {
         name: "test",
         playbackPolicy: {
-          type: "signed",
+          type: "jwt",
         },
       });
       const otherStreamPlaybackId = (await otherStream.json()).playbackId;

--- a/packages/api/src/controllers/access-control.test.ts
+++ b/packages/api/src/controllers/access-control.test.ts
@@ -1,14 +1,7 @@
 import serverPromise, { TestServer } from "../test-server";
-import {
-  TestClient,
-  clearDatabase,
-  setupUsers,
-  verifyJwt,
-} from "../test-helpers";
+import { TestClient, clearDatabase, setupUsers } from "../test-helpers";
 import { SigningKey, SigningKeyResponsePayload, User } from "../schema/types";
 import { WithID } from "../store/types";
-import jwt, { JsonWebTokenError, JwtPayload } from "jsonwebtoken";
-import { db } from "../store";
 
 // includes auth file tests
 
@@ -122,6 +115,14 @@ describe("controllers/signing-key", () => {
         type: "jwt",
       });
       expect(res.status).toBe(403);
+    });
+
+    it("should allow playback on public playbackId", async () => {
+      const res = await client.post("/access-control/gate", {
+        stream: `video+${publicPlaybackId}`,
+        type: "jwt",
+      });
+      expect(res.status).toBe(200);
     });
   });
 });

--- a/packages/api/src/controllers/access-control.test.ts
+++ b/packages/api/src/controllers/access-control.test.ts
@@ -124,5 +124,18 @@ describe("controllers/signing-key", () => {
       });
       expect(res.status).toBe(200);
     });
+
+    it("should allow playback if playbackPolicy is not specified", async () => {
+      const stream = await client.post("/stream", {
+        name: "test",
+      });
+      const streamPlaybackId = (await stream.json()).playbackId;
+      const res = await client.post("/access-control/gate", {
+        stream: `video+${streamPlaybackId}`,
+        type: "jwt",
+        pub: signingKey.publicKey,
+      });
+      expect(res.status).toBe(200);
+    });
   });
 });

--- a/packages/api/src/controllers/access-control.test.ts
+++ b/packages/api/src/controllers/access-control.test.ts
@@ -1,0 +1,127 @@
+import serverPromise, { TestServer } from "../test-server";
+import {
+  TestClient,
+  clearDatabase,
+  setupUsers,
+  verifyJwt,
+} from "../test-helpers";
+import { SigningKey, SigningKeyResponsePayload, User } from "../schema/types";
+import { WithID } from "../store/types";
+import jwt, { JsonWebTokenError, JwtPayload } from "jsonwebtoken";
+import { db } from "../store";
+
+// includes auth file tests
+
+let server: TestServer;
+let mockAdminUserInput: User;
+let mockNonAdminUserInput: User;
+
+// jest.setTimeout(70000)
+
+beforeAll(async () => {
+  server = await serverPromise;
+
+  mockAdminUserInput = {
+    email: "user_admin@gmail.com",
+    password: "x".repeat(64),
+  };
+
+  mockNonAdminUserInput = {
+    email: "user_non_admin@gmail.com",
+    password: "y".repeat(64),
+  };
+});
+
+afterEach(async () => {
+  await clearDatabase(server);
+});
+
+describe("controllers/signing-key", () => {
+  describe("basic CRUD with JWT authorization", () => {
+    let client: TestClient;
+    let adminUser: User;
+    let adminToken: string;
+    let nonAdminUser: User;
+    let nonAdminToken: string;
+    let otherUserToken: string;
+    let signingKey: WithID<SigningKey>;
+    let gatedPlaybackId: string;
+    let publicPlaybackId: string;
+
+    beforeEach(async () => {
+      ({ client, adminUser, adminToken, nonAdminUser, nonAdminToken } =
+        await setupUsers(server, mockAdminUserInput, mockNonAdminUserInput));
+      client.jwtAuth = nonAdminToken;
+      let created: SigningKeyResponsePayload = await client
+        .post("/access-control/signing-key")
+        .then((res) => res.json());
+      let res = await client.get(`/access-control/signing-key/${created.id}`);
+      signingKey = await res.json();
+      const res2 = await client.post("/stream", {
+        name: "test",
+        playbackPolicy: {
+          type: "signed",
+        },
+      });
+      const stream = await res2.json();
+      gatedPlaybackId = stream.playbackId;
+      const res3 = await client.post("/stream", {
+        name: "test",
+        playbackPolicy: {
+          type: "public",
+        },
+      });
+      const publicStream = await res3.json();
+      publicPlaybackId = publicStream.playbackId;
+    });
+
+    it("should create a gate stream and allow playback with given public key", async () => {
+      client.jwtAuth = adminToken;
+      const res2 = await client.post("/access-control/gate", {
+        stream: `video+${gatedPlaybackId}`,
+        pub: signingKey.publicKey,
+        type: "jwt",
+      });
+      expect(res2.status).toBe(200);
+    });
+
+    it("should not allow playback on not existing streams or public keys", async () => {
+      const res = await client.post("/access-control/gate", {
+        stream: `video+0000000000`,
+        pub: signingKey.publicKey,
+        type: "jwt",
+      });
+      expect(res.status).toBe(403);
+      const res2 = await client.post("/access-control/gate", {
+        stream: `video+${gatedPlaybackId}`,
+        pub: "00000000000000",
+        type: "jwt",
+      });
+      expect(res2.status).toBe(403);
+    });
+
+    it("should not allow playback if stream is gated an pub is missing", async () => {
+      const res2 = await client.post("/access-control/gate", {
+        stream: `video+${gatedPlaybackId}`,
+        type: "jwt",
+      });
+      expect(res2.status).toBe(403);
+    });
+
+    it("should not allow playback if stream and public key does not share the same owner", async () => {
+      const otherStream = await client.post("/stream", {
+        name: "test",
+        playbackPolicy: {
+          type: "signed",
+        },
+      });
+      const otherStreamPlaybackId = (await otherStream.json()).playbackId;
+      const res = await client.post("/access-control/gate", {
+        stream: `video+${otherStreamPlaybackId}`,
+        pub: signingKey.publicKey,
+        type: "jwt",
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/packages/api/src/controllers/access-control.ts
+++ b/packages/api/src/controllers/access-control.ts
@@ -42,7 +42,7 @@ accessControl.post(
     if (playbackPolicy) {
       if (playbackPolicy.type === "public") {
         res.set("Cache-Control", "max-age=120,stale-while-revalidate=600");
-        res.status(200);
+        res.status(204);
         return res.json();
       }
 
@@ -76,7 +76,7 @@ accessControl.post(
       }
     }
     res.set("Cache-Control", "max-age=120,stale-while-revalidate=600");
-    res.status(200);
+    res.status(204);
     return res.json();
   }
 );

--- a/packages/api/src/controllers/access-control.ts
+++ b/packages/api/src/controllers/access-control.ts
@@ -5,7 +5,7 @@ import { Router } from "express";
 import _ from "lodash";
 import { db } from "../store";
 import sql from "sql-template-strings";
-import { ForbiddenError, NotFoundError } from "../store/errors";
+import { NotFoundError, ForbiddenError } from "../store/errors";
 
 const accessControl = Router();
 

--- a/packages/api/src/controllers/access-control.ts
+++ b/packages/api/src/controllers/access-control.ts
@@ -41,8 +41,9 @@ accessControl.post(
 
     if (playbackPolicy) {
       if (playbackPolicy.type === "public") {
+        res.set("Cache-Control", "max-age=120,stale-while-revalidate=600");
         res.status(200);
-        return res.json(playbackPolicy);
+        return res.json();
       }
 
       if (playbackPolicy.type === "signed") {
@@ -74,10 +75,9 @@ accessControl.post(
         }
       }
     }
-
     res.set("Cache-Control", "max-age=120,stale-while-revalidate=600");
     res.status(200);
-    return res.json(playbackPolicy);
+    return res.json();
   }
 );
 

--- a/packages/api/src/controllers/access-control.ts
+++ b/packages/api/src/controllers/access-control.ts
@@ -32,13 +32,13 @@ accessControl.post(
       throw new NotFoundError("Content not found");
     }
 
-    const playbackPolicyType: string = content.playbackPolicy?.type ?? "public";
+    const playbackPolicyType = content.playbackPolicy?.type ?? "public";
     res.set("Cache-Control", "max-age=120,stale-while-revalidate=600");
 
     if (playbackPolicyType === "public") {
       res.status(204);
       return res.end();
-    } else if (playbackPolicyType === "signed") {
+    } else if (playbackPolicyType === "jwt") {
       if (!req.body.pub) {
         throw new ForbiddenError("Stream is gated and requires a public key");
       }

--- a/packages/api/src/controllers/access-control.ts
+++ b/packages/api/src/controllers/access-control.ts
@@ -33,9 +33,9 @@ accessControl.post(
     }
 
     const playbackPolicyType = content.playbackPolicy?.type ?? "public";
-    res.set("Cache-Control", "max-age=120,stale-while-revalidate=600");
 
     if (playbackPolicyType === "public") {
+      res.set("Cache-Control", "max-age=120,stale-while-revalidate=600");
       res.status(204);
       return res.end();
     } else if (playbackPolicyType === "jwt") {
@@ -66,6 +66,7 @@ accessControl.post(
         throw new ForbiddenError("The public key is disabled or deleted");
       }
 
+      res.set("Cache-Control", "max-age=120,stale-while-revalidate=600");
       res.status(204);
       return res.end();
     } else {

--- a/packages/api/src/controllers/access-control.ts
+++ b/packages/api/src/controllers/access-control.ts
@@ -5,7 +5,7 @@ import { Router } from "express";
 import _ from "lodash";
 import { db } from "../store";
 import sql from "sql-template-strings";
-import { ForbiddenError } from "../store/errors";
+import { ForbiddenError, NotFoundError } from "../store/errors";
 
 const accessControl = Router();
 
@@ -24,12 +24,8 @@ accessControl.post(
       (await db.stream.getByPlaybackId(playbackId)) ||
       (await db.asset.getByPlaybackId(playbackId));
 
-    if (!content) {
-      throw new ForbiddenError("Content not found");
-    }
-
-    if (content.deleted) {
-      throw new ForbiddenError("Stream is deleted");
+    if (!content || content.deleted) {
+      throw new NotFoundError("Content not found");
     }
 
     const playbackPolicy = content.playbackPolicy;

--- a/packages/api/src/controllers/access-control.ts
+++ b/packages/api/src/controllers/access-control.ts
@@ -1,5 +1,11 @@
-import { Router } from "express";
 import signingKeyApp from "./signing-key";
+import { authorizer } from "../middleware";
+import { validatePost } from "../middleware";
+import { Router } from "express";
+import _ from "lodash";
+import { db } from "../store";
+import sql from "sql-template-strings";
+import { ForbiddenError } from "../store/errors";
 
 const accessControl = Router();
 
@@ -7,5 +13,60 @@ const app = Router();
 
 accessControl.use("/signing-key", signingKeyApp);
 app.use("/access-control", accessControl);
+
+accessControl.post(
+  "/gate",
+  authorizer({ anyAdmin: true }),
+  validatePost("access-control-gate-payload"),
+  async (req, res) => {
+    const playbackId = req.body.stream.replace("video+", "");
+
+    var query = [];
+    query.push(sql`stream.data->>'playbackId' = ${playbackId}`);
+    var [output] = await db.stream.find(query);
+
+    if (output.length === 0) {
+      // TODO: VOD Assets
+      throw new ForbiddenError("Stream not found");
+    }
+
+    const stream = output[0];
+    const playbackPolicy = stream.playbackPolicy;
+
+    if (playbackPolicy) {
+      if (playbackPolicy.type === "public") {
+        res.status(200);
+        return res.json(playbackPolicy);
+      }
+
+      if (playbackPolicy.type === "signed") {
+        if (!req.body.pub) {
+          throw new ForbiddenError("Stream is gated and requires a public key");
+        }
+
+        var query = [];
+        query.push(sql`signing_key.data->>'publicKey' = ${req.body.pub}`);
+        var [signingKeyOutput] = await db.signingKey.find(query);
+
+        if (signingKeyOutput.length == 0) {
+          throw new ForbiddenError(
+            "Stream is gated and corresponding public key not found"
+          );
+        }
+
+        const signingKey = signingKeyOutput[0];
+        if (signingKey.userId !== stream.userId) {
+          throw new ForbiddenError(
+            "The stream and the public key do not share the same owner"
+          );
+        }
+      }
+    }
+
+    res.set("Cache-Control", "max-age=120,stale-while-revalidate=600");
+    res.status(200);
+    return res.json(playbackPolicy);
+  }
+);
 
 export default accessControl;

--- a/packages/api/src/controllers/access-control.ts
+++ b/packages/api/src/controllers/access-control.ts
@@ -72,6 +72,12 @@ accessControl.post(
         throw new ForbiddenError("The public key is disabled or deleted");
       }
 
+      const user = await db.user.get(content.userId);
+
+      if (user.suspended) {
+        throw new ForbiddenError("The owner of the content is suspended");
+      }
+
       res.set("Cache-Control", "max-age=120,stale-while-revalidate=600");
       res.status(204);
       return res.end();

--- a/packages/api/src/controllers/access-control.ts
+++ b/packages/api/src/controllers/access-control.ts
@@ -10,6 +10,7 @@ import {
   ForbiddenError,
   BadRequestError,
 } from "../store/errors";
+import tracking from "../middleware/tracking";
 
 const accessControl = Router();
 
@@ -62,6 +63,7 @@ accessControl.post(
       }
 
       const signingKey = signingKeyOutput[0];
+
       if (signingKey.userId !== content.userId) {
         throw new ForbiddenError(
           "The stream and the public key do not share the same owner"
@@ -78,6 +80,7 @@ accessControl.post(
         throw new ForbiddenError("The owner of the content is suspended");
       }
 
+      tracking.recordSigningKeyValidation(signingKey.id);
       res.set("Cache-Control", "max-age=120,stale-while-revalidate=600");
       res.status(204);
       return res.end();

--- a/packages/api/src/controllers/access-control.ts
+++ b/packages/api/src/controllers/access-control.ts
@@ -55,6 +55,12 @@ accessControl.post(
         );
       }
 
+      if (signingKeyOutput.length > 1) {
+        throw new BadRequestError(
+          "Multiple signing keys found for the same public key. This shouldn't happen."
+        );
+      }
+
       const signingKey = signingKeyOutput[0];
       if (signingKey.userId !== content.userId) {
         throw new ForbiddenError(
@@ -70,7 +76,9 @@ accessControl.post(
       res.status(204);
       return res.end();
     } else {
-      throw new BadRequestError(`unknown policy type: ${playbackPolicyType}`);
+      throw new BadRequestError(
+        `unknown playbackPolicy type: ${playbackPolicyType}`
+      );
     }
   }
 );

--- a/packages/api/src/controllers/signing-key.ts
+++ b/packages/api/src/controllers/signing-key.ts
@@ -10,11 +10,7 @@ import {
 import { db } from "../store";
 import sql from "sql-template-strings";
 import { v4 as uuid } from "uuid";
-import {
-  generateKeyPairSync,
-  generateKeyPair,
-  KeyPairSyncResult,
-} from "crypto";
+import { generateKeyPair, KeyPairSyncResult } from "crypto";
 import { ForbiddenError, NotFoundError } from "../store/errors";
 import {
   SigningKey,

--- a/packages/api/src/middleware/tracking.ts
+++ b/packages/api/src/middleware/tracking.ts
@@ -22,6 +22,10 @@ class Tracker {
     this.recordLastSeen(db.apiToken, id);
   }
 
+  recordSigningKeyValidation(signingKeyId: string) {
+    this.recordLastSeen(db.signingKey, signingKeyId);
+  }
+
   private recordLastSeen(
     table: Table<{ id: string; lastSeen?: number }>,
     id: string

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -773,7 +773,7 @@ components:
       properties:
         type:
           type: string
-          enum: [public, signed]
+          enum: [public, jwt]
 
     session:
       type: object

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -749,6 +749,21 @@ components:
         response:
           $ref: "#/components/schemas/webhook-response"
 
+    access-control-gate-payload:
+      type: object
+      additionalProperties: false
+      required: [type, stream]
+      properties:
+        type:
+          type: string
+          enum: [jwt]
+        stream:
+          type: string
+          description: Stream ID to which this gate applies
+        pub:
+          type: string
+          description: Base64 of Public key used for JWT verification
+
     playback-policy:
       type: object
       description:

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1625,7 +1625,7 @@ components:
           description:
             Timestamp (in milliseconds) at which the signing-key was created
           example: 1587667174725
-        lastUsedAt:
+        lastSeen:
           type: number
           readOnly: true
           description:


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Creates a `/access-control/gate` endpoint for Catalyst integration

**Specific updates (required)**

- Allow to pass a `stream` or an `asset` playbackId to the endpoint
- The response can be either `2XX` or `4XX` depending on the existence of the content, whether the publicKey is valid and owned by the same `User` that own the content



Condition | Status Code | Allowed
-- | -- | --
Content is not gated | 204 No Content | YES
Content is gated and JWT is valid | 204 No Content | YES
Content not found | 404 Not found | NO
Content is gated, Signing Key does not exist | 403 Forbidden | NO
Content is gated, signing key and content don’t share the same owner | 403 Forbidden | NO
Content is gated, signing key is disabled | 403 Forbidden | NO
Content does not have a playback Policy | 204 No Content | YES

- Tests for all the possible cases

**How did you test each of these updates (required)**

yarn test

**Does this pull request close any open issues?**

Fixes #1285 
Partially Fixes #1288 

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
