### PR TITLE
Re-enabled the SWC minify

### DIFF
--- a/packages/www/next.config.js
+++ b/packages/www/next.config.js
@@ -9,7 +9,6 @@ const withMDX = require("@next/mdx")({
 const isAnalyzeEnabled = process.env.ANALYZE === "true";
 
 const config = {
-  swcMinify: false,
   images: {
     domains: ["cdn.sanity.io"],
   },


### PR DESCRIPTION
⚠️ DO NOT MERGE ⚠️
Turns out that Next.js 13.0.4 did not solve the issue in the end... Here [details](https://github.com/vercel/next.js/issues/42852).

**What does this pull request do? Explain your changes. (required)**
Re-enabled the SWC minify

A week ago the SWC minify was disabled because it broke his.js and consequently the player, due to some bug with Next.js 13.
They released a fix now so, after having updated to Next.js, we can re-enable SWC minify.

Fixed #1478 