### PR TITLE
Fetch playback URL for imported asset using source ID

### DIFF
--- a/packages/api/src/controllers/access-control.test.ts
+++ b/packages/api/src/controllers/access-control.test.ts
@@ -73,6 +73,9 @@ describe("controllers/signing-key", () => {
       let id = uuid();
       gatedAsset = await db.asset.create({
         id,
+        source: {
+          type: "directUpload",
+        },
         name: "test-storage",
         createdAt: Date.now(),
         playbackId: await generateUniquePlaybackId(id),

--- a/packages/api/src/controllers/asset.test.ts
+++ b/packages/api/src/controllers/asset.test.ts
@@ -110,6 +110,9 @@ describe("controllers/asset", () => {
     beforeEach(async () => {
       asset = await db.asset.create({
         id: uuid(),
+        source: {
+          type: "directUpload",
+        },
         name: "test-storage",
         createdAt: Date.now(),
         status: {
@@ -414,6 +417,9 @@ describe("controllers/asset", () => {
     beforeEach(async () => {
       await db.asset.create({
         id: uuid(),
+        source: {
+          type: "directUpload",
+        },
         name: "dummy",
         createdAt: Date.now(),
         status: {
@@ -425,6 +431,9 @@ describe("controllers/asset", () => {
       const id = uuid();
       asset = await db.asset.create({
         id,
+        source: {
+          type: "directUpload",
+        },
         name: "test-storage",
         createdAt: Date.now(),
         playbackId: await generateUniquePlaybackId(id),

--- a/packages/api/src/controllers/asset.test.ts
+++ b/packages/api/src/controllers/asset.test.ts
@@ -409,6 +409,48 @@ describe("controllers/asset", () => {
         expect.not.stringMatching(firstTaskId);
       await testStoragePatch(patch, expectedStorage);
     });
+
+    it("should set source field with IPFS information if specified", async () => {
+      const source = {
+        url: "https://zora-dev.mypinata.cloud/ipfs/bafybeic7eaf4k34jp7onsrumd2y7z5qjxisu6ya3eziyvcgbspnp4esimm",
+        type: "url",
+        id: "bafybeic7eaf4k34jp7onsrumd2y7z5qjxisu6ya3eziyvcgbspnp4esimm",
+      };
+      let res = await client.post("/asset/import", {
+        name: "import-test",
+        source,
+      });
+      expect(res.status).toBe(201);
+
+      const { asset } = await res.json();
+
+      res = await client.get(`/asset/${asset.id}`);
+      expect(res.status).toBe(200);
+
+      const { source: sourceObj } = await res.json();
+      expect(sourceObj).toMatchObject(source);
+    });
+
+    it("should set source field with Arweave information if specified", async () => {
+      const source = {
+        url: "https://l34wjojevqdgngyhzs7hje7bth37wawkgdqwgt3ihi3qzsy64gta.arweave.net/UyvmvEslVytmcH1-NH8rPm2FRBss5U3esVolWMVD72I",
+        type: "url",
+        id: "UyvmvEslVytmcH1-NH8rPm2FRBss5U3esVolWMVD72I",
+      };
+      let res = await client.post("/asset/import", {
+        name: "import-test",
+        source,
+      });
+      expect(res.status).toBe(201);
+
+      const { asset } = await res.json();
+
+      res = await client.get(`/asset/${asset.id}`);
+      expect(res.status).toBe(200);
+
+      const { source: sourceObj } = await res.json();
+      expect(sourceObj).toMatchObject(source);
+    });
   });
 
   describe("asset list", () => {

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -485,11 +485,17 @@ const uploadWithUrlHandler: RequestHandler = async (req, res) => {
     req.user.id,
     Date.now(),
     req.config.vodObjectStoreId,
-    req.body
+    req.body,
+    req.body.source
   );
-  if (!req.body.url) {
+
+  const url =
+    req.body.url ?? (req.body.source ? req.body.source.url : undefined);
+  if (!url) {
     return res.status(422).json({
-      errors: [`Must provide a "url" field for the asset contents`],
+      errors: [
+        `Must provide a "url" or "source.url" field for the asset contents`,
+      ],
     });
   }
 
@@ -499,7 +505,7 @@ const uploadWithUrlHandler: RequestHandler = async (req, res) => {
     taskType,
     {
       [taskType]: {
-        url: req.body.url,
+        url,
       },
     },
     undefined,

--- a/packages/api/src/controllers/playback.ts
+++ b/packages/api/src/controllers/playback.ts
@@ -48,7 +48,8 @@ const getAssetPlaybackUrl = async (
 ) => {
   const asset = cid
     ? await db.asset.getByIpfsCid(id)
-    : await db.asset.getByPlaybackId(id);
+    : (await db.asset.getByPlaybackId(id)) ??
+      (await db.asset.getBySourceId(id));
   if (!asset || asset.deleted) {
     return null;
   }

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1031,15 +1031,7 @@ components:
           example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
         source:
           oneOf:
-            - additionalProperties: false
-              required: [type, url]
-              properties:
-                type:
-                  type: string
-                  enum: [url]
-                url:
-                  type: string
-                  description: URL from which the asset was uploaded
+            - $ref: "#/components/schemas/remote-source-payload"
             - additionalProperties: false
               required: [type]
               properties:
@@ -1326,6 +1318,21 @@ components:
           type: string
           description: Name of the signing key
 
+    remote-source-payload:
+      required: [type, url]
+      properties:
+        type:
+          type: string
+          enum: [url]
+        url:
+          type: string
+          description: URL from which the asset was uploaded
+        id:
+          type: string
+          description:
+            ID for the asset in the context of where it was uploaded from
+          example: bafybeic7eaf4k34jp7onsrumd2y7z5qjxisu6ya3eziyvcgbspnp4esimm
+
     new-asset-payload:
       additionalProperties: false
       required:
@@ -1363,6 +1370,8 @@ components:
             URL where the asset contents can be retrieved. Only valid for the
             import task endpoint.
           example: https://s3.amazonaws.com/my-bucket/path/filename.mp4
+        source:
+          $ref: "#/components/schemas/remote-source-payload"
 
     transcode-asset-payload:
       additionalProperties: false

--- a/packages/api/src/store/asset-table.ts
+++ b/packages/api/src/store/asset-table.ts
@@ -53,4 +53,19 @@ export default class AssetTable extends Table<WithID<Asset>> {
     }
     return assets[0];
   }
+
+  async getBySourceId(id: string): Promise<WithID<Asset>> {
+    const query = [
+      sql`asset.data->'source'->>'id' = ${id}`,
+      sql`asset.data->>'deleted' IS NULL`,
+    ];
+    const [assets] = await this.find(query, {
+      limit: 2,
+      order: "coalesce((asset.data->'createdAt')::bigint, 0) ASC",
+    });
+    if (!assets || assets.length < 1) {
+      return null;
+    }
+    return assets[0];
+  }
 }

--- a/packages/api/src/store/table.ts
+++ b/packages/api/src/store/table.ts
@@ -342,6 +342,13 @@ export default class Table<T extends DBObject> {
       // avoid creating indexes in production right now...
       return;
     }
+    if (prop.oneOf?.length) {
+      return Promise.all(
+        prop.oneOf.map((oneSchema) =>
+          this.ensureIndex(propName, oneSchema, parents)
+        )
+      );
+    }
 
     if (!prop.index && !prop.unique) {
       if (prop.properties && this.name === "asset") {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

<!-- A clear and concise description of what this pull request does. -->

Supersedes https://github.com/livepeer/studio/pull/1364 in favor of building off of https://github.com/livepeer/studio/pull/1365 which introduces a `source` field to the `Asset` entity.

This PR allows a user to specify a `source` field in the request body for a `/api/asset/import` request that looks like:

```
{
    "url": ...,
    "type": ...,
    "id": ...
}
```

For now, `type` must be `url`.

The user is responsible for specifying a value for the `id` field. For example, the value could be an IPFS CID or Arweave tx ID.

The `/playback` endpoint can then do a lookup for assets based on `source.id` which is useful when the asset is imported from an IPFS gateway and you want to plug in a CID to playback the asset. Or when the asset is imported from an Arweave gateway and you want to plug in a tx ID to playback the asset.

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

See commit history.

- **How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Updated unit tests.

**Does this pull request close any open issues?**

<!-- Fixes # -->

Fixes https://github.com/livepeer/studio/issues/1362.

TODO: Test in an e2e environment and make sure /playback returns the correct playback URL for a source ID.

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
