### PR TITLE
api/queue: Add support for a global CloudAMQP rabbit setup

### DIFF
--- a/packages/api/src/app-router.ts
+++ b/packages/api/src/app-router.ts
@@ -76,6 +76,7 @@ export default async function makeApp(params: CliArgs) {
     insecureTestToken,
     stripeSecretKey,
     amqpUrl,
+    amqpTasksExchange,
     returnRegionInOrchestrator,
     halfRegionOrchestratorsUntrusted,
   } = params;
@@ -98,7 +99,7 @@ export default async function makeApp(params: CliArgs) {
 
   // RabbitMQ
   const queue: Queue = amqpUrl
-    ? await RabbitQueue.connect(amqpUrl)
+    ? await RabbitQueue.connect(amqpUrl, amqpTasksExchange)
     : new NoopQueue();
 
   // Task Scheduler

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -1,6 +1,7 @@
 import yargs from "yargs";
 import yargsToMist from "./yargs-to-mist";
 import { CamelKeys } from "./types/common";
+import { defaultTaskExchange } from "./store/queue";
 
 function coerceArr(arg: any) {
   if (!Array.isArray(arg)) {
@@ -81,6 +82,12 @@ export default function parseCli(argv?: string | readonly string[]) {
       "amqp-url": {
         describe: "the RabbitMQ Url",
         type: "string",
+      },
+      "amqp-tasks-exchange": {
+        describe:
+          "the name of the exchange for scheduling tasks and receiving results",
+        type: "string",
+        default: defaultTaskExchange,
       },
       "client-id": {
         describe: "google auth ID",

--- a/packages/api/src/store/queue.ts
+++ b/packages/api/src/store/queue.ts
@@ -10,14 +10,12 @@ const getExchanges = (tasksExchange = defaultTaskExchange) =>
   ({
     webhooks: "webhook_default_exchange",
     task: tasksExchange,
-    delayed_old: "webhook_delayed_exchange",
   } as const);
 const getQueues = (tasksExchange = defaultTaskExchange) =>
   ({
     events: "webhook_events_queue_v1",
     webhooks: "webhook_cannon_single_url_v1",
     task: `${tasksExchange}_results`,
-    delayed_old: "webhook_delayed_queue",
   } as const);
 const delayedWebhookQueue = (delayMs: number) => `delayed_webhook_${delayMs}ms`;
 
@@ -146,21 +144,6 @@ export class RabbitQueue implements Queue {
             "task.result.#"
           ),
           channel.prefetch(2),
-        ]);
-        // TODO: Remove this once all old queues have been deleted.
-        await Promise.all([
-          channel.unbindQueue(
-            this.queues.delayed_old,
-            this.exchanges.delayed_old,
-            "#"
-          ),
-          channel.deleteQueue(this.queues.delayed_old, {
-            ifUnused: true,
-            ifEmpty: true,
-          }),
-          channel.deleteExchange(this.exchanges.delayed_old, {
-            ifUnused: true,
-          }),
         ]);
       },
     });


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This adds support for a global RabbitMQ setup by allowing to split tasks events into different regions.

Notice that webhooks are still global, but I think that's OK. Only recordings might get processed in a
different region from the original stream.

**Specific updates (required)**
 - Receive exchange name from CLI args
 - Use it to create the exchange and queues

## -

- **How did you test each of these updates (required)**
Deployed to staging and checked CloudAMQP.

**Does this pull request close any open issues?**
Fixes all my rabbit nightmares.

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
