### PR TITLE
api/asset: Return object store URLs for catalyst

### DIFF
--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -148,12 +148,14 @@ export function getPlaybackUrl(
     if (os.id !== vodCatalystObjectStoreId) {
       return pathJoin(os.publicUrl, asset.playbackId, catalystManifest.path);
     }
-    return pathJoin(
-      "https://playback.livepeer.monster:10443/", // TODO: Make this a cli arg
-      "hls",
-      `asset+${asset.playbackId}`,
-      "index.m3u8"
-    );
+    // TODO: Set up Catalyst playback or a CDN in front of the default object store.
+    return pathJoin(os.publicUrl, asset.playbackId, catalystManifest.path);
+    // return pathJoin(
+    //   "https://playback.livepeer.monster:10443/", // TODO: Make this a cli arg
+    //   "hls",
+    //   `asset+${asset.playbackId}`,
+    //   "index.m3u8"
+    // );
   }
   return undefined;
 }


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This is to revert back to VoD playback directly from the object store (S3, Google, Storj, etc)
while we sort out issues with playing back from Catalyst.

Notice that this will just serve directly from the object store with no caching layer in front
of it. This could be very expensive for us, and so a pending change here is to put a CDN
(likely StackPath) in front of it.

**Specific updates (required)**
 - Change playback URLs returned for assets

## -

- **How did you test each of these updates (required)**
`yarn test`

**Does this pull request close any open issues?**
N/A

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
