### PR TITLE
Revert 'return orchestrators pending activation for Confluence upgrade'

### DIFF
--- a/packages/api/src/middleware/subgraph.ts
+++ b/packages/api/src/middleware/subgraph.ts
@@ -25,37 +25,18 @@ export default function subgraphMiddleware({
   let cachedResp: Array<OrchestratorNodeAddress> = [];
   let lastCachedRespUpdate = 0;
 
-  const getCurrentRound = async () => {
-    const res = await fetchWithTimeout(subgraphUrl, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-      },
-      body: JSON.stringify({
-        query: `{ protocol(id: "0") { lastInitializedRound { id } } }`,
-      }),
-      timeout: SUBGRAPH_TIMEOUT,
-    });
-
-    return +(await res.json()).data.protocol.lastInitializedRound.id;
-  };
-
   const getOrchestrators = async () => {
+    const query = `
+      {
+        transcoders(where: { active: true }) {
+          id
+          serviceURI
+        }
+      }
+    `;
+
     if (lastCachedRespUpdate + CACHE_REFRESH_INTERVAL < Date.now()) {
       try {
-        const currentRound = await getCurrentRound();
-        const query = `
-          {
-            transcoders(where: { activationRound_lte: "${
-              currentRound + 1
-            }", deactivationRound_gt: "${currentRound}" }) {
-              id
-              serviceURI
-            }
-          }
-        `;
-
         const res = await fetchWithTimeout(subgraphUrl, {
           method: "POST",
           headers: {


### PR DESCRIPTION
After the Arbitrum migration, we should move to the logic as before, meaning that only active Os can accept transcoding.

Related Discord discussion: https://discord.com/channels/423160867534929930/750796877762527262/1074970658544558092

This PR is an exact revert of this: https://github.com/livepeer/studio/pull/911

Tested locally.