### PR TITLE
webhook: created playback.accessControl event & return playbackPolicy in playback request

### DIFF
--- a/packages/api/src/controllers/access-control.ts
+++ b/packages/api/src/controllers/access-control.ts
@@ -1,6 +1,6 @@
 import signingKeyApp from "./signing-key";
 import { validatePost } from "../middleware";
-import { Request, Router } from "express";
+import { Router } from "express";
 import _ from "lodash";
 import { db } from "../store";
 import sql from "sql-template-strings";
@@ -10,10 +10,6 @@ import {
   BadRequestError,
 } from "../store/errors";
 import tracking from "../middleware/tracking";
-import { v4 as uuid } from "uuid";
-import { DBStream } from "../store/stream-table";
-import { Asset } from "../schema/types";
-import { WithID } from "../store/types";
 
 const app = Router();
 
@@ -53,11 +49,6 @@ app.post(
     }
 
     const playbackPolicyType = content.playbackPolicy?.type ?? "public";
-
-    if (playbackPolicyType !== "public") {
-      // TODO: move it into specific policy conditions
-      fireEventWebhook(req, content);
-    }
 
     if (playbackPolicyType === "public") {
       res.set("Cache-Control", "max-age=120,stale-while-revalidate=600");
@@ -127,20 +118,5 @@ app.post(
     }
   }
 );
-
-async function fireEventWebhook(
-  req: Request,
-  content: DBStream | WithID<Asset>
-) {
-  const queue = req.queue;
-  await queue.publishWebhook(`events.playback.accessControl`, {
-    type: "webhook_event",
-    id: uuid(),
-    timestamp: Date.now(),
-    streamId: content.id,
-    event: "playback.accessControl",
-    userId: content.userId,
-  });
-}
 
 export default app;

--- a/packages/api/src/controllers/playback.ts
+++ b/packages/api/src/controllers/playback.ts
@@ -89,16 +89,13 @@ const getAssetPlaybackUrl = async (
   }
   const playbackUrl = assetPlaybackUrl(config, ingest, asset, os);
   const staticFilesPlaybackInfo = getStaticPlaybackInfo(asset, os);
-  const inExperiment = await isExperimentSubject(
-    "lit-signing-condition",
-    asset.userId
-  );
+
   return !playbackUrl
     ? null
     : {
         staticFilesPlaybackInfo,
         playbackUrl,
-        playbackPolicy: inExperiment ? asset.playbackPolicy : null,
+        playbackPolicy: asset.playbackPolicy || null,
       };
 };
 

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -213,6 +213,7 @@ components:
               - multistream.error
               - multistream.disconnected
               - playback.user.new
+              - playback.accessControl
               - asset.created
               - asset.updated
               - asset.failed

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -106,6 +106,12 @@ export default class WebhookCannon {
   async processWebhookEvent(msg: messages.WebhookEvent): Promise<boolean> {
     const { event, streamId, sessionId, userId } = msg;
     const { mp4Url } = msg.payload ?? {};
+
+    if (event === "playback.accessControl") {
+      // Cannot fire this event as a webhook, this is specific to access control and fired there
+      return true;
+    }
+
     if (event === "recording.ready" && sessionId && mp4Url) {
       try {
         await this.handleRecordingReadyChecks(sessionId, mp4Url);

--- a/packages/www/components/Dashboard/WebhookDialogs/CreateEditDialog.tsx
+++ b/packages/www/components/Dashboard/WebhookDialogs/CreateEditDialog.tsx
@@ -48,6 +48,7 @@ const eventOptions: Webhook["events"] = [
   "task.completed",
   "task.failed",
   // "playback.user.new",
+  "playback.accessControl",
 ];
 
 export enum Action {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This pull request adds a new webhook event called playback.accessControl, which is triggered when the playback policy type is not public.
Also, return the playbackPolicy with the playback info
To be updated accordingly with #1665

**Specific updates (required)**

- Update the event list in packages/api/src/schema/schema.yaml to include the new event playback.accessControl
- Add the new event to the eventOptions array in packages/www/components/Dashboard/WebhookDialogs/CreateEditDialog.tsx
- Return playbackPolicy from playback endpoint

**How did you test each of these updates (required)**

yarn test

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional)**

<!-- Drag some screenshots here, if applicable -->

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
