### PR TITLE
api: Improve Live 2 VOD asset names

### DIFF
--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -510,6 +510,15 @@ export default class WebhookCannon {
     const id = uuid();
     const playbackId = await generateUniquePlaybackId(sessionId);
 
+    const session = await this.db.session.get(sessionId);
+    if (!session) {
+      throw new Error("session not found");
+    }
+
+    // trim the second precision from the time string
+    var startedAt = new Date(session.createdAt).toISOString();
+    startedAt = startedAt.substring(0, startedAt.length - 8) + "Z";
+
     const createdAt = Date.now();
     const asset = await createAsset(
       {
@@ -519,7 +528,7 @@ export default class WebhookCannon {
         createdAt,
         source: { type: "recording", sessionId },
         status: { phase: "waiting", updatedAt: createdAt },
-        name: `live-to-vod-${sessionId}`,
+        name: `live-${startedAt}`,
         objectStoreId: this.vodObjectStoreId,
       },
       this.queue

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -510,7 +510,7 @@ export default class WebhookCannon {
     const id = uuid();
     const playbackId = await generateUniquePlaybackId(sessionId);
 
-    const session = await this.db.session.get(sessionId);
+    const session = await this.db.stream.get(sessionId);
     if (!session) {
       throw new Error("session not found");
     }

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -519,15 +519,14 @@ export default class WebhookCannon {
     var startedAt = new Date(session.createdAt).toISOString();
     startedAt = startedAt.substring(0, startedAt.length - 8) + "Z";
 
-    const createdAt = Date.now();
     const asset = await createAsset(
       {
         id,
         playbackId,
         userId,
-        createdAt,
+        createdAt: session.createdAt,
         source: { type: "recording", sessionId },
-        status: { phase: "waiting", updatedAt: createdAt },
+        status: { phase: "waiting", updatedAt: Date.now() },
         name: `live-${startedAt}`,
         objectStoreId: this.vodObjectStoreId,
       },


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Improves the name we give to "live 2 vod" assets so they are more human friendly
as initial names of the assets. 

Recording assets like `live-to-vod-be5615c6-0687-4943-97ed-68e5bcd391e9`
will become`live-2023-02-16T23:36Z` 😌 
and also fit on the asset list column 🙏  
<img width="528" alt="Screenshot 2023-02-17 at 11 20 20" src="https://user-images.githubusercontent.com/1613383/219680198-6b865b94-a615-4c85-bee8-ce93ff1d4b48.png">


**Specific updates (required)**
Update the `name` and `createdAt` from the created assets to better reflect their origin.

**How did you test each of these updates (required)**
Staging!

**Does this pull request close any open issues?**
No. 

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
