### PR TITLE
api: Fix race condition on task schedule

### DIFF
--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -287,13 +287,24 @@ export class TaskScheduler {
       updatedAt: Date.now(),
       retries: task.status.retries,
     };
-    await this.queue.publish("task", `task.trigger.${task.type}.${task.id}`, {
-      type: "task_trigger",
-      id: uuid(),
-      timestamp: status.updatedAt,
-      task: taskInfo(task),
-    });
     await this.updateTask(task, { status });
+    try {
+      await this.queue.publish("task", `task.trigger.${task.type}.${task.id}`, {
+        type: "task_trigger",
+        id: uuid(),
+        timestamp: status.updatedAt,
+        task: taskInfo(task),
+      });
+    } catch (err) {
+      console.error(`Failed to enqueue task: taskId=${task.id} err=`, err);
+      this.failTask(task, "Failed to enqueue task").catch((err) =>
+        console.error(
+          `Error failing task after enqueue error: taskId=${task.id} err=`,
+          err
+        )
+      );
+      throw new Error(`Failed to enqueue task: ${err}`);
+    }
   }
 
   async retryTask(task: WithID<Task>, errorMessage: string) {


### PR DESCRIPTION
We were updating the DB only after sending the Rabbit event, which was good not to update the task in case of failures to send the event, but could lead to race conditions in case the event was processed before we could get back and update the DB.

Couldn't think of an ideal solution without getting too complex, so decided to just move the DB update to before the event. Now tasks will go to waiting before we know if the event scheduling actually worked (but only when it is intended to happen).

Also added error handling to the publish, failing the task if so.

