### PR TITLE
api: Allow providing decryption keys to decrypt uploaded assets

### DIFF
--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -599,6 +599,9 @@ const uploadWithUrlHandler: RequestHandler = async (req, res) => {
       errors: [`Must provide a "url" field for the asset contents`],
     });
   }
+  if (encryption) {
+    await ensureExperimentSubject("vod-encrypted-input", req.user.id);
+  }
 
   const id = uuid();
   const playbackId = await generateUniquePlaybackId(id);
@@ -735,6 +738,10 @@ app.post(
 
     const { vodObjectStoreId, jwtSecret, jwtAudience } = req.config;
     const { encryption } = req.body as NewAssetPayload;
+    if (encryption) {
+      await ensureExperimentSubject("vod-encrypted-input", req.user.id);
+    }
+
     let asset = await validateAssetPayload(
       id,
       playbackId,

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -612,7 +612,7 @@ const uploadWithUrlHandler: RequestHandler = async (req, res) => {
     Date.now(),
     defaultObjectStoreId(req),
     req.body,
-    { type: "url", url, encryption }
+    { type: "url", url, encryption: { ...encryption, key: "***" } }
   );
   const dupAsset = await db.asset.findDuplicateUrlUpload(url, req.user.id);
   if (dupAsset) {
@@ -749,7 +749,7 @@ app.post(
       Date.now(),
       defaultObjectStoreId(req),
       req.body,
-      { type: "directUpload", encryption }
+      { type: "directUpload", encryption: { ...encryption, key: "***" } }
     );
 
     const { uploadToken, downloadUrl } = await genUploadUrl(

--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -143,19 +143,6 @@ export interface Web3StoreStorage {
   };
 }
 
-export function taskWithoutCredentials(task: WithID<Task>): WithID<Task> {
-  if (task?.type !== "transcode-file") {
-    return task;
-  }
-  task.params["transcode-file"].input.url = deleteCredentials(
-    task.params["transcode-file"].input.url
-  );
-  task.params["transcode-file"].storage.url = deleteCredentials(
-    task.params["transcode-file"].storage.url
-  );
-  return task;
-}
-
 export function toWeb3StorageUrl(storage: Web3StoreStorage): string {
   if (!storage.credentials || !storage.credentials.proof) {
     throw new Error("undefined property 'credentials.proof'");

--- a/packages/api/src/controllers/task.ts
+++ b/packages/api/src/controllers/task.ts
@@ -109,10 +109,10 @@ export const cleanTaskResponses = () =>
   mung.jsonAsync(async function cleanWriteOnlyResponses(data, req) {
     const toExternalTask = async (t: WithID<Task>) => {
       t = taskWithIpfsUrls(req.config.ipfsGatewayUrl, t);
-      t.params = taskParamsWithoutCredentials(t.type, t.params);
       if (req.user.admin) {
         return t;
       }
+      t.params = taskParamsWithoutCredentials(t.type, t.params);
       return db.task.cleanWriteOnlyResponse(t);
     };
 

--- a/packages/api/src/controllers/transcode.ts
+++ b/packages/api/src/controllers/transcode.ts
@@ -4,12 +4,14 @@ import { TranscodePayload } from "../schema/types";
 import {
   toObjectStoreUrl,
   ObjectStoreStorage,
-  taskWithoutCredentials,
   toWeb3StorageUrl,
 } from "./helpers";
 import { ensureQueueCapacity } from "../task/scheduler";
+import { cleanTaskResponses } from "./task";
 
 const app = Router();
+
+app.use(cleanTaskResponses());
 
 app.post(
   "/",
@@ -53,7 +55,7 @@ app.post(
       null,
       req.user.id
     );
-    res.json(taskWithoutCredentials(task));
+    res.json(task);
   }
 );
 

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1449,6 +1449,7 @@ components:
               description:
                 Encryption algorithm used to encrypt the asset, defaults to
                 AES-256 CBC mode.
+              enum: [aes-256-cbc]
               default: aes-256-cbc
         catalystPipelineStrategy:
           $ref: "#/components/schemas/task/properties/params/properties/upload/properties/catalystPipelineStrategy"

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1126,12 +1126,16 @@ components:
                   type: string
                   index: true
                   description: URL from which the asset was uploaded
+                encryption:
+                  $ref: "#/components/schemas/new-asset-payload/properties/encryption"
             - additionalProperties: false
               required: [type]
               properties:
                 type:
                   type: string
                   enum: [directUpload]
+                encryption:
+                  $ref: "#/components/schemas/new-asset-payload/properties/encryption"
             - additionalProperties: false
               required: [type, sessionId]
               properties:
@@ -1427,6 +1431,24 @@ components:
             URL where the asset contents can be retrieved. Only valid for the
             import task endpoint.
           example: https://s3.amazonaws.com/my-bucket/path/filename.mp4
+        encryption:
+          type: object
+          required: [key]
+          properties:
+            key:
+              type: string
+              writeOnly: true
+              description:
+                Encryption key used to encrypt the asset encoded in base16. Only
+                writable in the upload asset endpoints and cannot be retrieved
+                back.
+              example: 9b560b28b85378a5004117539196ab24e21bbd75b0e9eb1a8bc7c5fd80dc5b57
+            algorithm:
+              type: string
+              description:
+                Encryption algorithm used to encrypt the asset, defaults to
+                AES-256 CBC mode.
+              default: aes-256-cbc
         catalystPipelineStrategy:
           $ref: "#/components/schemas/task/properties/params/properties/upload/properties/catalystPipelineStrategy"
 
@@ -1670,6 +1692,8 @@ components:
                   type: string
                   description: URL of the asset to "upload"
                   example: https://cdn.livepeer.com/ABC123/filename.mp4
+                encryption:
+                  $ref: "#/components/schemas/new-asset-payload/properties/encryption"
                 recordedSessionId:
                   type: string
                   description:

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1443,7 +1443,7 @@ components:
                 Encryption key used to encrypt the asset encoded in base16. Only
                 writable in the upload asset endpoints and cannot be retrieved
                 back.
-              example: 9b560b28b85378a5004117539196ab24e21bbd75b0e9eb1a8bc7c5fd80dc5b57
+              example: 74686973206d65616e73206e6f7468696e672120676f2061776179206672656e
             algorithm:
               type: string
               description:

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1433,6 +1433,7 @@ components:
           example: https://s3.amazonaws.com/my-bucket/path/filename.mp4
         encryption:
           type: object
+          additionalProperties: false
           required: [key]
           properties:
             key:

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1447,10 +1447,10 @@ components:
             algorithm:
               type: string
               description:
-                Encryption algorithm used to encrypt the asset, defaults to
-                AES-256 CBC mode.
-              enum: [aes-256-cbc]
-              default: aes-256-cbc
+                Encryption algorithm used to encrypt the asset, defaults to AES
+                in CBC block cipher mode.
+              enum: [aes-cbc]
+              default: aes-cbc
         catalystPipelineStrategy:
           $ref: "#/components/schemas/task/properties/params/properties/upload/properties/catalystPipelineStrategy"
 

--- a/packages/api/src/store/asset-table.ts
+++ b/packages/api/src/store/asset-table.ts
@@ -72,6 +72,7 @@ export default class AssetTable extends Table<WithID<Asset>> {
     const query = [
       sql`asset.data->'source'->>'type' = 'url'`,
       sql`asset.data->'source'->>'url' = ${url}`,
+      sql`asset.data->'source'->>'encryption' IS NULL`,
       sql`asset.data->>'deleted' IS NULL`,
       sql`asset.data->'status'->>'phase' = 'ready'`,
     ];

--- a/packages/api/src/store/table.ts
+++ b/packages/api/src/store/table.ts
@@ -347,7 +347,10 @@ export default class Table<T extends DBObject> {
 
   // on startup: auto-create indices if they don't exist
   async ensureIndex(propName: string, prop: FieldSpec, parents: string[] = []) {
-    if (process.env.NODE_ENV !== "test" && this.name !== "asset") {
+    if (
+      process.env.NODE_ENV !== "test" &&
+      !["asset", "experiment"].includes(this.name)
+    ) {
       // avoid creating indexes in production right now...
       return;
     }

--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -9,10 +9,10 @@ import { taskOutputToIpfsStorage } from "../store/asset-table";
 import { RoutingKey } from "../store/queue";
 import { EventKey } from "../store/webhook-table";
 import { sleep } from "../util";
-import sql, { SQLStatement } from "sql-template-strings";
-import { deleteCredentials } from "../controllers/helpers";
+import sql from "sql-template-strings";
 import { TooManyRequestsError } from "../store/errors";
 import { CliArgs } from "../parse-cli";
+import { taskParamsWithoutCredentials } from "../controllers/task";
 
 const taskInfo = (task: Task): messages.TaskInfo => ({
   id: task.id,
@@ -388,39 +388,17 @@ export class TaskScheduler {
     updates: Pick<Task, "status" | "output" | "params">
   ): Pick<Task, "status" | "output" | "params"> {
     // We should remove this at some point and do not store credentials at all
-    const result = updates;
     const isTerminal =
       updates?.status.phase === "completed" ||
       updates?.status.phase === "failed";
     if (!isTerminal) {
-      return result;
+      return updates;
     }
 
-    switch (task.type) {
-      case "transcode-file":
-        result.params = task.params;
-        result.params["transcode-file"].input.url = deleteCredentials(
-          updates.params["transcode-file"].input.url
-        );
-        result.params["transcode-file"].storage.url = deleteCredentials(
-          updates.params["transcode-file"].storage.url
-        );
-        break;
-      case "upload":
-        const encryption = task.params.upload?.encryption;
-        if (!encryption) {
-          break;
-        }
-        result.params = {
-          ...task.params,
-          upload: {
-            ...task.params.upload,
-            encryption: { ...encryption, key: "***" },
-          },
-        };
-        break;
-    }
-    return result;
+    return {
+      ...updates,
+      params: taskParamsWithoutCredentials(task.type, task.params),
+    };
   }
 
   async deleteAsset(asset: string | Asset) {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This is in order to support uploading files encrypted with Lit directly, normally stored on Bundlr.

Since the focus is on Lot, we also have an `algorithm` field which can only be AES-256-CBC for now
which is what's used for Lit. It is surprisingly cumbersome to do crypto in Go tho, so adding more 
algorithms here might not be as cheap as just calling a different function.

**Specific updates (required)**
 - Add field in task, asset and new asset payload
 - Pass the field around internally and omit it from responses
 - Make sure we delete the field in the end of a task as well
 - Improve credential cleanup logic

**How did you test each of these updates (required)**
Send lit and manually encrypted files to check it worked.

**Does this pull request close any open issues?**
Yes of a bundlr integration. Missing explicit issue.

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
