### PR TITLE
api: Implement concurrent tasks rate-limiting for VOD

### DIFF
--- a/packages/api/src/controllers/asset.test.ts
+++ b/packages/api/src/controllers/asset.test.ts
@@ -167,6 +167,25 @@ describe("controllers/asset", () => {
     });
   });
 
+  it("should detect duplicate assets", async () => {
+    const spec = {
+      name: "test",
+      url: "https://example.com/test.mp4",
+    };
+    let res = await client.post(`/asset/upload/url`, spec);
+    expect(res.status).toBe(201);
+    const { asset } = await res.json();
+    expect(asset).toMatchObject({
+      id: expect.any(String),
+    });
+    const assetId = asset.id;
+
+    res = await client.post(`/asset/upload/url`, spec);
+    expect(res.status).toBe(409);
+    const { errors } = await res.json();
+    expect(errors).toMatchObject([expect.stringContaining(assetId)]);
+  });
+
   describe("asset inline storage", () => {
     let asset: WithID<Asset>;
 

--- a/packages/api/src/controllers/asset.test.ts
+++ b/packages/api/src/controllers/asset.test.ts
@@ -174,16 +174,19 @@ describe("controllers/asset", () => {
     };
     let res = await client.post(`/asset/upload/url`, spec);
     expect(res.status).toBe(201);
-    const { asset } = await res.json();
-    expect(asset).toMatchObject({
-      id: expect.any(String),
-    });
-    const assetId = asset.id;
+    let {
+      asset: { id: assetId },
+      task: { id: taskId },
+    } = await res.json();
+    expect(assetId).toMatch(/^[a-f0-9-]{36}$/);
+    expect(taskId).toMatch(/^[a-f0-9-]{36}$/);
 
     res = await client.post(`/asset/upload/url`, spec);
-    expect(res.status).toBe(409);
-    const { errors } = await res.json();
-    expect(errors).toMatchObject([expect.stringContaining(assetId)]);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      asset: { id: assetId },
+      task: { id: taskId },
+    });
   });
 
   describe("asset inline storage", () => {

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -546,7 +546,7 @@ const uploadWithUrlHandler: RequestHandler = async (req, res) => {
     defaultObjectStoreId(req, useCatalyst),
     req.body
   );
-  const dupAsset = await db.task.findDuplicateUrlUpload(
+  const dupAsset = await db.asset.findDuplicateUrlUpload(
     url,
     req.user.id,
     DUPLICATE_ASSETS_THRESHOLD

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -45,8 +45,6 @@ import taskScheduler from "../task/scheduler";
 import { S3ClientConfig } from "@aws-sdk/client-s3";
 import os from "os";
 
-const DUPLICATE_ASSETS_THRESHOLD = 15 * 60 * 1000; // 15 mins
-
 const app = Router();
 
 function shouldUseCatalyst({ query, user, config }: Request) {
@@ -546,11 +544,7 @@ const uploadWithUrlHandler: RequestHandler = async (req, res) => {
     defaultObjectStoreId(req, useCatalyst),
     req.body
   );
-  const dupAsset = await db.asset.findDuplicateUrlUpload(
-    url,
-    req.user.id,
-    DUPLICATE_ASSETS_THRESHOLD
-  );
+  const dupAsset = await db.asset.findDuplicateUrlUpload(url, req.user.id);
   if (dupAsset) {
     const [task] = await db.task.find({ outputAssetId: dupAsset.id });
     if (!task.length) {

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -238,7 +238,7 @@ async function ensureQueueCapacity(config: CliArgs, userId: string) {
   const numScheduled = await db.task.countScheduledTasks(userId);
   if (numScheduled >= config.vodMaxScheduledTasksPerUser) {
     throw new TooManyRequestsError(
-      `user ${userId} has reached the maximum number of concurrent tasks`
+      `user ${userId} has reached the maximum number of pending tasks`
     );
   }
 }

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -555,7 +555,7 @@ const uploadWithUrlHandler: RequestHandler = async (req, res) => {
   const id = uuid();
   const playbackId = await generateUniquePlaybackId(id);
   const useCatalyst = shouldUseCatalyst(req);
-  let asset = await validateAssetPayload(
+  const newAsset = await validateAssetPayload(
     id,
     playbackId,
     req.user.id,
@@ -572,14 +572,14 @@ const uploadWithUrlHandler: RequestHandler = async (req, res) => {
     } else {
       // return the existing asset and task, as if created now, with a slightly
       // different status code (200, not 201). Should be transparent to clients.
-      res.status(200).json({ asset, task: { id: task[0].id } });
+      res.status(200).json({ asset: dupAsset, task: { id: task[0].id } });
       return;
     }
   }
 
   await ensureQueueCapacity(req.config, req.user.id);
 
-  asset = await createAsset(asset, req.queue);
+  const asset = await createAsset(newAsset, req.queue);
   const taskType = useCatalyst ? "upload" : "import";
   const task = await req.taskScheduler.scheduleTask(
     taskType,

--- a/packages/api/src/controllers/multistream.ts
+++ b/packages/api/src/controllers/multistream.ts
@@ -35,7 +35,7 @@ function adminListQuery(
   cursor: string,
   orderStr: string,
   filters: string
-): [SQLStatement[], FindOptions] {
+): [SQLStatement[], FindOptions<DBMultistreamTarget & { user: User }>] {
   type ResultRow = {
     id: string;
     data: DBMultistreamTarget;
@@ -98,7 +98,7 @@ target.get("/", authorizer({}), async (req, res) => {
   }
 
   let query: FindQuery | Array<SQLStatement>;
-  let opts: FindOptions;
+  let opts: FindOptions<any>;
   if (!userId) {
     if (!isAdmin) {
       return badRequest(res, "required query parameter: userId");

--- a/packages/api/src/controllers/task.ts
+++ b/packages/api/src/controllers/task.ts
@@ -249,9 +249,9 @@ app.post("/:id/status", authorizer({ anyAdmin: true }), async (req, res) => {
         return true;
       }
       taskScheduler
-        .failTask(task, "internal error executing task")
+        .failTask(t, "internal error executing task") // don't be too explicit to users about losing tasks
         .catch((err) =>
-          console.error(`error failing task id=${task.id} err=`, err)
+          console.error(`error failing task id=${t.id} err=`, err)
         );
       return false;
     });

--- a/packages/api/src/controllers/task.ts
+++ b/packages/api/src/controllers/task.ts
@@ -234,12 +234,10 @@ app.post("/:id/status", authorizer({ anyAdmin: true }), async (req, res) => {
   // allow test users to run as many tasks as necessary
   if (!user.isTestUser && phase === "waiting" && !retries) {
     // this is an attempt to start executing the task for the first time. check concurrent tasks limit
-    const tasks = await db.task.listPendingTasks(req.user.id, true);
-    if (tasks.length >= req.config.vodMaxConcurrentTasksPerUser) {
+    const numRunning = await db.task.countRunningTasks(req.user.id);
+    if (numRunning >= req.config.vodMaxConcurrentTasksPerUser) {
       return res.status(429).json({
-        errors: [
-          `too many tasks running for user ${user.id} (${tasks.length})`,
-        ],
+        errors: [`too many tasks running for user ${user.id} (${numRunning})`],
       });
     }
   }

--- a/packages/api/src/controllers/task.ts
+++ b/packages/api/src/controllers/task.ts
@@ -238,7 +238,7 @@ app.post("/:id/status", authorizer({ anyAdmin: true }), async (req, res) => {
       sql`task.data->>'deleted' IS NULL`,
       sql`task.data->>'userId' = ${user.id}`,
       sql`task.data->'status'->>'phase' = 'running' OR `.append(
-        `(task.data->'status'->>'phase' = 'waiting' AND task.data->'status'->>'retries' IS NOT NULL)')`
+        `(task.data->'status'->>'phase' = 'waiting' AND task.data->'status'->>'retries' IS NOT NULL)`
       ),
     ];
     const maxAllowed = req.config.vodMaxConcurrentTasksPerUser;

--- a/packages/api/src/controllers/task.ts
+++ b/packages/api/src/controllers/task.ts
@@ -237,8 +237,8 @@ app.post("/:id/status", authorizer({ anyAdmin: true }), async (req, res) => {
     const query = [
       sql`task.data->>'deleted' IS NULL`,
       sql`task.data->>'userId' = ${user.id}`,
-      sql`task.data->'status'->>'phase' = 'running' OR `.append(
-        `(task.data->'status'->>'phase' = 'waiting' AND task.data->'status'->>'retries' IS NOT NULL)`
+      sql`(task.data->'status'->>'phase' = 'running'`.append(
+        ` OR (task.data->'status'->>'phase' = 'waiting' AND task.data->'status'->>'retries' IS NOT NULL))`
       ),
     ];
     const maxAllowed = req.config.vodMaxConcurrentTasksPerUser;

--- a/packages/api/src/controllers/task.ts
+++ b/packages/api/src/controllers/task.ts
@@ -18,6 +18,7 @@ import { Asset, Task } from "../schema/types";
 import { WithID } from "../store/types";
 import { withIpfsUrls } from "./asset";
 import { taskOutputToIpfsStorage } from "../store/asset-table";
+import { TooManyRequestsError } from "../store/errors";
 
 const app = Router();
 
@@ -236,9 +237,9 @@ app.post("/:id/status", authorizer({ anyAdmin: true }), async (req, res) => {
     // this is an attempt to start executing the task for the first time. check concurrent tasks limit
     const numRunning = await db.task.countRunningTasks(req.user.id);
     if (numRunning >= req.config.vodMaxConcurrentTasksPerUser) {
-      return res.status(429).json({
-        errors: [`too many tasks running for user ${user.id} (${numRunning})`],
-      });
+      throw new TooManyRequestsError(
+        `too many tasks running for user ${user.id} (${numRunning})`
+      );
     }
   }
 

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -248,6 +248,12 @@ export default function parseCli(argv?: string | readonly string[]) {
         default: 5,
         type: "number",
       },
+      vodMaxScheduledTasksPerUser: {
+        describe:
+          "maximum number of tasks that can be in the VOD execution queue for a given user",
+        default: 100,
+        type: "number",
+      },
       "ingest-region": {
         describe:
           "list of ingest endpoints to use as servers to consult for /api/ingest",

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -242,6 +242,12 @@ export default function parseCli(argv?: string | readonly string[]) {
         default: 0,
         type: "number",
       },
+      vodMaxConcurrentTasksPerUser: {
+        describe:
+          "maximum number of tasks that can be running for a given user",
+        default: 5,
+        type: "number",
+      },
       "ingest-region": {
         describe:
           "list of ingest endpoints to use as servers to consult for /api/ingest",

--- a/packages/api/src/store/asset-table.ts
+++ b/packages/api/src/store/asset-table.ts
@@ -82,7 +82,7 @@ export default class AssetTable extends Table<WithID<Asset>> {
       sql`asset.data->'source'->>'type' = 'url'`,
       sql`asset.data->>'deleted' IS NULL`,
       sql`asset.data->'status'->>'phase' IN ('waiting', 'pending')`,
-      sql`asset.data->'userId' = ${userId}`,
+      sql`asset.data->>'userId' = ${userId}`,
       sql`asset.data->'source'->>'url' = ${url}`,
       sql`coalesce((asset.data->'createdAt')::bigint, 0) > ${createdAfter}`,
     ];

--- a/packages/api/src/store/asset-table.ts
+++ b/packages/api/src/store/asset-table.ts
@@ -3,6 +3,8 @@ import { Asset, Task } from "../schema/types";
 import Table from "./table";
 import { QueryOptions, WithID } from "./types";
 
+const DUPLICATE_ASSETS_THRESHOLD = 15 * 60 * 1000; // 15 mins
+
 export const taskOutputToIpfsStorage = (
   out: Task["output"]["export"]["ipfs"]
 ): Omit<Asset["storage"]["ipfs"], "spec"> =>
@@ -74,10 +76,9 @@ export default class AssetTable extends Table<WithID<Asset>> {
 
   async findDuplicateUrlUpload(
     url: string,
-    userId: string,
-    maxAssetAgeMs: number
+    userId: string
   ): Promise<WithID<Asset>> {
-    const createdAfter = Date.now() - maxAssetAgeMs;
+    const createdAfter = Date.now() - DUPLICATE_ASSETS_THRESHOLD;
     const query = [
       sql`asset.data->>'deleted' IS NULL`,
       sql`asset.data->>'userId' = ${userId}`,

--- a/packages/api/src/store/asset-table.ts
+++ b/packages/api/src/store/asset-table.ts
@@ -1,7 +1,7 @@
 import sql from "sql-template-strings";
 import { Asset, Task } from "../schema/types";
 import Table from "./table";
-import { FindOptions, QueryOptions, WithID } from "./types";
+import { QueryOptions, WithID } from "./types";
 
 export const taskOutputToIpfsStorage = (
   out: Task["output"]["export"]["ipfs"]
@@ -72,23 +72,21 @@ export default class AssetTable extends Table<WithID<Asset>> {
     return assets[0];
   }
 
-  async findRecentDuplicateAssets(
+  async findDuplicateUrlUpload(
     url: string,
     userId: string,
-    createdAfter: number,
-    opts: FindOptions = { limit: 10 }
-  ): Promise<[WithID<Asset>[], string]> {
+    maxAssetAgeMs: number
+  ): Promise<WithID<Asset>> {
+    const createdAfter = Date.now() - maxAssetAgeMs;
     const query = [
-      sql`asset.data->'source'->>'type' = 'url'`,
       sql`asset.data->>'deleted' IS NULL`,
-      sql`asset.data->'status'->>'phase' IN ('waiting', 'pending')`,
       sql`asset.data->>'userId' = ${userId}`,
+      sql`asset.data->'source'->>'type' = 'url'`,
       sql`asset.data->'source'->>'url' = ${url}`,
-      sql`coalesce((asset.data->'createdAt')::bigint, 0) > ${createdAfter}`,
+      sql`asset.data->'status'->>'phase' IN ('waiting', 'processing')`,
+      sql`coalesce((asset.data->>'createdAt')::bigint, 0) > ${createdAfter}`,
     ];
-    return this.find(query, {
-      order: "coalesce((asset.data->'createdAt')::bigint, 0) DESC",
-      ...opts,
-    });
+    const [assets] = await this.find(query, { limit: 1 });
+    return assets?.length > 0 ? assets[0] : null;
   }
 }

--- a/packages/api/src/store/db.ts
+++ b/packages/api/src/store/db.ts
@@ -26,6 +26,7 @@ import MultistreamTargetTable from "./multistream-table";
 import WebhookTable from "./webhook-table";
 import { CdnUsageTable } from "./cdn-usage-table";
 import AssetTable from "./asset-table";
+import TaskTable from "./task-table";
 
 // Should be configurable, perhaps?
 const CONNECT_TIMEOUT = 5000;
@@ -64,7 +65,7 @@ export class DB {
   objectStore: Table<ObjectStore>;
   multistreamTarget: MultistreamTargetTable;
   asset: AssetTable;
-  task: Table<Task>;
+  task: TaskTable;
   signingKey: Table<SigningKey>;
   apiToken: Table<ApiToken>;
   user: Table<User>;
@@ -151,7 +152,7 @@ export class DB {
       db: this,
       schema: schemas["asset"],
     });
-    this.task = makeTable<Task>({
+    this.task = new TaskTable({
       db: this,
       schema: schemas["task"],
     });

--- a/packages/api/src/store/errors.ts
+++ b/packages/api/src/store/errors.ts
@@ -19,14 +19,6 @@ export class BadRequestError extends APIError {
   }
 }
 
-export class UnprocessableEntityError extends APIError {
-  constructor(message) {
-    super(message);
-    this.type = "UnprocessableEntityError";
-    this.status = 422;
-  }
-}
-
 export class NotFoundError extends APIError {
   constructor(message) {
     super(message);
@@ -48,6 +40,22 @@ export class ForbiddenError extends APIError {
     super(message);
     this.type = "ForbiddenError";
     this.status = 403;
+  }
+}
+
+export class UnprocessableEntityError extends APIError {
+  constructor(message) {
+    super(message);
+    this.type = "UnprocessableEntityError";
+    this.status = 422;
+  }
+}
+
+export class TooManyRequestsError extends APIError {
+  constructor(message) {
+    super(message);
+    this.type = "TooManyRequestsError";
+    this.status = 429;
   }
 }
 

--- a/packages/api/src/store/queue.ts
+++ b/packages/api/src/store/queue.ts
@@ -217,6 +217,7 @@ export class RabbitQueue implements Queue {
     );
     await this._channelPublish(this.exchanges[exchangeName], route, msg, {
       persistent: true,
+      mandatory: true,
     });
   }
 

--- a/packages/api/src/store/queue.ts
+++ b/packages/api/src/store/queue.ts
@@ -107,7 +107,6 @@ export class RabbitQueue implements Queue {
     // Create a new connection manager
     this.connection = amqp.connect([url]);
     this.channel = this.connection.createChannel({
-      confirm: true,
       json: true,
       publishTimeout: 10_000, // 10s
       setup: async (channel: Channel) => {
@@ -218,8 +217,8 @@ export class RabbitQueue implements Queue {
     );
     await this._channelPublish(this.exchanges[exchangeName], route, msg, {
       persistent: true,
-      // TODO: Actually handle returns from the AMQP server. Needs to setup a `return` event handler in the channel.
-      mandatory: true,
+      // TODO: Actually handle confirms and returns from the AMQP server. Needs to setup a `return` event handler in the channel.
+      // mandatory: true,
     });
   }
 

--- a/packages/api/src/store/queue.ts
+++ b/packages/api/src/store/queue.ts
@@ -107,6 +107,7 @@ export class RabbitQueue implements Queue {
     // Create a new connection manager
     this.connection = amqp.connect([url]);
     this.channel = this.connection.createChannel({
+      confirm: true,
       json: true,
       publishTimeout: 10_000, // 10s
       setup: async (channel: Channel) => {
@@ -217,6 +218,7 @@ export class RabbitQueue implements Queue {
     );
     await this._channelPublish(this.exchanges[exchangeName], route, msg, {
       persistent: true,
+      // TODO: Actually handle returns from the AMQP server. Needs to setup a `return` event handler in the channel.
       mandatory: true,
     });
   }

--- a/packages/api/src/store/table.ts
+++ b/packages/api/src/store/table.ts
@@ -140,7 +140,6 @@ export default class Table<T extends DBObject> {
     if (cursor && cursor.includes("skip")) {
       q.append(sql` OFFSET ${cursor.replace("skip", "")}`);
     }
-    console.log("executing query ", q.text);
 
     let res: QueryResult;
     if (useReplica) {

--- a/packages/api/src/store/table.ts
+++ b/packages/api/src/store/table.ts
@@ -131,7 +131,9 @@ export default class Table<T extends DBObject> {
       q.append(" ");
     }
 
-    q.append(` ORDER BY ${order}`);
+    if (order) {
+      q.append(` ORDER BY ${order}`);
+    }
     if (limit) {
       q.append(sql` LIMIT ${limit}`);
     }

--- a/packages/api/src/store/table.ts
+++ b/packages/api/src/store/table.ts
@@ -140,6 +140,7 @@ export default class Table<T extends DBObject> {
     if (cursor && cursor.includes("skip")) {
       q.append(sql` OFFSET ${cursor.replace("skip", "")}`);
     }
+    console.log("executing query ", q.text);
 
     let res: QueryResult;
     if (useReplica) {

--- a/packages/api/src/store/table.ts
+++ b/packages/api/src/store/table.ts
@@ -84,10 +84,10 @@ export default class Table<T extends DBObject> {
   }
 
   // returns [docs, cursor]
-  async find(
+  async find<Q = T>(
     query: FindQuery | Array<SQLStatement> = {},
-    opts: FindOptions = {}
-  ): Promise<[Array<T>, string]> {
+    opts: FindOptions<Q> = {}
+  ): Promise<[Array<Q>, string]> {
     const {
       cursor = "",
       useReplica = true,
@@ -139,14 +139,14 @@ export default class Table<T extends DBObject> {
       q.append(sql` OFFSET ${cursor.replace("skip", "")}`);
     }
 
-    let res;
+    let res: QueryResult;
     if (useReplica) {
       res = await this.db.replicaQuery(q);
     } else {
       res = await this.db.query(q);
     }
 
-    const docs = res.rows.map(process ? process : ({ data }) => data);
+    const docs = res.rows.map(process ? process : ({ data }) => data as Q);
 
     if (docs.length < 1) {
       return [docs, null];

--- a/packages/api/src/store/task-table.ts
+++ b/packages/api/src/store/task-table.ts
@@ -5,7 +5,7 @@ import { FindOptions, WithID } from "./types";
 
 // TODO: Clean-up these lost tasks, making them failed
 const ACTIVE_TASK_TIMEOUT = 5 * 60 * 1000; // 5 mins
-const ENQUEUED_TASK_TIMEOUT = 24 * 60 * 60 * 1000; // 24 hours
+const ENQUEUED_TASK_TIMEOUT = 6 * 60 * 60 * 1000; // 6 hours
 
 function joinOr(filters: SQLStatement[]): SQLStatement {
   const stmt = sql`(`;

--- a/packages/api/src/store/task-table.ts
+++ b/packages/api/src/store/task-table.ts
@@ -1,0 +1,26 @@
+import sql from "sql-template-strings";
+import { Task } from "../schema/types";
+import Table from "./table";
+import { FindOptions, WithID } from "./types";
+
+export default class TaskTable extends Table<WithID<Task>> {
+  async listRunningTasks(
+    userId: string,
+    maxTaskUpdateAge: number,
+    opts: FindOptions = { limit: 10 }
+  ): Promise<WithID<Task>[]> {
+    const activeTaskThreshold = Date.now() - maxTaskUpdateAge;
+    const query = [
+      sql`task.data->>'deleted' IS NULL`,
+      sql`task.data->>'userId' = ${userId}`,
+      sql`(
+        task.data->'status'->>'phase' = 'running' OR
+        (task.data->'status'->>'phase' = 'waiting' AND task.data->'status'->>'retries' IS NOT NULL)
+      )`,
+      // TODO: Clean-up these lost tasks, making them failed
+      sql`coalesce((task.data->'status'->>'updatedAt')::bigint, 0) > ${activeTaskThreshold}`,
+    ];
+    let [tasks] = await this.find(query, opts);
+    return tasks;
+  }
+}

--- a/packages/api/src/store/task-table.ts
+++ b/packages/api/src/store/task-table.ts
@@ -58,6 +58,7 @@ export default class TaskTable extends Table<WithID<Task>> {
     ];
     let [count] = await this.find(query, {
       fields: "COUNT(*) as count",
+      order: "",
       process: (row: { count: number }) => row.count,
     });
     return count[0] ?? 0;

--- a/packages/api/src/store/task-table.ts
+++ b/packages/api/src/store/task-table.ts
@@ -71,8 +71,8 @@ export default class TaskTable extends Table<WithID<Task>> {
 
     const indexName = [this.name, "pendingTasks"].join("_");
     try {
-      await this.db.query(sql`
-          CREATE INDEX ${indexName} ON ${this.name}
+      await this.db.query(`
+          CREATE INDEX "${indexName}" ON "${this.name}"
           USING BTREE (
             (data->>'userId'),
             coalesce((task.data->'status'->>'updatedAt')::bigint, 0),

--- a/packages/api/src/store/task-table.ts
+++ b/packages/api/src/store/task-table.ts
@@ -8,14 +8,14 @@ const ACTIVE_TASK_TIMEOUT = 5 * 60 * 1000; // 5 mins
 const ENQUEUED_TASK_TIMEOUT = 24 * 60 * 60 * 1000; // 24 hours
 
 function joinOr(filters: SQLStatement[]): SQLStatement {
-  const stmt = sql`( `;
+  const stmt = sql`(`;
   filters.forEach((filter, idx) => {
     if (idx > 0) {
       stmt.append(" OR ");
     }
-    stmt.append(sql`( ${filter} )`);
+    stmt.append(`(`).append(filter).append(`)`);
   });
-  return stmt.append(` )`);
+  return stmt.append(`)`);
 }
 
 export default class TaskTable extends Table<WithID<Task>> {
@@ -48,7 +48,7 @@ export default class TaskTable extends Table<WithID<Task>> {
         sql`
           task.data->'status'->>'phase' = 'waiting'
           AND task.data->'status'->>'retries' IS NULL
-          AND coalesce((task.data->'status'->>'updatedAt')::bigint, 0) > ${enqueuedTaskThreshold}`
+          AND coalesce( (task.data->'status'->>'updatedAt')::bigint, 0) > ${enqueuedTaskThreshold}`
       );
     }
 

--- a/packages/api/src/store/task-table.ts
+++ b/packages/api/src/store/task-table.ts
@@ -8,14 +8,14 @@ const ACTIVE_TASK_TIMEOUT = 5 * 60 * 1000; // 5 mins
 const ENQUEUED_TASK_TIMEOUT = 24 * 60 * 60 * 1000; // 24 hours
 
 function joinOr(filters: SQLStatement[]): SQLStatement {
-  const stmt = sql`(`;
+  const stmt = sql`( `;
   filters.forEach((filter, idx) => {
     if (idx > 0) {
       stmt.append(" OR ");
     }
-    stmt.append(sql`(${filter})`);
+    stmt.append(sql`( ${filter} )`);
   });
-  return stmt.append(`)`);
+  return stmt.append(` )`);
 }
 
 export default class TaskTable extends Table<WithID<Task>> {
@@ -38,7 +38,8 @@ export default class TaskTable extends Table<WithID<Task>> {
       (
         task.data->'status'->>'phase' = 'running'
         OR (task.data->'status'->>'phase' = 'waiting' AND task.data->'status'->>'retries' IS NOT NULL)
-      ) AND coalesce((task.data->'status'->>'updatedAt')::bigint, 0) > ${activeTaskThreshold}`,
+      )
+      AND coalesce( (task.data->'status'->>'updatedAt')::bigint, 0) > ${activeTaskThreshold}`,
     ];
 
     if (!startedTasksOnly) {

--- a/packages/api/src/store/types.ts
+++ b/packages/api/src/store/types.ts
@@ -28,13 +28,13 @@ export interface QueryOptions {
   useReplica?: boolean;
 }
 
-export interface FindOptions extends QueryOptions {
+export interface FindOptions<T = never> extends QueryOptions {
   cursor?: string;
   limit?: number | string;
   order?: string;
   fields?: string;
   from?: string;
-  process?: Function;
+  process?: (row: any) => T;
 }
 
 export interface GetOptions {

--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -186,7 +186,7 @@ export class TaskScheduler {
     return true;
   }
 
-  private async failTask(
+  public async failTask(
     task: WithID<Task>,
     error: string,
     output?: Task["output"]

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -524,6 +524,7 @@ export default class WebhookCannon {
       },
       this.queue
     );
+    // we can't rate limit this task because it's not a user action
     await taskScheduler.scheduleTask(
       "import",
       {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This is to implement a couple rate-limiting protections on the VOD pipeline against exaggerated traffic
from specific users. There are 3 main and independent strategies for rate-limiting implemented here.

**Specific updates (required)**
The strategies are:
1.   A maximum number of tasks that the pipeline can run for the same user concurrently.
  - This works by querying for tasks in the `running` or "retrying" state, and returning 429 on the initial request made by `task-runner` to start executing the task. Task runner learned how to process that here https://github.com/livepeer/task-runner/pull/95 and will backoff the message on the delayed queue for a minute, before trying to start again
2. A maximum number of tasks that can be enqueued for the same user. This includes the tasks that are currently executing.
  - Differently from the previous strategy, this doesn't just backoff the execution of the task, but it returns an explicit error to the user when they try to create more tasks. 
  - The point here is to protect the delayed queue which is used in the first strategy. We delay events for 1 minute at each step, so there is a number of tasks being delayed at which we would not be able to process even the quick-delayed-tasks in a timely manner. Assuming a latency of 100ms to process each message and the same 15x concurrency on a region/queue, this would mean that `60*1000/100*15=9000` messages could create a problem if we didn't have this rate limiting, which seems pretty possible.
  - Based on the numbers above, setup a limit of 100 tasks (by default, everything is configurable) enqueued for each user.
3. A deduplication strategy to avoid processing the same file multiple times. Yeah this might be annoying for testing, but will protect us in production from possible bugs in client implementations or our own (like the old livepeer.js bug that published created of assets for the same URL). The neat thing here is that we don't return an error: we just return the already running/duplicate task back.

## -

- **How did you test each of these updates (required)**
`yarn test`, transcoded dozens of files in staging, tried uploading 200 files at once (got rate limited), observed how execution is now happening 5 tasks at a time, pretty orderly, and tried publishing duplicate assets and ensured same asset/task was returned.

**Does this pull request close any open issues?**
I think so but idk where it is. It's a blocker for MediaCovnert launch on 12/16.

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
