### PR TITLE
Improved the Create Asset Dialog to show the supported file types

### DIFF
--- a/packages/www/components/Dashboard/AssetsTable/CreateAssetDialog.tsx
+++ b/packages/www/components/Dashboard/AssetsTable/CreateAssetDialog.tsx
@@ -152,25 +152,27 @@ const CreateAssetDialog = ({
                 </Text>
               </Box>
             </Box>
-            {videoFiles &&
-              Object.keys(videoFiles).map((key) => (
-                <Flex key={key} align="center">
-                  <IconButton
-                    onClick={() => setVideoFiles((prev) => omit(prev, key))}
-                    css={{ color: "$whiteA12", mr: "$1", cursor: "pointer" }}>
-                    <Cross2Icon />
-                  </IconButton>
 
-                  <Text
-                    as="p"
-                    css={{
-                      my: "$1",
-                      fontSize: "$1",
-                    }}>
-                    {key}
-                  </Text>
-                </Flex>
-              ))}
+            <Box css={{ mt: "$1" }}>
+              {videoFiles &&
+                Object.keys(videoFiles).map((key) => (
+                  <Flex key={key} align="center">
+                    <IconButton
+                      onClick={() => setVideoFiles((prev) => omit(prev, key))}
+                      css={{ mr: "$1", cursor: "pointer" }}>
+                      <Cross2Icon />
+                    </IconButton>
+                    <Text
+                      as="p"
+                      css={{
+                        my: "$1",
+                        fontSize: "$1",
+                      }}>
+                      {key}
+                    </Text>
+                  </Flex>
+                ))}
+            </Box>
 
             {error && (
               <Box>
@@ -184,6 +186,8 @@ const CreateAssetDialog = ({
               variant="gray"
               css={{ mt: "$1", fontSize: "$2", mb: "$4" }}>
               Select up to 20 files at a time
+              <br />
+              .mp4 files supported
             </Text>
           </AlertDialogDescription>
           <Flex css={{ jc: "flex-end", gap: "$3", mt: "$4" }}>


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Improved the Create Asset Dialog to show the supported file types

**Specific updates (required)**
- Listing the supported files types
- Changed the color of the delete pending-for-upload icon

**Does this pull request close any open issues?**
Fixes #1384 

**Screenshots (optional):**
<img width="419" alt="Screenshot 2022-11-03 at 15 32 36" src="https://user-images.githubusercontent.com/161903/199764756-dd1f5fcc-6605-4472-b9bf-3734131c7bb4.png">
<img width="424" alt="Screenshot 2022-11-03 at 15 32 45" src="https://user-images.githubusercontent.com/161903/199764759-f6192e42-ae50-4241-8d21-c91ce8144248.png">

