### PR TITLE
api+www: Delete asset meta field

### DIFF
--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -295,6 +295,8 @@ app.use(
     let toExternalAsset = (a: WithID<Asset>) => {
       a = withPlaybackUrls(ingest, a);
       a = assetWithIpfsUrls(a);
+      // TODO: Remove compatibiltiy logic (tags used to be called meta)
+      a = { ...a, tags: a.tags || (a as any).meta };
       if (req.user.admin) {
         return a;
       }

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -45,8 +45,6 @@ import os from "os";
 
 const app = Router();
 
-const TAGS_MAX_SIZE = 1024;
-
 function shouldUseCatalyst({ query, user, config }: Request) {
   const { upload } = toStringValues(query);
   if (user.admin && upload === "1") {
@@ -305,7 +303,6 @@ const fieldsMap: FieldsMap = {
   playbackRecordingId: `asset.data->>'playbackRecordingId'`,
   phase: `asset.data->'status'->>'phase'`,
   "user.email": { val: `users.data->>'email'`, type: "full-text" },
-  tags: `asset.data->>'tags'`,
   cid: `asset.data->'storage'->'ipfs'->>'cid'`,
   nftMetadataCid: `asset.data->'storage'->'ipfs'->'nftMetadata'->>'cid'`,
 };
@@ -716,7 +713,7 @@ app.post("/upload/tus", async (req, res) => {
   const { jwtSecret, jwtAudience } = req.config;
   const { playbackId } = parseUploadUrl(uploadToken, jwtSecret, jwtAudience);
   await getPendingAssetAndTask(playbackId);
-  // TODO: Consider updating asset name and tags from metadata?
+  // TODO: Consider updating asset name from metadata?
   res.setHeader("livepeer-playback-id", playbackId);
   return tusServer.handle(req, res);
 });

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -649,8 +649,6 @@ components:
       properties:
         name:
           $ref: "#/components/schemas/asset/properties/name"
-        tags:
-          $ref: "#/components/schemas/asset/properties/tags"
         playbackPolicy:
           $ref: "#/components/schemas/playback-policy"
         storage:
@@ -1133,17 +1131,6 @@ components:
             Name of the asset. This is not necessarily the filename, can be a
             custom name or title
           example: filename.mp4
-        tags:
-          type: object
-          description: User input metadata associated with the asset
-          additionalProperties:
-            type: string
-          example:
-            {
-              "title": "My awesome video",
-              "description": "This is a video of my awesome life",
-              "tags": "awesome,life,video",
-            }
         createdAt:
           type: number
           readOnly: true
@@ -1304,17 +1291,6 @@ components:
           example: filename.mp4
         playbackPolicy:
           $ref: "#/components/schemas/playback-policy"
-        tags:
-          type: object
-          description: User input metadata associated with the asset
-          additionalProperties:
-            type: string
-          example:
-            {
-              "title": "My awesome video",
-              "description": "This is a video of my awesome life",
-              "tags": ["awesome", "life", "video"],
-            }
         url:
           type: string
           format: uri

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -649,8 +649,8 @@ components:
       properties:
         name:
           $ref: "#/components/schemas/asset/properties/name"
-        meta:
-          $ref: "#/components/schemas/asset/properties/meta"
+        tags:
+          $ref: "#/components/schemas/asset/properties/tags"
         playbackPolicy:
           $ref: "#/components/schemas/playback-policy"
         storage:
@@ -1133,7 +1133,7 @@ components:
             Name of the asset. This is not necessarily the filename, can be a
             custom name or title
           example: filename.mp4
-        meta:
+        tags:
           type: object
           description: User input metadata associated with the asset
           additionalProperties:
@@ -1304,7 +1304,7 @@ components:
           example: filename.mp4
         playbackPolicy:
           $ref: "#/components/schemas/playback-policy"
-        meta:
+        tags:
           type: object
           description: User input metadata associated with the asset
           additionalProperties:

--- a/packages/www/components/Dashboard/AssetDetails/AssetOverviewTab.tsx
+++ b/packages/www/components/Dashboard/AssetDetails/AssetOverviewTab.tsx
@@ -60,15 +60,15 @@ const AssetOverviewTab = ({
     }
   }, [asset, patchAsset]);
 
-  const metadataStringified = useMemo(
-    () => (asset?.meta ? JSON.stringify(asset.meta, null, 4) : ""),
-    [asset?.meta]
-  );
+  // const metadataStringified = useMemo(
+  //   () => (asset?.meta ? JSON.stringify(asset.meta, null, 4) : ""),
+  //   [asset?.meta]
+  // );
 
   return (
     <>
       <Box>
-        <Box
+        {/* <Box
           css={{
             mb: "$3",
             width: "100%",
@@ -116,7 +116,7 @@ const AssetOverviewTab = ({
               No metadata yet
             </Text>
           )}
-        </Promo>
+        </Promo> */}
 
         <Box
           css={{

--- a/packages/www/components/Dashboard/AssetDetails/AssetOverviewTab.tsx
+++ b/packages/www/components/Dashboard/AssetDetails/AssetOverviewTab.tsx
@@ -79,8 +79,8 @@ const AssetOverviewTab = ({
             </Heading>
           </Flex>
           <Text variant="gray" size="2">
-            A list of key value pairs that you use to add information to your
-            video.{" "}
+            A list of key value pairs that you use to add app-specific
+            annotations about your video.{" "}
             <A css={{ cursor: "pointer" }} onClick={onEditAsset}>
               Edit asset
             </A>{" "}
@@ -112,7 +112,7 @@ const AssetOverviewTab = ({
               css={{
                 mr: "$1",
               }}>
-              No tags set yet
+              No tags set
             </Text>
           )}
         </Promo>

--- a/packages/www/components/Dashboard/AssetDetails/AssetOverviewTab.tsx
+++ b/packages/www/components/Dashboard/AssetDetails/AssetOverviewTab.tsx
@@ -7,7 +7,6 @@ import {
   Heading,
   Promo,
   Text,
-  useSnackbar,
 } from "@livepeer/design-system";
 
 import { Asset } from "@livepeer.studio/api";
@@ -60,9 +59,9 @@ const AssetOverviewTab = ({
     }
   }, [asset, patchAsset]);
 
-  const metadataStringified = useMemo(
-    () => (asset?.meta ? JSON.stringify(asset.meta, null, 4) : ""),
-    [asset?.meta]
+  const tagsStringified = useMemo(
+    () => (asset?.tags ? JSON.stringify(asset.tags, null, 4) : ""),
+    [asset?.tags]
   );
 
   return (
@@ -76,20 +75,20 @@ const AssetOverviewTab = ({
           <Flex css={{ mb: "$2" }} align="center">
             <StyledCurlyBracesIcon />
             <Heading size="1" css={{ fontWeight: 500 }}>
-              Metadata
+              Tags
             </Heading>
           </Flex>
           <Text variant="gray" size="2">
-            A list of key value pairs that you use to provide metadata for your
+            A list of key value pairs that you use to add information to your
             video.{" "}
             <A css={{ cursor: "pointer" }} onClick={onEditAsset}>
               Edit asset
             </A>{" "}
-            to add metadata.
+            to add tags.
           </Text>
         </Box>
         <Promo size="2" css={{ mb: "$5" }}>
-          {metadataStringified ? (
+          {tagsStringified ? (
             <Flex
               align="center"
               css={{
@@ -97,13 +96,13 @@ const AssetOverviewTab = ({
                 justifyContent: "space-between",
               }}>
               <Text variant="gray" size="2">
-                {metadataStringified}
+                {tagsStringified}
               </Text>
 
               <Box>
                 <ClipButton
-                  value={metadataStringified}
-                  successMessage="Copied metadata to clipboard"
+                  value={tagsStringified}
+                  successMessage="Copied tags to clipboard"
                 />
               </Box>
             </Flex>
@@ -113,7 +112,7 @@ const AssetOverviewTab = ({
               css={{
                 mr: "$1",
               }}>
-              No metadata yet
+              No tags set yet
             </Text>
           )}
         </Promo>

--- a/packages/www/components/Dashboard/AssetDetails/AssetOverviewTab.tsx
+++ b/packages/www/components/Dashboard/AssetDetails/AssetOverviewTab.tsx
@@ -7,6 +7,7 @@ import {
   Heading,
   Promo,
   Text,
+  useSnackbar,
 } from "@livepeer/design-system";
 
 import { Asset } from "@livepeer.studio/api";
@@ -59,9 +60,9 @@ const AssetOverviewTab = ({
     }
   }, [asset, patchAsset]);
 
-  const tagsStringified = useMemo(
-    () => (asset?.tags ? JSON.stringify(asset.tags, null, 4) : ""),
-    [asset?.tags]
+  const metadataStringified = useMemo(
+    () => (asset?.meta ? JSON.stringify(asset.meta, null, 4) : ""),
+    [asset?.meta]
   );
 
   return (
@@ -75,20 +76,20 @@ const AssetOverviewTab = ({
           <Flex css={{ mb: "$2" }} align="center">
             <StyledCurlyBracesIcon />
             <Heading size="1" css={{ fontWeight: 500 }}>
-              Tags
+              Metadata
             </Heading>
           </Flex>
           <Text variant="gray" size="2">
-            A list of key value pairs that you use to add app-specific
-            annotations about your video.{" "}
+            A list of key value pairs that you use to provide metadata for your
+            video.{" "}
             <A css={{ cursor: "pointer" }} onClick={onEditAsset}>
               Edit asset
             </A>{" "}
-            to add tags.
+            to add metadata.
           </Text>
         </Box>
         <Promo size="2" css={{ mb: "$5" }}>
-          {tagsStringified ? (
+          {metadataStringified ? (
             <Flex
               align="center"
               css={{
@@ -96,13 +97,13 @@ const AssetOverviewTab = ({
                 justifyContent: "space-between",
               }}>
               <Text variant="gray" size="2">
-                {tagsStringified}
+                {metadataStringified}
               </Text>
 
               <Box>
                 <ClipButton
-                  value={tagsStringified}
-                  successMessage="Copied tags to clipboard"
+                  value={metadataStringified}
+                  successMessage="Copied metadata to clipboard"
                 />
               </Box>
             </Flex>
@@ -112,7 +113,7 @@ const AssetOverviewTab = ({
               css={{
                 mr: "$1",
               }}>
-              No tags set
+              No metadata yet
             </Text>
           )}
         </Promo>

--- a/packages/www/components/Dashboard/AssetDetails/EditAssetDialog.tsx
+++ b/packages/www/components/Dashboard/AssetDetails/EditAssetDialog.tsx
@@ -103,6 +103,8 @@ const EditAssetDialog = ({
                 (error as HttpError)?.message?.includes("should be string")
               ) {
                 setTagsError("Tags must only contain string key value pairs.");
+              } else {
+                setTagsError("Error updating asset.");
               }
             } finally {
               setEditing(false);

--- a/packages/www/components/Dashboard/AssetDetails/EditAssetDialog.tsx
+++ b/packages/www/components/Dashboard/AssetDetails/EditAssetDialog.tsx
@@ -26,7 +26,6 @@ const demoIpfsContent = {
 
 export type EditAssetReturnValue = {
   name: string;
-  metadata: Record<string, unknown> | null;
 };
 
 const EditAssetDialog = ({
@@ -93,7 +92,6 @@ const EditAssetDialog = ({
             try {
               await onEdit({
                 name,
-                metadata: metadata ? JSON.parse(metadata) : null,
               });
               onOpenChange(false);
             } catch (error) {
@@ -123,7 +121,7 @@ const EditAssetDialog = ({
             />
           </Flex>
 
-          <Flex css={{ mt: "$2" }} direction="column" gap="1">
+          {/* <Flex css={{ mt: "$2" }} direction="column" gap="1">
             <Label htmlFor="metadata">Metadata</Label>
             <TextArea
               size="2"
@@ -142,7 +140,7 @@ const EditAssetDialog = ({
                 {metadataError || "Metadata must be valid JSON."}
               </Text>
             </AlertDialogDescription>
-          )}
+          )} */}
 
           <Flex css={{ jc: "flex-end", gap: "$3", mt: "$4" }}>
             <AlertDialogCancel asChild>
@@ -154,7 +152,7 @@ const EditAssetDialog = ({
               css={{ display: "flex", ai: "center" }}
               type="submit"
               size="2"
-              disabled={editing || !isMetadataValid || !name}
+              disabled={editing || !name} // || !isMetadataValid
               variant="primary">
               {editing && (
                 <Spinner

--- a/packages/www/components/Dashboard/AssetDetails/EditAssetDialog.tsx
+++ b/packages/www/components/Dashboard/AssetDetails/EditAssetDialog.tsx
@@ -1,5 +1,5 @@
 import { HttpError } from "@lib/utils";
-import { Asset } from "livepeer";
+import { Asset } from "@livepeer.studio/api";
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -18,15 +18,15 @@ import {
 import Spinner from "components/Dashboard/Spinner";
 import { useEffect, useMemo, useState } from "react";
 
-const demoIpfsContent = {
-  name: "Singularity in Heritage - Chapter III #095",
-  tokenID: "316",
-  image: "ipfs://QmUrkCHzXHFE2DVucEcarXSe7po39mcKereN1wd9k6gQfw/316.jpg",
+const demoTags = {
+  rating: "E",
+  category: "abstract",
+  languages: "english",
 } as const;
 
 export type EditAssetReturnValue = {
   name: string;
-  metadata: Record<string, unknown> | null;
+  tags?: Record<string, string>;
 };
 
 const EditAssetDialog = ({
@@ -42,28 +42,28 @@ const EditAssetDialog = ({
 }) => {
   const [editing, setEditing] = useState(false);
   const [name, setName] = useState("");
-  const [metadata, setMetadata] = useState("");
-  const [metadataError, setMetadataError] = useState("");
+  const [tags, setTags] = useState("");
+  const [tagsError, setTagsError] = useState("");
 
   useEffect(() => {
     setName(asset?.name);
-    if (asset?.meta) {
-      setMetadata(JSON.stringify(asset?.meta ?? {}, null, 4));
+    if (asset?.tags) {
+      setTags(JSON.stringify(asset?.tags ?? {}, null, 4));
     }
   }, [asset]);
 
-  const isMetadataValid = useMemo(() => {
-    if (!metadata) {
+  const areTagsValid = useMemo(() => {
+    if (!tags) {
       return true;
     }
 
     try {
-      const value = JSON.parse(metadata);
+      const value = JSON.parse(tags);
       return Boolean(value);
     } catch (e) {}
 
     return false;
-  }, [metadata]);
+  }, [tags]);
 
   return (
     <AlertDialog open={isOpen} onOpenChange={onOpenChange}>
@@ -88,12 +88,12 @@ const EditAssetDialog = ({
             if (editing || !name) {
               return;
             }
-            setMetadataError("");
+            setTagsError("");
             setEditing(true);
             try {
               await onEdit({
                 name,
-                metadata: metadata ? JSON.parse(metadata) : null,
+                tags: tags ? JSON.parse(tags) : null,
               });
               onOpenChange(false);
             } catch (error) {
@@ -102,9 +102,7 @@ const EditAssetDialog = ({
                 (error as HttpError)?.status === 422 &&
                 (error as HttpError)?.message?.includes("should be string")
               ) {
-                setMetadataError(
-                  "Metadata must only contain string key value pairs."
-                );
+                setTagsError("Tags must only contain string key value pairs.");
               }
             } finally {
               setEditing(false);
@@ -124,22 +122,22 @@ const EditAssetDialog = ({
           </Flex>
 
           <Flex css={{ mt: "$2" }} direction="column" gap="1">
-            <Label htmlFor="metadata">Metadata</Label>
+            <Label htmlFor="tags">Tags</Label>
             <TextArea
               size="2"
-              id="metadata"
-              value={metadata}
-              onChange={(e) => setMetadata(e.target.value)}
-              placeholder={JSON.stringify(demoIpfsContent, null, 4)}
+              id="tags"
+              value={tags}
+              onChange={(e) => setTags(e.target.value)}
+              placeholder={JSON.stringify(demoTags, null, 4)}
             />
           </Flex>
-          {(metadataError || !isMetadataValid) && (
+          {(tagsError || !areTagsValid) && (
             <AlertDialogDescription asChild>
               <Text
                 size="3"
                 variant="red"
                 css={{ mt: "$2", fontSize: "$2", mb: "$4" }}>
-                {metadataError || "Metadata must be valid JSON."}
+                {tagsError || "Tags must be valid JSON."}
               </Text>
             </AlertDialogDescription>
           )}
@@ -154,7 +152,7 @@ const EditAssetDialog = ({
               css={{ display: "flex", ai: "center" }}
               type="submit"
               size="2"
-              disabled={editing || !isMetadataValid || !name}
+              disabled={editing || !areTagsValid || !name}
               variant="primary">
               {editing && (
                 <Spinner

--- a/packages/www/layouts/assetDetail.tsx
+++ b/packages/www/layouts/assetDetail.tsx
@@ -11,6 +11,7 @@ import Spinner from "components/Dashboard/Spinner";
 import { useApi, useLoggedIn } from "hooks";
 import Layout, { Breadcrumb } from "layouts/dashboard";
 import { Asset } from "livepeer";
+import { Asset as ApiAsset } from "@livepeer.studio/api";
 import {
   Dispatch,
   SetStateAction,
@@ -52,12 +53,10 @@ const AssetDetail = ({
 
   const onEditAsset = useCallback(
     async (v: EditAssetReturnValue) => {
-      if (asset?.id && (v?.name || v?.metadata)) {
+      if (asset?.id && (v?.name || v?.tags)) {
         await patchAsset(asset.id, {
           ...(v?.name ? { name: v.name } : {}),
-          ...(v?.metadata
-            ? { meta: v.metadata as Record<string, string> }
-            : {}),
+          ...(v?.tags ? { tags: v.tags } : {}),
         });
         await refetchAsset();
       }
@@ -84,7 +83,7 @@ const AssetDetail = ({
         isOpen={editAssetDialogOpen}
         onOpenChange={setEditAssetDialogOpen}
         onEdit={onEditAsset}
-        asset={asset}
+        asset={asset as ApiAsset}
       />
 
       <EmbedVideoDialog

--- a/packages/www/layouts/assetDetail.tsx
+++ b/packages/www/layouts/assetDetail.tsx
@@ -52,12 +52,12 @@ const AssetDetail = ({
 
   const onEditAsset = useCallback(
     async (v: EditAssetReturnValue) => {
-      if (asset?.id && (v?.name || v?.metadata)) {
+      if (asset?.id && v?.name) {
         await patchAsset(asset.id, {
           ...(v?.name ? { name: v.name } : {}),
-          ...(v?.metadata
-            ? { meta: v.metadata as Record<string, string> }
-            : {}),
+          // ...(v?.metadata
+          //   ? { meta: v.metadata as Record<string, string> }
+          //   : {}),
         });
         await refetchAsset();
       }

--- a/packages/www/layouts/assetDetail.tsx
+++ b/packages/www/layouts/assetDetail.tsx
@@ -11,7 +11,6 @@ import Spinner from "components/Dashboard/Spinner";
 import { useApi, useLoggedIn } from "hooks";
 import Layout, { Breadcrumb } from "layouts/dashboard";
 import { Asset } from "livepeer";
-import { Asset as ApiAsset } from "@livepeer.studio/api";
 import {
   Dispatch,
   SetStateAction,
@@ -53,10 +52,12 @@ const AssetDetail = ({
 
   const onEditAsset = useCallback(
     async (v: EditAssetReturnValue) => {
-      if (asset?.id && (v?.name || v?.tags)) {
+      if (asset?.id && (v?.name || v?.metadata)) {
         await patchAsset(asset.id, {
           ...(v?.name ? { name: v.name } : {}),
-          ...(v?.tags ? { tags: v.tags } : {}),
+          ...(v?.metadata
+            ? { meta: v.metadata as Record<string, string> }
+            : {}),
         });
         await refetchAsset();
       }
@@ -83,7 +84,7 @@ const AssetDetail = ({
         isOpen={editAssetDialogOpen}
         onOpenChange={setEditAssetDialogOpen}
         onEdit={onEditAsset}
-        asset={asset as ApiAsset}
+        asset={asset}
       />
 
       <EmbedVideoDialog


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Update: we decided to delete the meta field altogether.

We have had plenty of confusion around this field already because of the unfortunate
name that makes it look like it means the NFT metadata exported to IPFS, when it is
just for adding user info to the API object on Studio for filtering etc.

Since we added a little more to that whole confusion now, with [a whole new field in the SDK](https://livepeerjs.org/react/asset/useUpdateAsset#return-value)
for setting the metadata, instead of the existing `storage.ipfs.nftMetadata`, I decided to
fix the part I'm responsible for and already had a quick fix in mind. Hence this PR.

Also made the changes in a partially backward compatible way, by not removing any 
existing `meta` field and copying them to the new `tags` field instead. So we will keep
compatibility on reads, but any write will need to use `tags` instead of `meta`. I opted for
this approach because we have less than 10 assets from real users that are actually using
this right now, and all of them look like just testing the feature (and most of them also
interpreting it wrong as NFT metadata, as we imply in the docs and dashboard):
![image](https://user-images.githubusercontent.com/1613383/197085644-0f5377aa-1ffe-481c-bbd9-9f058a788815.png)

Notice that deploying this also depends on:
 - [ ] Fix any documentation about the `meta` field
 - [ ] Update the SDK to use the new `tags` field instead of `meta` (or just remove it from there for now)

An alternative to this might actually be deleting this field altogether, either only from the dashboard 
(as the current UI was misguided by thinking the `meta` were NFT metadata) or both from the API
and dashboard, since not many users are depending on it anyway. We can discuss about it.

**Specific updates (required)**
 - Rename `meta` to `tags` in API 
 - Add compatibility logic to keep `meta` untouched and just copy it to the `tags` in asset objects returned by the API
 - Update dashboard asset detail view to refer only to tags, not metadata
 - Update asset edit dialog the same way, and fix the example

## -

- **How did you test each of these updates (required)**
 - Play around with tags on the dashboard 
 - Call an existing asset with `meta` and make sure `tags` also show up with the same value

**Does this pull request close any open issues?**
The `meta` confusion. Not the whole NFT metadata confusion anymore tho 🙃 

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
