### PR TITLE
www: Round session durations instead of ceil

### DIFF
--- a/packages/www/components/Dashboard/Table/cells/duration.tsx
+++ b/packages/www/components/Dashboard/Table/cells/duration.tsx
@@ -16,11 +16,13 @@ const DurationCell = <D extends TableData>({
     return "n/a";
   }
   try {
+    const durationMins = Math.round(cell.value.sourceSegmentsDuration / 60);
+    if (!durationMins) {
+      return "<1 minute";
+    }
     const dur = intervalToDuration({
       start: new Date(0),
-      end: new Date(
-        Math.ceil(cell.value.sourceSegmentsDuration / 60) * 60 * 1000 || 0
-      ),
+      end: new Date(durationMins * 60 * 1000 || 0),
     });
     return formatDuration(dur);
   } catch (error) {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

I was testing some things out and realized that our dashboard code weirdly
ceils the duration of sessions. So I had made a 13 minute session broke up in
2 and it became 11 and 4 minutes which was very surprising and I thought I
still had a bug. They were actually 10.x and 3.x each but were all rounded up,
probably to avoid "0 minutes" duration (fixed as well).

**Specific updates (required)**
 - `Math.round` instead of `Math.ceil` for the minutes duration
 - Display durations rounded to 0 as "<1 minute" instead

**How did you test each of these updates (required)**
Check if that same stream now shows 10 and 3 minutes 😌 

**Does this pull request close any open issues?**
No just a nit

**Screenshots (optional)**

<img width="745" alt="Screenshot 2023-03-29 at 17 14 52" src="https://user-images.githubusercontent.com/1613383/228656824-60b47f96-4d4f-422a-bd11-b8fe8cae6188.png">

<img width="746" alt="Screenshot 2023-03-29 at 17 15 25" src="https://user-images.githubusercontent.com/1613383/228656914-72172921-98f3-4e14-9b37-e360eb7a0dab.png">

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
