### PR TITLE
Removed the footer from the Admin layout to improve UX

### DIFF
--- a/packages/www/layouts/admin.tsx
+++ b/packages/www/layouts/admin.tsx
@@ -3,7 +3,6 @@ import { jsx } from "theme-ui";
 import { NextSeo } from "next-seo";
 import { withEmailVerifyMode } from "./withEmailVerifyMode";
 import { DefaultNav } from "@components/Site/Navigation";
-import Footer from "@components/Site/Footer";
 import { Flex, Box } from "@theme-ui/components";
 import { useEffect } from "react";
 import ReactGA from "react-ga";
@@ -128,7 +127,6 @@ const Layout = ({
               )}
               <Box css={{ position: "relative" }}>{children}</Box>
             </Flex>
-            <Footer />
           </Flex>
         </Box>
       </ThemeProvider>


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Removed the footer from the Admin layout to improve UX.
It was big and moving while the page loaded, being very intrusive. It requested visual attention. Just removing it makes a better UX.

**Screenshots (optional):**

**Before**
<img width="1512" alt="Screenshot 2022-11-03 at 15 52 54" src="https://user-images.githubusercontent.com/161903/199770384-df252709-d8ad-4f14-90d2-ef7ca273d49c.png">

**After**
<img width="1512" alt="Screenshot 2022-11-03 at 15 53 00" src="https://user-images.githubusercontent.com/161903/199770388-5acf22c6-7edc-46f0-9aea-3bede9a058ad.png">
