### PR TITLE
www/asset: Fix "processing" progress update

### DIFF
--- a/packages/www/components/Dashboard/AssetsTable/helpers.tsx
+++ b/packages/www/components/Dashboard/AssetsTable/helpers.tsx
@@ -144,7 +144,7 @@ export const fileUploadProgressForAsset = (
     (upload) => upload.file.name === asset.name
   );
   return fileUpload && asset.status?.phase === "waiting"
-    ? fileUpload.progress
+    ? (fileUpload.completed ? 1 : 0.99) * fileUpload.progress
     : undefined;
 };
 

--- a/packages/www/components/Dashboard/AssetsTable/index.tsx
+++ b/packages/www/components/Dashboard/AssetsTable/index.tsx
@@ -12,6 +12,7 @@ import {
   rowsPageFromState,
 } from "./helpers";
 import { makeCreateAction } from "../Table/helpers";
+import { sleep } from "react-query/types/core/utils";
 
 const AssetsTable = ({
   userId,
@@ -42,7 +43,7 @@ const AssetsTable = ({
     })();
   };
 
-  const onUploadAssetSuccess = () => state.invalidate();
+  const onUploadAssetSuccess = () => sleep(2000).then(() => state.invalidate());
 
   const onCreate = async ({ videoFiles }: { videoFiles: File[] }) => {
     try {

--- a/packages/www/components/Dashboard/AssetsTable/index.tsx
+++ b/packages/www/components/Dashboard/AssetsTable/index.tsx
@@ -12,7 +12,8 @@ import {
   rowsPageFromState,
 } from "./helpers";
 import { makeCreateAction } from "../Table/helpers";
-import { sleep } from "react-query/types/core/utils";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const AssetsTable = ({
   userId,

--- a/packages/www/components/Dashboard/FileUpload/FileItem.tsx
+++ b/packages/www/components/Dashboard/FileUpload/FileItem.tsx
@@ -29,7 +29,7 @@ const FileItem = ({ fileUpload }: { fileUpload: FileUpload }) => {
     <Box as={CheckIcon} css={{ align: "right", color: "$green9" }} />
   ) : (
     <Text size="2" css={{ mr: "$2", width: 25 }} variant="gray">
-      {(Number(progress ?? 0) * 100).toFixed(0)}
+      {(Number(progress ?? 0) * 99).toFixed(0)}
       {"%"}
     </Text>
   );


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This introduces a little delay after finishing upload so that there's time for the
task to start executing. This will guarantee that we will show a swift update from 
"uploading 100%" to "processing x%" instead of taking up to 10 seconds depending
on the refresh interval.

**Specific updates (required)**
Create a `sleep` helper and use it to delay state invalidation.

## -

- **How did you test each of these updates (required)**
Upload on the vercel preview and check described behavior.

**Does this pull request close any open issues?**
No only my "OCD".

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
