### PR TITLE
Update default configuration of stream-info-service

### DIFF
--- a/packages/api/src/stream-info-service.ts
+++ b/packages/api/src/stream-info-service.ts
@@ -37,7 +37,7 @@ function parseCli() {
         broadcaster: {
           describe: "broadcaster host:port to fetch info from",
           type: "string",
-          default: "localhost:7935",
+          default: "127.0.0.1:7935",
         },
         "postgres-url": {
           describe: "url of a postgres database",


### PR DESCRIPTION
With the default catalyst setup `localhost` does not work, but `127.0.0.1` 🤔 

Let's just change it to simplify the local setup.