### PR TITLE
www: Fix webhooks UI for access control

### DIFF
--- a/packages/www/components/Dashboard/WebhookDetails/DetailsBox.tsx
+++ b/packages/www/components/Dashboard/WebhookDetails/DetailsBox.tsx
@@ -1,6 +1,7 @@
 import { Text, Box, Badge, styled } from "@livepeer/design-system";
 import { format } from "date-fns";
 import { STATUS_CODES } from "http";
+import ClipButton from "../Clipping/ClipButton";
 
 const Cell = styled(Text, {
   py: "$2",
@@ -20,6 +21,10 @@ const DetailsBox = ({ data }) => (
       borderBottomRightRadius: 6,
       backgroundColor: "$panel",
     }}>
+    <Cell variant="gray">Webhook ID</Cell>
+    <Cell>
+      <ClipButton text={data.id} value={data.id} />
+    </Cell>
     <Cell variant="gray">URL</Cell>
     <Cell>{data.url}</Cell>
     <Cell variant="gray">Name</Cell>
@@ -59,7 +64,7 @@ const DetailsBox = ({ data }) => (
         <>
           <Cell variant="gray">Error Status Code</Cell>
           <Cell>
-            {`${data.status.lastFailure.statusCode} 
+            {`${data.status.lastFailure.statusCode}
             ${STATUS_CODES[data.status.lastFailure.statusCode]}`}
           </Cell>
         </>

--- a/packages/www/components/Dashboard/WebhookDetails/index.tsx
+++ b/packages/www/components/Dashboard/WebhookDetails/index.tsx
@@ -67,7 +67,7 @@ const WebhookDetails = ({ id, data }) => {
               width: "100%",
               ai: "flex-start",
             }}>
-            {data.url}
+            {data.name}
           </Heading>
 
           <Flex css={{ ai: "flex-end", fg: "0", fs: "0", pl: "$3" }}>

--- a/packages/www/components/Dashboard/WebhookDialogs/CreateEditDialog.tsx
+++ b/packages/www/components/Dashboard/WebhookDialogs/CreateEditDialog.tsx
@@ -30,8 +30,8 @@ const StyledCrossIcon = styled(Cross1Icon, {
 });
 
 const eventOptions: Webhook["events"] = [
+  "playback.accessControl",
   "stream.started",
-  // "stream.detection", // not yet...
   "stream.idle",
   "recording.ready",
   "recording.started",
@@ -47,8 +47,6 @@ const eventOptions: Webhook["events"] = [
   "task.updated",
   "task.completed",
   "task.failed",
-  // "playback.user.new",
-  "playback.accessControl",
 ];
 
 export enum Action {

--- a/packages/www/components/Dashboard/WebhookDialogs/CreateEditDialog.tsx
+++ b/packages/www/components/Dashboard/WebhookDialogs/CreateEditDialog.tsx
@@ -289,7 +289,7 @@ const CreateEditDialog = ({
                     }}
                   />
                 )}
-                {action} endpoint
+                {action} webhook
               </Button>
             </Flex>
           </Box>


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Started from just adding the webhook ID on the details page (since it's required
in the new access control flow) and ended up doing some other improvements.

**Specific updates (required)**
 - Add webhook ID field on details page so it can be easily copied
 - Show playback.accessControl event first on event list
 - Other "text" nits (create button text, webhook details title as name instead of url)

**How did you test each of these updates (required)**
Create a webhook, check details, copy the ID, etc

**Does this pull request close any open issues?**
Related to access control but we had no ticket for this.

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
