### PR TITLE
When FileUpload has a lot of elements, made the content scrollable

### DIFF
--- a/packages/www/components/Dashboard/FileUpload/index.tsx
+++ b/packages/www/components/Dashboard/FileUpload/index.tsx
@@ -50,12 +50,14 @@ const FileUpload = () => {
         p: "$4",
         maxWidth: 550,
         minWidth: 420,
+        maxHeight: "90%",
+        overflowY: "scroll",
         border: "1px solid $neutral6",
         borderRadius: "$3",
         zIndex: 2,
         backgroundColor: "$panel",
       }}>
-      <Flex direction="column" justify="center" css={{}}>
+      <Flex direction="column" justify="center">
         {!hasPendingFileUploads && (
           <Box css={{ position: "absolute", top: "$3", right: "$2" }}>
             <IconButton


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
When FileUpload has a lot of elements, made the content scrollable

**How did you test each of these updates (required)**
Tested on Chrome and Safari, Dark and Light mode.

**Does this pull request close any open issues?**
Fixes #1516 

**Screenshots (optional):**
<img width="470" alt="Screenshot 2022-12-05 at 16 57 51" src="https://user-images.githubusercontent.com/161903/205696698-9f9de9eb-f4bf-41dd-bcbc-c434bbf57fc9.png">
<img width="470" alt="Screenshot 2022-12-05 at 16 57 54" src="https://user-images.githubusercontent.com/161903/205696703-60f660af-126e-42e9-9409-332124f7d279.png">
<img width="482" alt="Screenshot 2022-12-05 at 16 55 20" src="https://user-images.githubusercontent.com/161903/205696729-f8fd2c21-3316-4229-a84f-ad52a85a7137.png">
<img width="468" alt="Screenshot 2022-12-05 at 16 55 27" src="https://user-images.githubusercontent.com/161903/205696735-f3764687-01a5-4940-bc86-976c190d9133.png">
