### PR TITLE
www: Fix asset table source column for recordings

### DIFF
--- a/packages/www/components/Dashboard/AssetsTable/helpers.tsx
+++ b/packages/www/components/Dashboard/AssetsTable/helpers.tsx
@@ -110,7 +110,9 @@ export const rowsPageFromState = async (
 
   const rows: AssetsTableData[] = assets.map(
     (asset: ApiAsset): AssetsTableData => {
-      const isLiveStream = hasLivestreamImportTask(tasks, asset.id);
+      const isLiveStream = asset.source?.type
+        ? asset.source.type === "recording"
+        : hasLivestreamImportTask(tasks, asset.id);
       const isStatusFailed = asset.status?.phase === "failed";
       const { errorMessage } = asset.status;
 

--- a/packages/www/components/Dashboard/AssetsTable/helpers.tsx
+++ b/packages/www/components/Dashboard/AssetsTable/helpers.tsx
@@ -78,7 +78,7 @@ const hasLivestreamImportTask = (tasks: Task[], assetId: string) => {
     const sourceUrl = get(task, "params.import.url");
     if (!sourceUrl) return false;
 
-    const sourceHost = sourceUrl && new URL(sourceUrl).host;
+    const sourceHost = new URL(sourceUrl).host;
     return liveStreamHosts.includes(sourceHost);
   } catch (err) {
     console.error("Error in checking import tasks: ", err);

--- a/packages/www/components/Dashboard/AssetsTable/helpers.tsx
+++ b/packages/www/components/Dashboard/AssetsTable/helpers.tsx
@@ -71,6 +71,21 @@ export const makeColumns = () => [
   },
 ];
 
+const hasLivestreamImportTask = (tasks: Task[], assetId: string) => {
+  try {
+    const task: Task =
+      tasks && tasks.find((task: Task) => task.outputAssetId === assetId);
+    const sourceUrl = get(task, "params.import.url");
+    if (!sourceUrl) return false;
+
+    const sourceHost = sourceUrl && new URL(sourceUrl).host;
+    return liveStreamHosts.includes(sourceHost);
+  } catch (err) {
+    console.error("Error in checking import tasks: ", err);
+    return false;
+  }
+};
+
 export const rowsPageFromState = async (
   state: State<AssetsTableData>,
   userId: string,
@@ -95,12 +110,7 @@ export const rowsPageFromState = async (
 
   const rows: AssetsTableData[] = assets.map(
     (asset: ApiAsset): AssetsTableData => {
-      const source: Task =
-        tasks && tasks.find((task: Task) => task.outputAssetId === asset.id);
-      const sourceUrl = get(source, "params.import.url");
-      const sourceHost = sourceUrl && new URL(sourceUrl).host;
-      const isLiveStream = !!sourceUrl && liveStreamHosts.includes(sourceHost);
-
+      const isLiveStream = hasLivestreamImportTask(tasks, asset.id);
       const isStatusFailed = asset.status?.phase === "failed";
       const { errorMessage } = asset.status;
 


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
We have a new field in assets that should be used to detect the source of an asset.
The old fix is likely broken because we changed our recording playback domains, and
it was never that reliable anyway. Still keep it for now for historical assets anyway.

**Specific updates (required)**
 - Create a helper function for the logic of checking import tasks
 - Give preference to checking asset's source field instead

**How did you test each of these updates (required)**
Check dashboard page.

**Does this pull request close any open issues?**
No.

**Screenshot**
<img width="1234" alt="Screenshot 2023-02-17 at 17 08 12" src="https://user-images.githubusercontent.com/1613383/219783203-5f57065c-1b9f-40a9-b7a5-2ecab9158203.png">
(don't worry it's failed, the point is only the right value for source column)

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
