### PR TITLE
Showing more user friendly error when the email is already registered

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -36,6 +36,17 @@ orchestrator that the development API server knows about.
 
 ## Testing
 
-To run the unit tests in development, you can run `npm run test:local`. The full
-`npm run test` suite runs against every store and amalgamates the runs to ensure
-full test coverage.
+To run the unit tests in development, you can run:
+
+```
+yarn test:dev
+```
+
+To run a single unit test file:
+
+```
+yarn jest -i --watch --silent src/controllers/user.test.ts
+```
+
+The full `yarn test` suite runs against every store and amalgamates the runs to
+ensure full test coverage.

--- a/packages/api/src/controllers/user.test.ts
+++ b/packages/api/src/controllers/user.test.ts
@@ -307,7 +307,17 @@ describe("controllers/user", () => {
       res = await client.post("/user/token", {
         ...mockUser,
       });
+      expect(res.status).toBe(201);
+      tokenRes = await res.json();
+      expect(tokenRes.id).toBeDefined();
+      expect(tokenRes.email).toBe(mockUser.email);
+      expect(tokenRes.token).toBeDefined();
 
+      // token should be returned without error with an uppercase email
+      res = await client.post("/user/token", {
+        ...mockUser,
+        email: mockUser.email.toUpperCase(),
+      });
       expect(res.status).toBe(201);
       tokenRes = await res.json();
       expect(tokenRes.id).toBeDefined();

--- a/packages/api/src/controllers/user.test.ts
+++ b/packages/api/src/controllers/user.test.ts
@@ -101,7 +101,7 @@ describe("controllers/user", () => {
 
     it("should create a user without authorization and not allow repeat user creation", async () => {
       client.jwtAuth = "";
-      let res = await client.post("/user/", { ...mockUser });
+      const res = await client.post("/user/", { ...mockUser });
       expect(res.status).toBe(201);
       const user = await res.json();
       expect(user.id).toBeDefined();
@@ -111,11 +111,11 @@ describe("controllers/user", () => {
       const resUser = await db.user.get(user.id);
       expect(resUser.email).toEqual(user.email);
 
-      // if same request is made, should return a 403
-      res = await client.post("/user", {
-        ...mockUser,
-      });
-      expect(res.status).toBe(400);
+      // Registering the same user again should fail
+      const resTwo = await client.post("/user", { ...mockUser });
+      let resTwoJson = await resTwo.json();
+      expect(resTwo.status).toBe(409);
+      expect(resTwoJson.errors[0]).toBe("email already registered");
     });
 
     it("should make a user an admin with admin email", async () => {

--- a/packages/api/src/controllers/user.test.ts
+++ b/packages/api/src/controllers/user.test.ts
@@ -116,6 +116,15 @@ describe("controllers/user", () => {
       let resTwoJson = await resTwo.json();
       expect(resTwo.status).toBe(409);
       expect(resTwoJson.errors[0]).toBe("email already registered");
+
+      // Registering a user with the same uppercased email should fail
+      const resThree = await client.post("/user", {
+        ...mockUser,
+        email: mockUser.email.toUpperCase(),
+      });
+      let resThreeJson = await resThree.json();
+      expect(resThree.status).toBe(409);
+      expect(resThreeJson.errors[0]).toBe("email already registered");
     });
 
     it("should make a user an admin with admin email", async () => {

--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -56,6 +56,18 @@ function cleanUserFields(user: WithID<User>, isAdmin = false) {
 }
 
 async function findUserByEmail(email: string, useReplica = true) {
+  // Look for user by lowercase email
+  const [lowercaseUsers] = await db.user.find(
+    { email: email.toLowerCase() },
+    { useReplica }
+  );
+  if (lowercaseUsers?.length === 1) {
+    return lowercaseUsers[0];
+  } else if (lowercaseUsers.length > 1) {
+    throw new InternalServerError("multiple users found with same email");
+  }
+
+  // Look for user by original email
   const [users] = await db.user.find({ email }, { useReplica });
   if (!users?.length) {
     throw new NotFoundError("user not found");

--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -65,6 +65,11 @@ async function findUserByEmail(email: string, useReplica = true) {
   return users[0];
 }
 
+async function isEmailRegistered(email: string, useReplica = true) {
+  const [users] = await db.user.find({ email }, { useReplica });
+  return users?.length > 0;
+}
+
 const frontendUrl = (
   {
     headers: { "x-forwarded-proto": proto },
@@ -247,6 +252,14 @@ app.post("/", validatePost("user"), async (req, res) => {
     res.json({ errors: ["invalid email"] });
     return;
   }
+
+  const isEmailRegisteredAlready = await isEmailRegistered(email);
+  if (isEmailRegisteredAlready) {
+    res.status(409);
+    res.json({ errors: ["email already registered"] });
+    return;
+  }
+
   const [hashedPassword, salt] = await hash(password);
   const id = uuid();
   const emailValidToken = uuid();

--- a/packages/www/components/Site/Login/index.tsx
+++ b/packages/www/components/Site/Login/index.tsx
@@ -180,11 +180,14 @@ const Login = ({
             onChange={(e) => setPassword(e.target.value)}
           />
         )}
-        <Box>{errors.join(", ")}&nbsp;</Box>
+
+        {errors.length > 0 && (
+          <Box css={{ mt: "$2" }}>{errors.join(", ")}&nbsp;</Box>
+        )}
 
         <Button
           small
-          css={{ width: "100%", mb: "$1", px: "$3", fontSize: "$3" }}>
+          css={{ width: "100%", my: "$3", px: "$3", fontSize: "$3" }}>
           {loading ? "Loading..." : buttonText}
         </Button>
       </Box>


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Showing more user friendly error when the email is already registered. Also looking for lowercase email when logging in, verifying email and resetting password.


**Specific updates (required)**
- Looking up for the email (as given and lowercased before registering)
- Registering with 3rd parties and in our DB the lowercase version of the email
- Looking for lowercase email when logging in, verifying email and resetting password.

**How did you test each of these updates (required)**
- Updated the unit tests
- Run locally the API server and made sure it was passing all the tests
- Manually tested in browser

**Does this pull request close any open issues?**
Fixes #1531
Fixes #1522 

**Screenshots:**
<img width="547" alt="Screenshot 2022-12-07 at 17 21 58" src="https://user-images.githubusercontent.com/161903/206247666-4dea480d-fac8-4a99-9aa5-45811bc20bf9.png">
