### PR TITLE
api: Fix recording webhooks

### DIFF
--- a/packages/api/src/controllers/session.ts
+++ b/packages/api/src/controllers/session.ts
@@ -129,7 +129,7 @@ app.get("/", authorizer({}), async (req, res, next) => {
     res.links({ next: makeNextHREF(req, newCursor) });
   }
   let sessions = output.map((session) =>
-    toExternalSession(session, ingest, req.user.admin)
+    toExternalSession(session, ingest, !!forceUrl, req.user.admin)
   );
   res.json(sessions);
 });
@@ -238,16 +238,17 @@ app.get("/:id", authorizer({}), async (req, res) => {
   res.status(200);
   const ingests = await req.getIngest();
   const ingest = ingests && ingests.length ? ingests[0].base : "";
-  session = toExternalSession(session, ingest, req.user.admin);
+  session = toExternalSession(session, ingest, false, req.user.admin);
   res.json(session);
 });
 
 export function toExternalSession(
   obj: DBSession,
   ingest: string,
+  forceUrl = false,
   isAdmin = false
 ) {
-  obj = withRecordingFields(ingest, obj, isAdmin);
+  obj = withRecordingFields(ingest, obj, forceUrl);
   if (!isAdmin) {
     removePrivateFields(obj);
   }

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -984,7 +984,10 @@ async function sendSetActiveHooks(
             payload: {
               recordingUrl: getRecordingUrl(ingest, userSession),
               mp4Url: getRecordingUrl(ingest, userSession, true),
-              session: toExternalSession(userSession, ingest),
+              session: {
+                ...toExternalSession(userSession, ingest, true),
+                recordingStatus: "ready", // recording will be ready if this webhook is actually sent
+              },
             },
           },
           USER_SESSION_TIMEOUT + HTTP_PUSH_TIMEOUT

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -967,10 +967,8 @@ async function sendSetActiveHooks(
         // last session is too old, probably transcoding wasn't happening, and so there
         // will be no recording
       } else {
-        let userSession = session;
-        if (session.previousSessions?.length) {
-          userSession = await db.stream.get(session.previousSessions[0]);
-        }
+        const userSessionId = session.previousSessions?.[0] ?? session.id;
+        const userSession = await db.session.get(userSessionId);
         await queue.delayedPublishWebhook(
           "events.recording.ready",
           {

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -207,7 +207,6 @@ components:
               - stream.idle
               - recording.ready
               - recording.started
-              - recording.waiting
               - multistream.connected
               - multistream.error
               - multistream.disconnected

--- a/packages/www/components/Dashboard/WebhookDialog/index.tsx
+++ b/packages/www/components/Dashboard/WebhookDialog/index.tsx
@@ -50,7 +50,6 @@ const eventOptions: Webhook["events"] = [
   "stream.idle",
   "recording.ready",
   "recording.started",
-  "recording.waiting",
   "multistream.connected",
   "multistream.error",
   "multistream.disconnected",


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
As an exercise of understanding the current recording pipeline as we'll need
to revamp it soon for the catalyst integreation (and since a key customer was
suffering with that), I found some easy improvements we could make to the 
recording webhooks in order to make them more useful.

The main changes revolve towards sending the session object with the recording
both on the `started` and `ready` webhooks. For that, it also required changing the
point in the code where we send the `recording.started` (but the `ready` had to stay
where it was).

**Specific updates (required)**
 - Move the `recording.ready` hook from `/setactive` to `POST /stream/:id` (`MistProcLivepeer`), where we create the user session object
 - Add `session` object to the webhook payload both `started` and `ready`
 - Make sure that session object is the user session, not the final "child stream" from MistProcLivepeer. Relevant only for the `recording.ready` hook.

## -

- **How did you test each of these updates (required)**
 - Deploy to staging
 - Make a recorded livestream
 - Check webhooks are received with the session in payload

**Does this pull request close any open issues?**
Fixes customer issue.

**Screenshots (optional):**
https://webhook.site/#!/d5fd9d61-383c-4891-8d10-0e29886fef50/c587140c-a5ae-4b22-a576-7d35f0553ff8/1

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
