### PR TITLE
access-control: signing key privateKey as b64 encoded pem

### DIFF
--- a/packages/api/src/controllers/signing-key.test.ts
+++ b/packages/api/src/controllers/signing-key.test.ts
@@ -56,7 +56,8 @@ describe("controllers/signing-key", () => {
       let created: SigningKeyResponsePayload = await client
         .post("/access-control/signing-key")
         .then((res) => res.json());
-      samplePrivateKey = created.privateKey;
+      let encodedPrivateKey = created.privateKey;
+      samplePrivateKey = Buffer.from(encodedPrivateKey, "base64").toString();
       let res = await client.get(`/access-control/signing-key/${created.id}`);
       signingKey = await res.json();
       // decoded public key is decoded b64 of signingKey.publicKey parsed as json

--- a/packages/api/src/controllers/signing-key.ts
+++ b/packages/api/src/controllers/signing-key.ts
@@ -179,6 +179,7 @@ signingKeyApp.post(
     const keypair = await generateSigningKeys();
 
     let b64PublicKey = Buffer.from(keypair.publicKey).toString("base64");
+    let b64PrivateKey = Buffer.from(keypair.privateKey).toString("base64");
 
     var doc: WithID<SigningKey> = {
       id,
@@ -192,7 +193,7 @@ signingKeyApp.post(
 
     var createdSigningKey: SigningKeyResponsePayload = {
       ...doc,
-      privateKey: keypair.privateKey.toString(),
+      privateKey: b64PrivateKey,
     };
 
     res.status(201);


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

The private key of a signing key is now returned as a b64 encoded PEM

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->



**How did you test each of these updates (required)**

yarn test

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional):**

<!-- Drag some screenshots here, if applicable -->

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
