### PR TITLE
api: Add scheduledAt field to tasks to allow proper time-to-ready metric

### DIFF
--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -914,7 +914,7 @@ const getPendingAssetAndTask = async (playbackId: string) => {
   });
   if (!asset) {
     throw new NotFoundError(`asset not found`);
-  } else if (asset.status.phase !== "waiting") {
+  } else if (asset.status.phase !== "uploading") {
     throw new UnprocessableEntityError(`asset has already been uploaded`);
   }
 

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -357,7 +357,7 @@ async function reconcileAssetStorage(
     if (!task) {
       await ensureQueueCapacity(config, asset.userId);
 
-      task = await taskScheduler.spawnAndScheduleTask(
+      task = await taskScheduler.createAndScheduleTask(
         "export",
         { export: { ipfs: newSpec } },
         asset
@@ -601,7 +601,7 @@ app.post(
     await ensureQueueCapacity(req.config, req.user.id);
 
     const params = req.body as ExportTaskParams;
-    const task = await req.taskScheduler.spawnAndScheduleTask(
+    const task = await req.taskScheduler.createAndScheduleTask(
       "export",
       { export: params },
       asset
@@ -666,7 +666,7 @@ const uploadWithUrlHandler: RequestHandler = async (req, res) => {
   await ensureQueueCapacity(req.config, req.user.id);
 
   const asset = await createAsset(newAsset, req.queue);
-  const task = await req.taskScheduler.spawnAndScheduleTask(
+  const task = await req.taskScheduler.createAndScheduleTask(
     "upload",
     {
       upload: {
@@ -736,7 +736,7 @@ const transcodeAssetHandler: RequestHandler = async (req, res) => {
   await ensureQueueCapacity(req.config, req.user.id);
   outputAsset = await createAsset(outputAsset, req.queue);
 
-  const task = await req.taskScheduler.spawnAndScheduleTask(
+  const task = await req.taskScheduler.createAndScheduleTask(
     "transcode",
     {
       transcode: {
@@ -813,7 +813,7 @@ app.post(
     await ensureQueueCapacity(req.config, req.user.id);
     asset = await createAsset(asset, req.queue);
 
-    const task = await req.taskScheduler.spawnTask(
+    const task = await req.taskScheduler.createTask(
       "upload",
       {
         upload: {

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -357,7 +357,7 @@ async function reconcileAssetStorage(
     if (!task) {
       await ensureQueueCapacity(config, asset.userId);
 
-      task = await taskScheduler.scheduleTask(
+      task = await taskScheduler.spawnAndScheduleTask(
         "export",
         { export: { ipfs: newSpec } },
         asset
@@ -601,7 +601,7 @@ app.post(
     await ensureQueueCapacity(req.config, req.user.id);
 
     const params = req.body as ExportTaskParams;
-    const task = await req.taskScheduler.scheduleTask(
+    const task = await req.taskScheduler.spawnAndScheduleTask(
       "export",
       { export: params },
       asset
@@ -666,7 +666,7 @@ const uploadWithUrlHandler: RequestHandler = async (req, res) => {
   await ensureQueueCapacity(req.config, req.user.id);
 
   const asset = await createAsset(newAsset, req.queue);
-  const task = await req.taskScheduler.scheduleTask(
+  const task = await req.taskScheduler.spawnAndScheduleTask(
     "upload",
     {
       upload: {
@@ -736,7 +736,7 @@ const transcodeAssetHandler: RequestHandler = async (req, res) => {
   await ensureQueueCapacity(req.config, req.user.id);
   outputAsset = await createAsset(outputAsset, req.queue);
 
-  const task = await req.taskScheduler.scheduleTask(
+  const task = await req.taskScheduler.spawnAndScheduleTask(
     "transcode",
     {
       transcode: {
@@ -893,7 +893,7 @@ const onTusUploadComplete =
 const onUploadComplete = async (playbackId: string) => {
   try {
     const { task, asset } = await getPendingAssetAndTask(playbackId);
-    await taskScheduler.enqueueTask(task);
+    await taskScheduler.scheduleTask(task);
     await db.asset.update(asset.id, {
       status: {
         phase: "waiting",

--- a/packages/api/src/controllers/transcode.ts
+++ b/packages/api/src/controllers/transcode.ts
@@ -36,7 +36,7 @@ app.post(
         ? toWeb3StorageUrl(params.storage)
         : toObjectStoreUrl(params.storage);
 
-    const task = await req.taskScheduler.scheduleTask(
+    const task = await req.taskScheduler.spawnAndScheduleTask(
       "transcode-file",
       {
         ["transcode-file"]: {

--- a/packages/api/src/controllers/transcode.ts
+++ b/packages/api/src/controllers/transcode.ts
@@ -36,7 +36,7 @@ app.post(
         ? toWeb3StorageUrl(params.storage)
         : toObjectStoreUrl(params.storage);
 
-    const task = await req.taskScheduler.spawnAndScheduleTask(
+    const task = await req.taskScheduler.createAndScheduleTask(
       "transcode-file",
       {
         ["transcode-file"]: {

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1686,7 +1686,7 @@ components:
           type: number
           readOnly: true
           description: |
-            Timestamp (in milliseconds) at which the task was scheduled or
+            Timestamp (in milliseconds) at which the task was scheduled for
             execution (e.g. after file upload finished).
           example: 1587667174725
         deleted:

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1232,6 +1232,7 @@ components:
               type: string
               description: Phase of the asset
               enum:
+                - uploading
                 - waiting
                 - processing
                 - ready

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1682,6 +1682,13 @@ components:
           readOnly: true
           description: Timestamp (in milliseconds) at which task was created
           example: 1587667174725
+        scheduledAt:
+          type: number
+          readOnly: true
+          description: |
+            Timestamp (in milliseconds) at which the task was scheduled or
+            execution (e.g. after file upload finished).
+          example: 1587667174725
         deleted:
           type: boolean
           description: Set to true when the task is deleted

--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -250,7 +250,7 @@ export class TaskScheduler {
     }
   }
 
-  async scheduleTask(
+  async spawnAndScheduleTask(
     type: Task["type"],
     params: Task["params"],
     inputAsset?: Asset,
@@ -264,7 +264,7 @@ export class TaskScheduler {
       outputAsset,
       userId
     );
-    await this.enqueueTask(task);
+    await this.scheduleTask(task);
     return task;
   }
 
@@ -301,7 +301,7 @@ export class TaskScheduler {
     return task;
   }
 
-  async enqueueTask(task: WithID<Task>, retries?: number) {
+  async scheduleTask(task: WithID<Task>, retries?: number) {
     const timestamp = Date.now();
     await this.updateTask(task, {
       scheduledAt: retries ? undefined : timestamp,
@@ -341,7 +341,7 @@ export class TaskScheduler {
 
     task = await this.updateTask(task, { status });
     await sleep(retries * TASK_RETRY_BASE_DELAY);
-    await this.enqueueTask(task, retries);
+    await this.scheduleTask(task, retries);
   }
 
   async updateTask(

--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -250,14 +250,14 @@ export class TaskScheduler {
     }
   }
 
-  async spawnAndScheduleTask(
+  async createAndScheduleTask(
     type: Task["type"],
     params: Task["params"],
     inputAsset?: Asset,
     outputAsset?: Asset,
     userId?: string
   ) {
-    const task = await this.spawnTask(
+    const task = await this.createTask(
       type,
       params,
       inputAsset,
@@ -268,7 +268,7 @@ export class TaskScheduler {
     return task;
   }
 
-  async spawnTask(
+  async createTask(
     type: Task["type"],
     params: Task["params"],
     inputAsset?: Asset,

--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -304,6 +304,7 @@ export class TaskScheduler {
   async scheduleTask(task: WithID<Task>, retries = 0) {
     const timestamp = Date.now();
     await this.updateTask(task, {
+      // only update scheduledAt on the first schedule (retries == 0)
       scheduledAt: retries ? undefined : timestamp,
       status: {
         phase: "waiting",

--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -301,7 +301,7 @@ export class TaskScheduler {
     return task;
   }
 
-  async scheduleTask(task: WithID<Task>, retries?: number) {
+  async scheduleTask(task: WithID<Task>, retries = 0) {
     const timestamp = Date.now();
     await this.updateTask(task, {
       scheduledAt: retries ? undefined : timestamp,

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -533,7 +533,7 @@ export default class WebhookCannon {
       this.queue
     );
     // we can't rate limit this task because it's not a user action
-    await taskScheduler.spawnAndScheduleTask(
+    await taskScheduler.createAndScheduleTask(
       "import",
       {
         import: {

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -533,7 +533,7 @@ export default class WebhookCannon {
       this.queue
     );
     // we can't rate limit this task because it's not a user action
-    await taskScheduler.scheduleTask(
+    await taskScheduler.spawnAndScheduleTask(
       "import",
       {
         import: {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This adds a `scheduledAt` field to tasks so we can tell how long an asset
actually took to upload then how long it actually took to be processed.

upload time = task->scheduledAt - task->createdAt 
time to ready = task->status->updatedAt - task->scheduledAt

On the way, also added an `uploading` phase to assets cause we need that for too long already.

**Specific updates (required)**
 - Add `scheduledAt` field to tasks and udpate them from scheduler
 - Add `uploading` phase to assets and update it from controller
 - Rename scheduler task scheduling functions

**How did you test each of these updates (required)**
in `yarn test`s we trust

**Does this pull request close any open issues?**
Implements API-31

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
