### PR TITLE
playback: return first created Asset by CID both in storage & import

### DIFF
--- a/packages/api/src/controllers/playback.ts
+++ b/packages/api/src/controllers/playback.ts
@@ -78,7 +78,6 @@ const getAssetPlaybackUrl = async (
   const asset =
     (await db.asset.getByPlaybackId(id)) ??
     (await db.asset.getByIpfsCid(id, user)) ??
-    (await db.asset.getBySourceURL("ipfs://" + id, user)) ??
     (await db.asset.getBySourceURL("ar://" + id, user));
   if (!asset || asset.deleted) {
     return null;


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

The playback API was looking for CIDs both into the storage field and into the source import URL, in this order.
However, this was returning the first created asset with storage.ipfs.cid, as that was the first check.

With this pr, they are both checked and compared to retrieve the asset actually created first in both cases.

<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional)**

<!-- Drag some screenshots here, if applicable -->

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
