### PR TITLE
www: Fix asset list page not loading

### DIFF
--- a/packages/www/components/Dashboard/AssetsTable/helpers.tsx
+++ b/packages/www/components/Dashboard/AssetsTable/helpers.tsx
@@ -75,17 +75,18 @@ export const rowsPageFromState = async (
   getTasks: Function,
   onDeleteAsset: Function
 ): Promise<RowsPageFromStateResult<AssetsTableData>> => {
-  const [assets, nextCursor, count] = await getAssets(userId, {
+  const assetsPromise = getAssets(userId, {
     filters: formatFiltersForApiRequest(state.filters),
     limit: state.pageSize.toString(),
     cursor: state.cursor,
     order: state.order,
     count: true,
   });
-
-  const [tasks] = await getTasks(userId, {
+  const tasksPromise = getTasks(userId, {
     limit: state.pageSize.toString(),
   });
+  const [assets, nextCursor, count] = await assetsPromise;
+  const [tasks] = await tasksPromise;
 
   const rows: AssetsTableData[] = assets.map(
     (asset: Asset): AssetsTableData => {

--- a/packages/www/components/Dashboard/AssetsTable/helpers.tsx
+++ b/packages/www/components/Dashboard/AssetsTable/helpers.tsx
@@ -83,7 +83,9 @@ export const rowsPageFromState = async (
     count: true,
   });
 
-  const [tasks] = await getTasks(userId);
+  const [tasks] = await getTasks(userId, {
+    limit: state.pageSize.toString(),
+  });
 
   const rows: AssetsTableData[] = assets.map(
     (asset: Asset): AssetsTableData => {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
I found out we had more than just the account-with-a-lot-of-tasks problem,
it was actually an unnecessary big "list" query that was being done for the 
tasks in the account. That didn't include any `limit` so was looking for 200
objects in the DB for no reason.

To fix, added a limit to that query of up to 20 items. We should eventually fix
the API not to have such big defaults as well.

On the way also noticed we were doing 2 potentially slow queries in sequence,
so parallelized them as well. This should make the loading more snappy even 
on the E2E test accounts.

**Specific updates (required)**
 - Add limit to tasks list query
 - Parallelize fetches

## -

- **How did you test each of these updates (required)**
Access dashboard with E2E account and check if it loads in a reasonable time.

**Does this pull request close any open issues?**
Fixes https://github.com/livepeer/studio/issues/1388

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
