### PR TITLE
Removed duplicated initial fetcher calls in Tables

### DIFF
--- a/packages/www/components/Dashboard/ApiKeys/index.tsx
+++ b/packages/www/components/Dashboard/ApiKeys/index.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useMemo, useState } from "react";
 import { useApi } from "../../../hooks";
-import Table, { Fetcher, useTableState } from "components/Dashboard/Table";
+import Table, {
+  DefaultSortBy,
+  Fetcher,
+  sortByToString,
+  useTableState,
+} from "components/Dashboard/Table";
 import CreateDialog from "./CreateDialog";
 import { useToggleState } from "hooks/use-toggle-state";
 import {
@@ -22,6 +27,7 @@ const ApiKeysTable = ({
   const { getApiTokens, deleteApiToken } = useApi();
   const { state, stateSetter } = useTableState<ApiKeysTableData>({
     tableId: "tokenTable",
+    initialOrder: sortByToString(DefaultSortBy),
   });
   const deleteDialogState = useToggleState();
   const createDialogState = useToggleState();
@@ -41,6 +47,7 @@ const ApiKeysTable = ({
         columns={columns}
         fetcher={fetcher}
         rowSelection="all"
+        initialSortBy={[DefaultSortBy]}
         emptyState={makeEmptyState(createDialogState)}
         selectAction={makeSelectAction("Delete", deleteDialogState.onOn)}
         createAction={makeCreateAction(

--- a/packages/www/components/Dashboard/AssetsTable/index.tsx
+++ b/packages/www/components/Dashboard/AssetsTable/index.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useMemo } from "react";
 import { useApi } from "hooks";
-import Table, { useTableState, Fetcher } from "components/Dashboard/Table";
+import Table, {
+  useTableState,
+  Fetcher,
+  sortByToString,
+  DefaultSortBy,
+} from "components/Dashboard/Table";
 import { useSnackbar } from "@livepeer/design-system";
 import { useToggleState } from "hooks/use-toggle-state";
 import CreateAssetDialog from "./CreateAssetDialog";
@@ -35,6 +40,7 @@ const AssetsTable = ({
   const { state, stateSetter } = useTableState<AssetsTableData>({
     pageSize,
     tableId,
+    initialOrder: sortByToString(DefaultSortBy),
   });
   const columns = useMemo(makeColumns, []);
 
@@ -80,7 +86,7 @@ const AssetsTable = ({
         stateSetter={stateSetter}
         filterItems={!viewAll && filterItems}
         viewAll={viewAll}
-        initialSortBy={[{ id: "createdAt", desc: true }]}
+        initialSortBy={[DefaultSortBy]}
         emptyState={makeEmptyState(createDialogState)}
         createAction={makeCreateAction("Upload asset", createDialogState.onOn)}
       />

--- a/packages/www/components/Dashboard/SigningKeysTable/index.tsx
+++ b/packages/www/components/Dashboard/SigningKeysTable/index.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useMemo } from "react";
 import { useApi } from "../../../hooks";
-import Table, { Fetcher, useTableState } from "components/Dashboard/Table";
+import Table, {
+  DefaultSortBy,
+  Fetcher,
+  sortByToString,
+  useTableState,
+} from "components/Dashboard/Table";
 import { useToggleState } from "hooks/use-toggle-state";
 import {
   makeColumns,
@@ -25,6 +30,7 @@ const SigningKeysTable = ({
   const { state, stateSetter } = useTableState<SigningKeysTableData>({
     pageSize,
     tableId,
+    initialOrder: sortByToString(DefaultSortBy),
   });
   const deleteDialogState = useToggleState();
   const createDialogState = useToggleState();
@@ -45,7 +51,7 @@ const SigningKeysTable = ({
         rowSelection="all"
         state={state}
         stateSetter={stateSetter}
-        initialSortBy={[{ id: "createdAt", desc: true }]}
+        initialSortBy={[DefaultSortBy]}
         emptyState={makeEmptyState(createDialogState)}
         selectAction={makeSelectAction("Delete", deleteDialogState.onOn)}
         createAction={makeCreateAction(

--- a/packages/www/components/Dashboard/StreamDetails/SessionsTable/index.tsx
+++ b/packages/www/components/Dashboard/StreamDetails/SessionsTable/index.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useMemo } from "react";
 import { useApi } from "../../../../hooks";
-import Table, { Fetcher, useTableState } from "components/Dashboard/Table";
+import Table, {
+  DefaultSortBy,
+  Fetcher,
+  sortByToString,
+  useTableState,
+} from "components/Dashboard/Table";
 import { Box, Heading, useSnackbar } from "@livepeer/design-system";
 import {
   filterItems,
@@ -25,6 +30,7 @@ const SessionsTable = ({
   const { user, getStreamSessions } = useApi();
   const { state, stateSetter } = useTableState<SessionsTableData>({
     tableId: "streamSessionsTable",
+    initialOrder: sortByToString(DefaultSortBy),
   });
   const [openSnackbar] = useSnackbar();
   const columns = useMemo(makeColumns, []);
@@ -46,7 +52,7 @@ const SessionsTable = ({
         columns={columns}
         fetcher={fetcher}
         rowSelection={null}
-        initialSortBy={[{ id: "createdAt", desc: true }]}
+        initialSortBy={[DefaultSortBy]}
         showOverflow={true}
         emptyState={emptyState}
         tableLayout={tableLayout}

--- a/packages/www/components/Dashboard/StreamSessionsTable/index.tsx
+++ b/packages/www/components/Dashboard/StreamSessionsTable/index.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useMemo } from "react";
 import { useApi } from "../../../hooks";
-import Table, { Fetcher, useTableState } from "components/Dashboard/Table";
+import Table, {
+  DefaultSortBy,
+  Fetcher,
+  sortByToString,
+  useTableState,
+} from "components/Dashboard/Table";
 import { useSnackbar } from "@livepeer/design-system";
 import {
   filterItems,
@@ -14,6 +19,7 @@ const StreamSessionsTable = ({ title = "Sessions" }: { title?: string }) => {
   const { user, getStreamSessionsByUserId } = useApi();
   const { state, stateSetter } = useTableState<StreamSessionsTableData>({
     tableId: "allSessionsTable",
+    initialOrder: sortByToString(DefaultSortBy),
   });
   const [openSnackbar] = useSnackbar();
   const columns = useMemo(makeColumns, []);
@@ -36,7 +42,7 @@ const StreamSessionsTable = ({ title = "Sessions" }: { title?: string }) => {
       stateSetter={stateSetter}
       columns={columns}
       fetcher={fetcher}
-      initialSortBy={[{ id: "createdAt", desc: true }]}
+      initialSortBy={[DefaultSortBy]}
       showOverflow={true}
       filterItems={filterItems}
       emptyState={makeEmptyState()}

--- a/packages/www/components/Dashboard/StreamsTable/index.tsx
+++ b/packages/www/components/Dashboard/StreamsTable/index.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useMemo } from "react";
 import { useApi } from "hooks";
-import Table, { useTableState, Fetcher } from "components/Dashboard/Table";
+import Table, {
+  useTableState,
+  Fetcher,
+  DefaultSortBy,
+  sortByToString,
+} from "components/Dashboard/Table";
 import { useToggleState } from "hooks/use-toggle-state";
 import CreateStreamDialog from "./CreateStreamDialog";
 import { useRouter } from "next/router";
@@ -37,6 +42,7 @@ const StreamsTable = ({
   const { state, stateSetter } = useTableState<StreamsTableData>({
     pageSize,
     tableId,
+    initialOrder: sortByToString(DefaultSortBy),
   });
   const columns = useMemo(makeColumns, []);
   const fetcher: Fetcher<StreamsTableData> = useCallback(
@@ -70,7 +76,7 @@ const StreamsTable = ({
         rowSelection="all"
         filterItems={!viewAll && filterItems}
         viewAll={viewAll}
-        initialSortBy={[{ id: "createdAt", desc: true }]}
+        initialSortBy={[DefaultSortBy]}
         emptyState={makeEmptyState(createDialogState)}
         selectAction={makeSelectAction("Delete", deleteDialogState.onOn)}
         createAction={makeCreateAction("Create stream", createDialogState.onOn)}

--- a/packages/www/components/Dashboard/Table/index.tsx
+++ b/packages/www/components/Dashboard/Table/index.tsx
@@ -38,7 +38,18 @@ import Spinner from "components/Dashboard/Spinner";
 import { ArrowRightIcon } from "@radix-ui/react-icons";
 import TableHeader from "./components/TableHeader";
 
-type Sort<T extends Record<string, unknown>> = { id: keyof T; desc: boolean };
+type Sort<T extends Record<string, unknown>> = {
+  id: keyof T;
+  desc: boolean;
+};
+
+export const DefaultSortBy: Sort<Record<string, unknown>> = {
+  id: "createdAt",
+  desc: true,
+};
+
+export const sortByToString = (sortBy: Sort<Record<string, unknown>>) =>
+  `${sortBy.id}-${sortBy.desc}`;
 
 type StateSetter<T extends Record<string, unknown>> = {
   setOrder: Dispatch<SetStateAction<string>>;
@@ -225,7 +236,7 @@ export const DataTableComponent = <T extends Record<string, unknown>>({
   }, [selectedFlatRows, stateSetter.setSelectedRows]);
 
   useEffect(() => {
-    const order = sortBy?.map((o) => `${o.id}-${o.desc}`).join(",") ?? "";
+    const order = sortBy?.map((o) => sortByToString(o)).join(",") ?? "";
     stateSetter.setOrder(order);
   }, [sortBy, stateSetter.setOrder]);
 
@@ -515,11 +526,13 @@ export const DataTableComponent = <T extends Record<string, unknown>>({
 export const useTableState = <T extends Record<string, unknown>>({
   tableId,
   pageSize = 20,
+  initialOrder,
 }: {
   tableId: string;
   pageSize?: number;
+  initialOrder?: string;
 }) => {
-  const [order, setOrder] = useState("");
+  const [order, setOrder] = useState(initialOrder || "");
   const [cursor, setCursor] = useState("");
   const [prevCursors, setPrevCursors] = useState<string[]>([]);
   const [nextCursor, setNextCursor] = useState("default");

--- a/packages/www/components/Dashboard/WebhooksTable/index.tsx
+++ b/packages/www/components/Dashboard/WebhooksTable/index.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useMemo } from "react";
 import { useApi } from "../../../hooks";
-import Table, { Fetcher, useTableState } from "components/Dashboard/Table";
+import Table, {
+  DefaultSortBy,
+  Fetcher,
+  sortByToString,
+  useTableState,
+} from "components/Dashboard/Table";
 import { Box } from "@livepeer/design-system";
 import { useToggleState } from "hooks/use-toggle-state";
 import CreateDialog, {
@@ -24,6 +29,7 @@ const WebhooksTable = ({ title = "Webhooks" }: { title?: string }) => {
   const createDialogState = useToggleState();
   const { state, stateSetter } = useTableState<WebhooksTableData>({
     tableId: "webhooksTable",
+    initialOrder: sortByToString(DefaultSortBy),
   });
 
   const columns = useMemo(makeColumns, []);
@@ -57,6 +63,7 @@ const WebhooksTable = ({ title = "Webhooks" }: { title?: string }) => {
         state={state}
         stateSetter={stateSetter}
         rowSelection="all"
+        initialSortBy={[DefaultSortBy]}
         emptyState={makeEmptyState(createDialogState)}
         selectAction={makeSelectAction("Delete", deleteDialogState.onOn)}
         createAction={makeCreateAction(


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Removed duplicated initial fetcher calls in Tables

**Specific updates (required)**
- Small refactor to pass the default `initialSortBy` when initialising the table and its state. Now since the state does not change during the first rendering of the table, there is only one request to the api, not two as before
- Applied the same changes to all the tables in studio

**Does this pull request close any open issues?**
Fixes #1559
