### PR TITLE
Add convertion from base64 to base64url

### DIFF
--- a/packages/api/src/controllers/helpers.test.ts
+++ b/packages/api/src/controllers/helpers.test.ts
@@ -190,11 +190,11 @@ describe("convert w3 storage to object store URL", () => {
       type: "web3.storage",
       credentials: {
         proof:
-          "EaJlcm9vdHOAZ3ZlcnNpb24BmgIBcRIg2uxHpcPYSWNtifMKFkPC7IEDvFDCxCd3ADViv0coV7SnYXNYRO2hA0AnblHEW38s3lSlcwaDjPn",
+          "EaJlcm9vdHOAZ3ZlcnNpb24BmgIBcRIg2uxHpcPYSWNtifMKFkPC7IEDvFDCxCd3ADViv0coV7SnYXNYRO2hA0AnblHEW38s3lSlcwaDjPn+/",
       },
     };
     expect(toWeb3StorageUrl(storageObj)).toBe(
-      "w3s://EaJlcm9vdHOAZ3ZlcnNpb24BmgIBcRIg2uxHpcPYSWNtifMKFkPC7IEDvFDCxCd3ADViv0coV7SnYXNYRO2hA0AnblHEW38s3lSlcwaDjPn@/"
+      "w3s://EaJlcm9vdHOAZ3ZlcnNpb24BmgIBcRIg2uxHpcPYSWNtifMKFkPC7IEDvFDCxCd3ADViv0coV7SnYXNYRO2hA0AnblHEW38s3lSlcwaDjPn-_@/"
     );
   });
 

--- a/packages/api/src/controllers/helpers.test.ts
+++ b/packages/api/src/controllers/helpers.test.ts
@@ -185,12 +185,25 @@ describe("controllers/helpers", () => {
 });
 
 describe("convert w3 storage to object store URL", () => {
-  it("should convert correct object", () => {
+  it("should convert correct object with base64-encoded proof", () => {
     const storageObj = {
       type: "web3.storage",
       credentials: {
         proof:
           "EaJlcm9vdHOAZ3ZlcnNpb24BmgIBcRIg2uxHpcPYSWNtifMKFkPC7IEDvFDCxCd3ADViv0coV7SnYXNYRO2hA0AnblHEW38s3lSlcwaDjPn+/",
+      },
+    };
+    expect(toWeb3StorageUrl(storageObj)).toBe(
+      "w3s://EaJlcm9vdHOAZ3ZlcnNpb24BmgIBcRIg2uxHpcPYSWNtifMKFkPC7IEDvFDCxCd3ADViv0coV7SnYXNYRO2hA0AnblHEW38s3lSlcwaDjPn-_@/"
+    );
+  });
+
+  it("should convert correct object with base64url-encoded proof", () => {
+    const storageObj = {
+      type: "web3.storage",
+      credentials: {
+        proof:
+          "EaJlcm9vdHOAZ3ZlcnNpb24BmgIBcRIg2uxHpcPYSWNtifMKFkPC7IEDvFDCxCd3ADViv0coV7SnYXNYRO2hA0AnblHEW38s3lSlcwaDjPn-_",
       },
     };
     expect(toWeb3StorageUrl(storageObj)).toBe(

--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -10,6 +10,7 @@ import { createHmac } from "crypto";
 import { S3Client, PutObjectCommand, S3ClientConfig } from "@aws-sdk/client-s3";
 import { S3StoreOptions as TusS3Opts } from "tus-node-server";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import base64url from "base64url";
 
 import { WithID } from "../store/types";
 import { ObjectStore, Task } from "../schema/types";
@@ -159,7 +160,7 @@ export function toWeb3StorageUrl(storage: Web3StoreStorage): string {
   if (!storage.credentials || !storage.credentials.proof) {
     throw new Error("undefined property 'credentials.proof'");
   }
-  return `w3s://${storage.credentials.proof}@/`;
+  return `w3s://${base64url.fromBase64(storage.credentials.proof)}@/`;
 }
 
 export function toObjectStoreUrl(storage: ObjectStoreStorage): string {


### PR DESCRIPTION
Convert the web3.storage proof from base64 to base64url

I believe that we should accept the base64 format from the user because it's more-widely used, plus the user does not need to be aware that internally we use some `w3://` URL.