### PR TITLE
api: Expose UCAN id

### DIFF
--- a/packages/api/src/controllers/did.js
+++ b/packages/api/src/controllers/did.js
@@ -2,8 +2,14 @@ import Router from "express/lib/router";
 
 const app = Router();
 
-app.get("/", (_, res) => {
-  res.json({ did: process.env.UCAN_DID || "" });
+app.get("/", (req, res) => {
+  const did = req.config.did;
+  if (did) {
+    res.json({ did });
+  } else {
+    res.status(501);
+    res.json({ errors: ["DID key not configured"] });
+  }
 });
 
 export default app;

--- a/packages/api/src/controllers/did.js
+++ b/packages/api/src/controllers/did.js
@@ -1,0 +1,9 @@
+import Router from "express/lib/router";
+
+const app = Router();
+
+app.get("/", (_, res) => {
+  res.json({ did: process.env.UCAN_DID || "" });
+});
+
+export default app;

--- a/packages/api/src/controllers/index.ts
+++ b/packages/api/src/controllers/index.ts
@@ -22,6 +22,7 @@ import region from "./region";
 import session from "./session";
 import cdnData from "./cdn-data";
 import playback from "./playback";
+import did from "./did";
 
 // Annoying but necessary to get the routing correct
 export default {
@@ -49,4 +50,5 @@ export default {
   session,
   "cdn-data": cdnData,
   playback,
+  did,
 };

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -352,6 +352,10 @@ export default function parseCli(argv?: string | readonly string[]) {
         type: "boolean",
         alias: "j",
       },
+      did: {
+        describe: "Livepeer DID key",
+        type: "string",
+      },
     })
     .usage(
       `


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Add `/api/did` endpoint to expose Livepeer's DID key got from UCAN_DID` env variable

**Does this pull request close any open issues?**

Fixes https://github.com/livepeer/catalyst/issues/364
