### PR TITLE
Improve error handling on stream suspension

### DIFF
--- a/packages/api/src/controllers/mist-api.ts
+++ b/packages/api/src/controllers/mist-api.ts
@@ -15,7 +15,13 @@ function hashChallenge(authChallenge, password) {
   challenge = authChallenge;
 }
 
-export async function listActiveStreams(mistHost, mistPort, login, password) {
+export async function listActiveStreams(
+  mistHost,
+  mistPort,
+  login,
+  password,
+  isRetry = false
+) {
   try {
     const req = {
       active_streams: 1,
@@ -50,9 +56,9 @@ export async function listActiveStreams(mistHost, mistPort, login, password) {
     }
     const body = await res1.json();
     const authStatus = ((body || {}).authorize || {}).status;
-    if (authStatus === "CHALL") {
+    if (authStatus === "CHALL" && !isRetry) {
       hashChallenge(((body || {}).authorize || {}).challenge, password);
-      return await listActiveStreams(mistHost, mistPort, login, password);
+      return await listActiveStreams(mistHost, mistPort, login, password, true);
     } else if (authStatus !== "OK") {
       logger.error(`Unexpected authorize status=${authStatus}`);
       return [];
@@ -70,7 +76,8 @@ export async function terminateStream(
   mistPort,
   streamName,
   login,
-  password
+  password,
+  isRetry = false
 ) {
   try {
     const req = {
@@ -99,14 +106,15 @@ export async function terminateStream(
     }
     const body = await res1.json();
     const authStatus = ((body || {}).authorize || {}).status;
-    if (authStatus === "CHALL") {
+    if (authStatus === "CHALL" && !isRetry) {
       hashChallenge(((body || {}).authorize || {}).challenge, password);
       return await terminateStream(
         mistHost,
         mistPort,
         streamName,
         login,
-        password
+        password,
+        true
       );
     } else if (authStatus !== "OK") {
       logger.error(`Unexpected authorize status=${authStatus}`);

--- a/packages/api/src/controllers/mist-api.ts
+++ b/packages/api/src/controllers/mist-api.ts
@@ -19,13 +19,15 @@ export async function listActiveStreams(mistHost, mistPort, login, password) {
   try {
     const req = {
       active_streams: 1,
+      ...(!challengeResponse
+        ? {}
+        : {
+            authorize: {
+              username: login,
+              password: challengeResponse,
+            },
+          }),
     };
-    if (challengeResponse) {
-      req.authorize = {
-        username: login,
-        password: challengeResponse,
-      };
-    }
     const params = {
       method: "POST",
       headers: {
@@ -73,13 +75,15 @@ export async function terminateStream(
   try {
     const req = {
       nuke_stream: streamName,
+      ...(!challengeResponse
+        ? {}
+        : {
+            authorize: {
+              username: login,
+              password: challengeResponse,
+            },
+          }),
     };
-    if (challengeResponse) {
-      req.authorize = {
-        username: login,
-        password: challengeResponse,
-      };
-    }
     const params = {
       method: "POST",
       headers: {

--- a/packages/www/components/Dashboard/StreamDetails/Suspend.tsx
+++ b/packages/www/components/Dashboard/StreamDetails/Suspend.tsx
@@ -59,12 +59,15 @@ const Suspend = ({ stream, invalidate }) => {
               disabled={saving}
               onClick={async (e) => {
                 e.preventDefault();
-                setSaving(true);
-                const suspended = !stream.suspended;
-                await patchStream(stream.id, { suspended });
-                await invalidate();
-                setSaving(false);
-                setOpen(false);
+                try {
+                  setSaving(true);
+                  const suspended = !stream.suspended;
+                  await patchStream(stream.id, { suspended });
+                  await invalidate();
+                } finally {
+                  setSaving(false);
+                  setOpen(false);
+                }
               }}>
               {saving && (
                 <Spinner


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This was made as I was trying to fix the stream suspension API. In the end,
no code changes are necessary and only the mist password was configured wrong.

This will make the errors a little clearer though.

**Specific updates (required)**
 - Fix the auth challenge handling on the mist API to avoid a stack overflow on wrong password
 - Fix the suspension dialog on the dashboard to not hang on screen forever on errors

**How did you test each of these updates (required)**
Sent to staging and tested the error flows.

**Does this pull request close any open issues?**
Related to API-38

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
