### PR TITLE
api: Make CID search check source URL as well

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - "master"
+      - "dev"
     tags:
       - "v*"
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - dev
     tags:
       - "v*"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - "master"
+      - "dev"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -117,6 +117,7 @@
     "@types/http-proxy": "^1.17.8",
     "@types/jest": "^26.0.10",
     "@types/jsonwebtoken": "^8.5.6",
+    "@types/lodash": "^4.14.191",
     "@types/ms": "^0.7.31",
     "@types/mustache": "^4.1.1",
     "@types/node-fetch": "^2.5.10",

--- a/packages/api/src/controllers/asset.test.ts
+++ b/packages/api/src/controllers/asset.test.ts
@@ -501,16 +501,38 @@ describe("controllers/asset", () => {
     let asset: WithID<Asset>;
     let assetFromIpfs: WithID<Asset>;
 
+    const createAsset = async (
+      payload: Omit<Asset, "id" | "playbackId" | "userId">
+    ) => {
+      const id = uuid();
+      const playbackId = await generateUniquePlaybackId(id);
+      return db.asset.cleanWriteOnlyResponse(
+        await db.asset.create({
+          id,
+          playbackId,
+          userId: nonAdminUser.id,
+          ...payload,
+        })
+      );
+    };
+
     beforeEach(async () => {
-      const createAsset = async (payload: WithID<Asset>) => {
-        return db.asset.cleanWriteOnlyResponse(await db.asset.create(payload));
-      };
+      // this dummy one is just to differentiate empty responses from "list all" responses
+      await createAsset({
+        name: "dummy",
+        source: { type: "directUpload" },
+        createdAt: Date.now(),
+        objectStoreId: "mock_vod_store",
+        status: {
+          phase: "ready",
+          updatedAt: Date.now(),
+        },
+      });
+
       asset = await createAsset({
-        id: uuid(),
         name: "test-storage",
         createdAt: Date.now(),
         objectStoreId: "mock_vod_store",
-        playbackId: await generateUniquePlaybackId(uuid()),
         source: { type: "directUpload" },
         storage: {
           ipfs: {
@@ -523,20 +545,16 @@ describe("controllers/asset", () => {
           phase: "ready",
           updatedAt: Date.now(),
         },
-        userId: nonAdminUser.id,
       });
       assetFromIpfs = await createAsset({
-        id: uuid(),
         name: "test-ipfs-source",
         createdAt: Date.now(),
         objectStoreId: "mock_vod_store",
-        playbackId: await generateUniquePlaybackId(uuid()),
         source: { type: "url", url: "ipfs://QmW456" },
         status: {
           phase: "ready",
           updatedAt: Date.now(),
         },
-        userId: nonAdminUser.id,
       });
     });
 

--- a/packages/api/src/controllers/asset.test.ts
+++ b/packages/api/src/controllers/asset.test.ts
@@ -531,7 +531,7 @@ describe("controllers/asset", () => {
         createdAt: Date.now(),
         objectStoreId: "mock_vod_store",
         playbackId: await generateUniquePlaybackId(uuid()),
-        source: { type: "url", url: "ipfs://QmY321" },
+        source: { type: "url", url: "ipfs://QmW456" },
         status: {
           phase: "ready",
           updatedAt: Date.now(),
@@ -560,8 +560,8 @@ describe("controllers/asset", () => {
     it("should find asset by CID", async () => {
       await expectFindAsset(`cid=somethingelse`, false);
       await expectFindAsset(`cid=QmX123`, true);
-      await expectFindAsset(`cid=QmY321`, assetFromIpfs);
-      await expectFindAsset(`sourceUrl=ipfs://QmY321`, assetFromIpfs);
+      await expectFindAsset(`cid=QmW456`, assetFromIpfs);
+      await expectFindAsset(`sourceUrl=ipfs://QmW456`, assetFromIpfs);
     });
 
     it("should find asset by NFT metadata CID", async () => {

--- a/packages/api/src/controllers/asset.test.ts
+++ b/packages/api/src/controllers/asset.test.ts
@@ -565,16 +565,22 @@ describe("controllers/asset", () => {
     });
 
     it("should find asset by NFT metadata CID", async () => {
-      await expectFindAsset(`nftMetadataCid=somethingelse`, false);
       await expectFindAsset(
-        `nftMetadataCid=${asset.storage.ipfs.nftMetadata.cid}`,
+        `filters=[{"id":"nftMetadataCid","value":"somethingelse"}]`,
+        false
+      );
+      await expectFindAsset(
+        `filters=[{"id":"nftMetadataCid","value":"${asset.storage.ipfs.nftMetadata.cid}"}]`,
         true
       );
     });
 
     it("should not mix main and NFT metadata CIDs", async () => {
       await expectFindAsset(`cid=${asset.storage.ipfs.nftMetadata.cid}`, false);
-      await expectFindAsset(`nftMetadataCid=${asset.storage.ipfs.cid}`, false);
+      await expectFindAsset(
+        `filter=[{"id":"nftMetadataCid","value":"${asset.storage.ipfs.cid}"}]`,
+        false
+      );
     });
 
     it("should NOT allow finding by name through direct query string", async () => {

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -400,7 +400,7 @@ const fieldsMap = {
 app.get("/", authorizer({}), async (req, res) => {
   let { limit, cursor, all, allUsers, order, filters, count, cid, ...otherQs } =
     toStringValues(req.query);
-  const fieldFilters = _.pick(otherQs, "playbackId", "nftMetadataCid", "sourceUrl");
+  const fieldFilters = _.pick(otherQs, "playbackId", "sourceUrl", "phase");
   if (isNaN(parseInt(limit))) {
     limit = undefined;
   }
@@ -419,7 +419,8 @@ app.get("/", authorizer({}), async (req, res) => {
   if (cid) {
     const ipfsUrl = `ipfs://${cid}`;
     query.push(
-      sql`(${fieldsMap.cid} = ${cid} OR ${fieldsMap.sourceUrl} = ${ipfsUrl})`
+      sql`(${fieldsMap.cid} = ${cid} OR ${fieldsMap.sourceUrl} = ${ipfsUrl})`,
+      sql`${fieldsMap.phase} = 'ready'`
     );
   }
 

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -400,7 +400,7 @@ const fieldsMap = {
 app.get("/", authorizer({}), async (req, res) => {
   let { limit, cursor, all, allUsers, order, filters, count, cid, ...otherQs } =
     toStringValues(req.query);
-  const fieldFilters = _.pick(otherQs, "playbackId", "nftMetadataCid");
+  const fieldFilters = _.pick(otherQs, "playbackId", "nftMetadataCid", "sourceUrl");
   if (isNaN(parseInt(limit))) {
     limit = undefined;
   }

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -419,8 +419,7 @@ app.get("/", authorizer({}), async (req, res) => {
   if (cid) {
     const ipfsUrl = `ipfs://${cid}`;
     query.push(
-      sql`(${fieldsMap.cid} = ${cid} OR ${fieldsMap.sourceUrl} = ${ipfsUrl})`,
-      sql`${fieldsMap.phase} = 'ready'`
+      sql`(asset.data->'storage'->'ipfs'->>'cid' = ${cid} OR asset.data->'source'->>'url' = ${ipfsUrl})`
     );
   }
 

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -400,7 +400,10 @@ const fieldsMap = {
 app.get("/", authorizer({}), async (req, res) => {
   let { limit, cursor, all, allUsers, order, filters, count, cid, ...otherQs } =
     toStringValues(req.query);
-  const fieldFilters = _.pick(otherQs, "playbackId", "sourceUrl", "phase");
+  const fieldFilters = _(otherQs)
+    .pick("playbackId", "sourceUrl", "phase")
+    .map((v, k) => ({ id: k, value: decodeURIComponent(v) }))
+    .value();
   if (isNaN(parseInt(limit))) {
     limit = undefined;
   }
@@ -410,10 +413,7 @@ app.get("/", authorizer({}), async (req, res) => {
 
   const query = [
     ...parseFilters(fieldsMap, filters),
-    ...parseFilters(
-      fieldsMap,
-      JSON.stringify(_.map(fieldFilters, (v, k) => ({ id: k, value: v })))
-    ),
+    ...parseFilters(fieldsMap, JSON.stringify(fieldFilters)),
   ];
 
   if (cid) {

--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -5,7 +5,7 @@ import fetch from "node-fetch";
 import SendgridMail from "@sendgrid/mail";
 import SendgridClient from "@sendgrid/client";
 import express, { Request } from "express";
-import sql from "sql-template-strings";
+import sql, { SQLStatement } from "sql-template-strings";
 import { createHmac } from "crypto";
 import { S3Client, PutObjectCommand, S3ClientConfig } from "@aws-sdk/client-s3";
 import { S3StoreOptions as TusS3Opts } from "tus-node-server";
@@ -372,12 +372,15 @@ export function parseOrder(fieldsMap: FieldsMap, val: string) {
   return prep.length ? prep.join(", ") : undefined;
 }
 
-export function parseFilters(fieldsMap: FieldsMap, val: string) {
+export function parseFilters(
+  fieldsMap: FieldsMap,
+  val: string
+): SQLStatement[] {
   const isObject = function (a) {
     return !!a && a.constructor === Object;
   };
 
-  const q = [];
+  const q: SQLStatement[] = [];
   if (!val) {
     return q;
   }

--- a/packages/api/src/store/table.ts
+++ b/packages/api/src/store/table.ts
@@ -22,6 +22,16 @@ export interface TableOptions {
   schema: TableSchema;
 }
 
+function parseLimit({ limit }: FindOptions<any>) {
+  if (typeof limit === "string") {
+    limit = parseInt(limit);
+  }
+  if (typeof limit !== "number" || isNaN(limit) || limit < 1) {
+    limit = 20;
+  }
+  return Math.min(limit, 1000);
+}
+
 export default class Table<T extends DBObject> {
   db: DB;
   schema: TableSchema;
@@ -96,10 +106,7 @@ export default class Table<T extends DBObject> {
       from = this.name,
       process,
     } = opts;
-    let limit = opts.hasOwnProperty("limit") ? opts.limit : 100;
-    if (typeof limit === "string") {
-      limit = parseInt(limit);
-    }
+    const limit = parseLimit(opts);
 
     const q = sql`SELECT `.append(fields).append(` FROM `).append(from);
     let filters = [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -6966,6 +6966,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/lodash@^4.14.191":
+  version "4.14.191"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.191.tgz#09511e7f7cba275acd8b419ddac8da9a6a79e2fa"
+  integrity sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==
+
 "@types/mdast@^3.0.0":
   version "3.0.10"
   resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.10.tgz#4724244a82a4598884cbbe9bcfd73dff927ee8af"


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Fixes CID search on the asset list API (`/asset?cid=<x>`) by also searching the
source URL of assets, consistently with the playback info endpoint.

**Specific updates (required)**
 - Create `sourceUrl` field filter in asset list (it's already indexed as well so that's safe)
 - Create a custom processing logic for the `cid` query string in the list API
 - Make that custom processing logic with an `OR` condition checking either pinned CID or source URL

**How did you test each of these updates (required)**
Sending to staging to check if CID-imported assets are also found, not only CID-exported.

**Does this pull request close any open issues?**

Fixes an issue lenstube was having for using this.

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
