### PR TITLE
api: Disallow asset progress from going back

### DIFF
--- a/packages/api/src/controllers/task.ts
+++ b/packages/api/src/controllers/task.ts
@@ -312,12 +312,16 @@ app.post("/:id/status", authorizer({ anyAdmin: true }), async (req, res) => {
   if (task.inputAssetId) {
     const asset = await db.asset.get(task.inputAssetId);
     if (task.id === asset?.storage?.status?.tasks.pending) {
+      const progress = Math.max(
+        doc.progress,
+        asset.storage.status.progress ?? 0
+      );
       await req.taskScheduler.updateAsset(asset, {
         storage: {
           ...asset.storage,
           status: {
             phase: "processing",
-            progress: doc.progress,
+            progress,
             tasks: asset.storage.status.tasks,
           },
         },

--- a/packages/api/src/controllers/task.ts
+++ b/packages/api/src/controllers/task.ts
@@ -296,13 +296,14 @@ app.post("/:id/status", authorizer({ anyAdmin: true }), async (req, res) => {
     { allowedPhases: ["waiting", "running"] }
   );
   if (task.outputAssetId) {
+    const asset = await db.asset.get(task.outputAssetId);
     await req.taskScheduler.updateAsset(
-      task.outputAssetId,
+      asset,
       {
         status: {
           phase: "processing",
           updatedAt: Date.now(),
-          progress: doc.progress,
+          progress: Math.max(doc.progress, asset.status.progress ?? 0),
         },
       },
       { allowedPhases: ["waiting", "processing"] }
@@ -311,7 +312,7 @@ app.post("/:id/status", authorizer({ anyAdmin: true }), async (req, res) => {
   if (task.inputAssetId) {
     const asset = await db.asset.get(task.inputAssetId);
     if (task.id === asset?.storage?.status?.tasks.pending) {
-      await req.taskScheduler.updateAsset(asset.id, {
+      await req.taskScheduler.updateAsset(asset, {
         storage: {
           ...asset.storage,
           status: {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

This disallows the progress displayed on asset objects to go back in time.

This avoids the potential confusion on the higher level asset objects. Notice that
the real progress and retry count are still available on the lower-level task objects,
for power-users that do want to display that in any UI.

**Specific updates (required)**
 - Make sure to never make the asset progress smaller than before

**How did you test each of these updates (required)**
`yarn test`
staging check

**Does this pull request close any open issues?**
Fixes API-41

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
