### PR TITLE
Remove explicit pipeline strategy value

### DIFF
--- a/packages/api/src/controllers/transcode.ts
+++ b/packages/api/src/controllers/transcode.ts
@@ -19,7 +19,7 @@ app.post(
   validatePost("transcode-payload"),
   async (req, res) => {
     const params = req.body as TranscodePayload;
-    const { catalystPipelineStrategy = "external" } = req.user.admin
+    const { catalystPipelineStrategy = undefined } = req.user.admin
       ? params
       : {};
 


### PR DESCRIPTION
Reverts livepeer/studio#1650

We're now using mainly the mist pipeline in catalyst-api so we need to stop overriding that default to external here.