### PR TITLE
Replace the react-tooltip component with the Tooltip component from @…

### DIFF
--- a/packages/www/components/Admin/CommonAdminTable/index.tsx
+++ b/packages/www/components/Admin/CommonAdminTable/index.tsx
@@ -13,7 +13,7 @@ import {
   useRowSelect,
 } from "react-table";
 import Help from "../../../public/img/help.svg";
-import ReactTooltip from "react-tooltip";
+import { Tooltip } from "@livepeer/design-system";
 import { User, Stream } from "@livepeer.studio/api";
 
 const loadingAnim = keyframes`
@@ -47,14 +47,14 @@ export const StreamName = ({
   return (
     <Box>
       {stream.createdByTokenName ? (
-        <ReactTooltip
+        <Tooltip
           id={pid}
           className="tooltip"
           place="top"
           type="dark"
           effect="solid">
           Created by token <b>{stream.createdByTokenName}</b>
-        </ReactTooltip>
+        </Tooltip>
       ) : null}
       <Box data-tip data-for={pid}>
         <Link
@@ -92,14 +92,14 @@ export const RelativeTime = ({
     <Box id={idpref} key={idpref}>
       {tm ? (
         <>
-          <ReactTooltip
+          <Tooltip
             id={`tooltip-${idpref}`}
             className="tooltip"
             place="top"
             type="dark"
             effect="solid">
             {toolTip}
-          </ReactTooltip>
+          </Tooltip>
           <span data-tip data-for={`tooltip-${idpref}`}>
             {main}
           </span>
@@ -119,7 +119,7 @@ export const UserName = ({ user }: { user: User }) => {
         overflow: "hidden",
         textOverflow: "ellipsis",
       }}>
-      <ReactTooltip
+      <Tooltip
         id={tid}
         className="tooltip"
         place="top"
@@ -128,7 +128,7 @@ export const UserName = ({ user }: { user: User }) => {
         <span>{user.id}</span>
         <span>{user.firstName}</span>
         <span>{user.lastName}</span>
-      </ReactTooltip>
+      </Tooltip>
       <span data-tip data-for={tid}>
         {user.email.includes("@")
           ? user.email.split("@").join("@\u{200B}")
@@ -453,7 +453,7 @@ const CommonAdminTable = ({
                         <Flex
                           sx={{ alignItems: "center", ml: "auto", mr: "1em" }}>
                           <Flex>
-                            <ReactTooltip
+                            <Tooltip
                               id={`tooltip-multiorder`}
                               className="tooltip"
                               place="top"
@@ -461,7 +461,7 @@ const CommonAdminTable = ({
                               effect="solid">
                               To multi-sort (sort by two column simultaneously)
                               hold shift while clicking on second column name.
-                            </ReactTooltip>
+                            </Tooltip>
                             <Help
                               data-tip
                               data-for={`tooltip-multiorder`}

--- a/packages/www/components/Admin/StreamsTable/index.tsx
+++ b/packages/www/components/Admin/StreamsTable/index.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { jsx } from "theme-ui";
 import Link from "next/link";
-import ReactTooltip from "react-tooltip";
+import { Tooltip } from "@livepeer/design-system";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useApi, usePageVisibility } from "hooks";
 import { Box, Button, Flex, Container, Link as A } from "@theme-ui/components";
@@ -95,14 +95,14 @@ export const RenditionsDetails = ({ stream }: { stream: Stream }) => {
       {detailsTooltip ? (
         <Flex sx={{ alignItems: "center" }}>
           <Flex>
-            <ReactTooltip
+            <Tooltip
               id={`tooltip-details-${stream.id}`}
               className="tooltip"
               place="top"
               type="dark"
               effect="solid">
               {detailsTooltip}
-            </ReactTooltip>
+            </Tooltip>
             <Help
               data-tip
               data-for={`tooltip-details-${stream.id}`}

--- a/packages/www/components/Admin/Table-v2/cells/streams-table.tsx
+++ b/packages/www/components/Admin/Table-v2/cells/streams-table.tsx
@@ -3,7 +3,7 @@ import { jsx } from "theme-ui";
 import { Stream } from "@livepeer.studio/api";
 import { Box } from "@theme-ui/components";
 import { Flex } from "@theme-ui/components";
-import ReactTooltip from "react-tooltip";
+import { Tooltip } from "@livepeer/design-system";
 import { CellComponentProps, TableData } from "../types";
 import Help from "../../../../public/img/help.svg";
 
@@ -91,14 +91,14 @@ const RenditionsDetailsCell = <D extends TableData>({
       {detailsTooltip ? (
         <Flex sx={{ alignItems: "center" }}>
           <Flex>
-            <ReactTooltip
+            <Tooltip
               id={`tooltip-details-${stream.id}`}
               className="tooltip"
               place="top"
               type="dark"
               effect="solid">
               {detailsTooltip}
-            </ReactTooltip>
+            </Tooltip>
             <Help
               data-tip
               data-for={`tooltip-details-${stream.id}`}

--- a/packages/www/components/Admin/Table-v2/cells/text.tsx
+++ b/packages/www/components/Admin/Table-v2/cells/text.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { jsx } from "theme-ui";
 import Link from "next/link";
-import ReactTooltip from "react-tooltip";
+import { Tooltip } from "@livepeer/design-system";
 import { CellComponentProps, TableData } from "../types";
 
 export type TextCellProps = {
@@ -18,14 +18,14 @@ const TextCell = <D extends TableData>({
   return (
     <div>
       {cell.value.tooltipChildren ? (
-        <ReactTooltip
+        <Tooltip
           id={pid}
           className="tooltip"
           place="top"
           type="dark"
           effect="solid">
           {cell.value.tooltipChildren}
-        </ReactTooltip>
+        </Tooltip>
       ) : null}
       <div data-tip data-for={pid}>
         {cell.value.href ? (

--- a/packages/www/components/Admin/Table-v2/index.tsx
+++ b/packages/www/components/Admin/Table-v2/index.tsx
@@ -11,7 +11,7 @@ import {
 } from "react-table";
 import { useEffect, useMemo, useCallback } from "react";
 import Paginator from "./paginator";
-import ReactTooltip from "react-tooltip";
+import { Tooltip } from "@livepeer/design-system";
 import Help from "../../../public/img/help.svg";
 import Checkbox from "@components/Admin/Checkbox";
 import {
@@ -294,7 +294,7 @@ const Table = <T extends Record<string, unknown>>({
                               top: "50%",
                               transform: "translateY(-50%)",
                             }}>
-                            <ReactTooltip
+                            <Tooltip
                               id={`tooltip-multiorder`}
                               className="tooltip"
                               place="top"
@@ -302,7 +302,7 @@ const Table = <T extends Record<string, unknown>>({
                               effect="solid">
                               To multi-sort (sort by two column simultaneously)
                               hold shift while clicking on second column name.
-                            </ReactTooltip>
+                            </Tooltip>
                             <Help
                               data-tip
                               data-for={`tooltip-multiorder`}

--- a/packages/www/components/Dashboard/RelativeTime/index.tsx
+++ b/packages/www/components/Dashboard/RelativeTime/index.tsx
@@ -1,6 +1,6 @@
 import moment from "moment";
 import { Box } from "@theme-ui/components";
-import ReactTooltip from "react-tooltip";
+import { Tooltip } from "@livepeer/design-system";
 
 type RelativeTimeProps = {
   id: string;
@@ -22,14 +22,14 @@ const RelativeTime = ({ id, prefix, tm, swap = false }: RelativeTimeProps) => {
     <Box id={idpref} key={idpref}>
       {tm ? (
         <>
-          <ReactTooltip
+          <Tooltip
             id={`tooltip-${idpref}`}
             className="tooltip"
             place="top"
             type="dark"
             effect="solid">
             {toolTip}
-          </ReactTooltip>
+          </Tooltip>
           <Box as="span" data-tip data-for={`tooltip-${idpref}`}>
             {main}
           </Box>

--- a/packages/www/components/Dashboard/StreamsTable/index.tsx
+++ b/packages/www/components/Dashboard/StreamsTable/index.tsx
@@ -14,7 +14,7 @@ import {
   Link as A,
   useSnackbar,
 } from "@livepeer/design-system";
-import ReactTooltip from "react-tooltip";
+import { Tooltip } from "@livepeer/design-system";
 import { useCallback, useMemo, useState } from "react";
 import { useApi } from "hooks";
 import Table, { useTableState, Fetcher } from "components/Dashboard/Table";
@@ -131,14 +131,14 @@ export const RenditionsDetails = ({ stream }: { stream: Stream }) => {
       {detailsTooltip ? (
         <Flex css={{ alignItems: "center" }}>
           <Flex>
-            <ReactTooltip
+            <Tooltip
               id={`tooltip-details-${stream.id}`}
               className="tooltip"
               place="top"
               type="dark"
               effect="solid">
               {detailsTooltip}
-            </ReactTooltip>
+            </Tooltip>
             <StyledQuestionMarkIcon
               data-tip
               data-for={`tooltip-details-${stream.id}`}

--- a/packages/www/components/Dashboard/Table/cells/action.tsx
+++ b/packages/www/components/Dashboard/Table/cells/action.tsx
@@ -2,7 +2,7 @@ import { CellComponentProps, TableData } from "../types";
 import { Box, Button } from "@livepeer/design-system";
 import Spinner from "components/Dashboard/Spinner";
 import { TrashIcon } from "@radix-ui/react-icons";
-import ReactTooltip from "react-tooltip";
+import { Tooltip } from "@livepeer/design-system";
 import { useState } from "react";
 
 const DeleteActionCell = ({
@@ -17,7 +17,7 @@ const DeleteActionCell = ({
 
   return (
     <>
-      <ReactTooltip
+      <Tooltip
         id={tooltipId}
         className="tooltip"
         place="top"
@@ -25,7 +25,7 @@ const DeleteActionCell = ({
         effect="solid"
         delayShow={500}>
         Delete
-      </ReactTooltip>
+      </Tooltip>
 
       <Box css={{ textAlign: "right" }}>
         <Button

--- a/packages/www/components/Dashboard/Table/cells/createdAt.tsx
+++ b/packages/www/components/Dashboard/Table/cells/createdAt.tsx
@@ -5,7 +5,7 @@ import { UploadIcon } from "@radix-ui/react-icons";
 import { format } from "date-fns";
 import { useApi } from "hooks";
 import { useEffect, useState } from "react";
-import ReactTooltip from "react-tooltip";
+import { Tooltip } from "@livepeer/design-system";
 import { CellComponentProps, TableData } from "../types";
 
 const CreatedAt = ({ date, fallback }) => {
@@ -21,7 +21,7 @@ const FailedProcessing = ({ id, errorMessage }) => {
   return (
     <>
       {errorMessage !== undefined && (
-        <ReactTooltip
+        <Tooltip
           id={tooltipId}
           className="tooltip"
           place="top"
@@ -29,7 +29,7 @@ const FailedProcessing = ({ id, errorMessage }) => {
           effect="solid"
           delayShow={500}>
           {errorMessage}
-        </ReactTooltip>
+        </Tooltip>
       )}
       <Badge
         data-tip

--- a/packages/www/components/Dashboard/Table/cells/name.tsx
+++ b/packages/www/components/Dashboard/Table/cells/name.tsx
@@ -1,7 +1,7 @@
 import { CellComponentProps, TableData } from "../types";
 import { Box } from "@livepeer/design-system";
 import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
-import ReactTooltip from "react-tooltip";
+import { Tooltip } from "@livepeer/design-system";
 
 export type NameCellProps = {
   id?: string;
@@ -25,7 +25,7 @@ const NameCell = <D extends TableData>({
     const tooltipId = "tooltip-error-" + id;
     return (
       <>
-        <ReactTooltip
+        <Tooltip
           id={tooltipId}
           className="tooltip"
           place="top"
@@ -33,7 +33,7 @@ const NameCell = <D extends TableData>({
           effect="solid"
           delayShow={500}>
           {errorMessage}
-        </ReactTooltip>
+        </Tooltip>
         <Box
           data-tip
           data-for={tooltipId}

--- a/packages/www/components/Dashboard/Table/cells/streams-table.tsx
+++ b/packages/www/components/Dashboard/Table/cells/streams-table.tsx
@@ -1,6 +1,6 @@
 import { Stream } from "@livepeer.studio/api";
 import { Box, Flex, styled } from "@livepeer/design-system";
-import ReactTooltip from "react-tooltip";
+import { Tooltip } from "@livepeer/design-system";
 import { CellComponentProps, TableData } from "../types";
 import { QuestionMarkIcon } from "@radix-ui/react-icons";
 
@@ -93,7 +93,7 @@ const RenditionsDetailsCell = <D extends TableData>({
       {detailsTooltip ? (
         <Flex css={{ alignItems: "center" }}>
           <Flex>
-            <ReactTooltip
+            <Tooltip
               id={`tooltip-details-${stream.id}`}
               className="tooltip"
               place="top"
@@ -101,7 +101,7 @@ const RenditionsDetailsCell = <D extends TableData>({
               effect="solid"
               delayShow={500}>
               {detailsTooltip}
-            </ReactTooltip>
+            </Tooltip>
             <StyledQuestionMarkIcon
               data-tip
               data-for={`tooltip-details-${stream.id}`}

--- a/packages/www/components/Dashboard/Table/cells/text.tsx
+++ b/packages/www/components/Dashboard/Table/cells/text.tsx
@@ -1,4 +1,4 @@
-import ReactTooltip from "react-tooltip";
+import { Tooltip } from "@livepeer/design-system";
 import { CellComponentProps, TableData } from "../types";
 import { Box } from "@livepeer/design-system";
 
@@ -17,7 +17,7 @@ const TextCell = <D extends TableData>({
   return (
     <Box css={{ lineHeight: 1.5 }}>
       {cell.value.tooltipChildren ? (
-        <ReactTooltip
+        <Tooltip
           id={pid}
           className="tooltip"
           place="top"
@@ -25,7 +25,7 @@ const TextCell = <D extends TableData>({
           effect="solid"
           delayShow={500}>
           {cell.value.tooltipChildren}
-        </ReactTooltip>
+        </Tooltip>
       ) : null}
       <Box data-tip data-for={pid}>
         {cell.value.children}

--- a/packages/www/pages/app/stream/[id].tsx
+++ b/packages/www/pages/app/stream/[id].tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import Link from "next/link";
-import ReactTooltip from "react-tooltip";
+import { Tooltip } from "@livepeer/design-system";
 import {
   Spinner,
   Box,
@@ -690,7 +690,7 @@ const ID = () => {
                         />
                       </Flex>
                     </Flex>
-                    <ReactTooltip
+                    <Tooltip
                       id={`tooltip-record-${stream.id}`}
                       className="tooltip"
                       place="top"
@@ -704,7 +704,7 @@ const ID = () => {
                         <br />
                         This feature is currently free.
                       </p>
-                    </ReactTooltip>
+                    </Tooltip>
                   </Box>
                   <Box sx={{ m: "0.4em", gridColumn: "1/-1" }}>
                     <hr />
@@ -769,7 +769,7 @@ const ID = () => {
                         />
                       </Flex>
                     </Flex>
-                    <ReactTooltip
+                    <Tooltip
                       id={`tooltip-suspend-${stream.id}`}
                       className="tooltip"
                       place="top"
@@ -782,7 +782,7 @@ const ID = () => {
                         New sessions will be prevented from starting until
                         turned off.
                       </p>
-                    </ReactTooltip>
+                    </Tooltip>
                   </Box>
                   <Box sx={{ m: "0.4em", gridColumn: "1/-1" }}>
                     <hr />


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This pull request replaces the react-tooltip component with the Tooltip component from @livepeer/design-system

**Specific updates (required)**

With the update, we will be using the tooltip component from the Livepeer Design System.

Usage example:

```
import { Tooltip } from '@livepeer/design-system'

<Tooltip multiline content="This tooltip has content which is multiple lines and goes for a longer span of space">
  <Button>This has a tooltip</Button>
</Tooltip>
```
              

## -

How did you test each of these updates (required)

yarn test


**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
