### PR TITLE
api: Add source field to assets

### DIFF
--- a/packages/api/src/controllers/access-control.test.ts
+++ b/packages/api/src/controllers/access-control.test.ts
@@ -74,6 +74,7 @@ describe("controllers/signing-key", () => {
       gatedAsset = await db.asset.create({
         id,
         name: "test-storage",
+        source: { type: "directUpload" },
         createdAt: Date.now(),
         playbackId: await generateUniquePlaybackId(id),
         playbackPolicy: {

--- a/packages/api/src/controllers/asset.test.ts
+++ b/packages/api/src/controllers/asset.test.ts
@@ -111,6 +111,7 @@ describe("controllers/asset", () => {
       asset = await db.asset.create({
         id: uuid(),
         name: "test-storage",
+        source: { type: "directUpload" },
         createdAt: Date.now(),
         status: {
           phase: "ready",
@@ -415,6 +416,7 @@ describe("controllers/asset", () => {
       await db.asset.create({
         id: uuid(),
         name: "dummy",
+        source: { type: "directUpload" },
         createdAt: Date.now(),
         status: {
           phase: "ready",
@@ -428,6 +430,7 @@ describe("controllers/asset", () => {
         name: "test-storage",
         createdAt: Date.now(),
         playbackId: await generateUniquePlaybackId(id),
+        source: { type: "directUpload" },
         storage: {
           ipfs: {
             spec: {},

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -99,7 +99,8 @@ async function validateAssetPayload(
   userId: string,
   createdAt: number,
   defaultObjectStoreId: string,
-  payload: NewAssetPayload
+  payload: NewAssetPayload,
+  source?: Asset["source"]
 ): Promise<WithID<Asset>> {
   if (payload.objectStoreId) {
     if (payload.objectStoreId !== defaultObjectStoreId) {
@@ -126,6 +127,11 @@ async function validateAssetPayload(
       updatedAt: createdAt,
     },
     name: payload.name,
+    source:
+      source ??
+      (payload.url
+        ? { type: "url", url: payload.url }
+        : { type: "directUpload" }),
     playbackPolicy: payload.playbackPolicy,
     meta: validateAssetMeta(payload.meta),
     objectStoreId: payload.objectStoreId || defaultObjectStoreId,
@@ -555,7 +561,8 @@ const transcodeAssetHandler: RequestHandler = async (req, res) => {
     req.config.vodObjectStoreId,
     {
       name: req.body.name ?? inputAsset.name,
-    }
+    },
+    { type: "transcode", inputAssetId: inputAsset.id }
   );
   outputAsset.sourceAssetId = inputAsset.sourceAssetId ?? inputAsset.id;
   outputAsset = await createAsset(outputAsset, req.queue);

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1036,7 +1036,7 @@ components:
               properties:
                 type:
                   type: string
-                  const: url
+                  enum: [url]
                 url:
                   type: string
                   description: URL from which the asset was uploaded
@@ -1045,13 +1045,13 @@ components:
               properties:
                 type:
                   type: string
-                  const: directUpload
+                  enum: [directUpload]
             - additionalProperties: false
               required: [type, sessionId]
               properties:
                 type:
                   type: string
-                  const: recording
+                  enum: [recording]
                 sessionId:
                   type: string
                   description:
@@ -1061,7 +1061,7 @@ components:
               properties:
                 type:
                   type: string
-                  const: transcode
+                  enum: [transcode]
                 inputAssetId:
                   type: string
                   description:

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -976,7 +976,9 @@ components:
       table: asset
       additionalProperties: false
       required:
+        - id
         - name
+        - source
       properties:
         id:
           type: string
@@ -1027,6 +1029,44 @@ components:
           description: Object store ID where the asset is stored
           writeOnly: true
           example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
+        source:
+          oneOf:
+            - additionalProperties: false
+              required: [type, url]
+              properties:
+                type:
+                  type: string
+                  const: url
+                url:
+                  type: string
+                  description: URL from which the asset was uploaded
+            - additionalProperties: false
+              required: [type]
+              properties:
+                type:
+                  type: string
+                  const: directUpload
+            - additionalProperties: false
+              required: [type, sessionId]
+              properties:
+                type:
+                  type: string
+                  const: recording
+                sessionId:
+                  type: string
+                  description:
+                    ID of the session from which this asset was created
+            - additionalProperties: false
+              required: [type, inputAssetId]
+              properties:
+                type:
+                  type: string
+                  const: transcode
+                inputAssetId:
+                  type: string
+                  description:
+                    ID of the source asset that was processed by a transcode
+                    task to create this asset
         storage:
           additionalProperties: false
           properties:

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -517,6 +517,7 @@ export default class WebhookCannon {
         playbackId,
         userId,
         createdAt,
+        source: { type: "recording", sessionId },
         status: { phase: "waiting", updatedAt: createdAt },
         name: `live-to-vod-${sessionId}`,
         objectStoreId: this.vodObjectStoreId,


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This is to create a new useful metadata in asset objects which is some object representing
where they come from / how they were created.

The idea for this is to solve an immediate user need for relating their VOD assets with the livestream
sessions of their users. We previously had no official way for that, and had workarounds in our 
dashboard that (I didn't even remember but also) we should not have our users depend on 
(regex on playback url of the asset).

It also opens room for an API proposed by @yondonfu for supporting automatic import + playback by CID
directly from IPFS (with no need to manually re-store the asset on IPFS).

**Specific updates (required)**
 - Create `source` field on the asset which could have several types and args
 - Set the `source` field on every asset creation today.

## -

- **How did you test each of these updates (required)**
Create an asset in the various different ways and make sure source field is set appropriately.

**Does this pull request close any open issues?**
No. Customer support.

**Checklist:**

- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
