### PR TITLE
api: Add `creatorId` field to assets

### DIFF
--- a/packages/api/src/controllers/asset.test.ts
+++ b/packages/api/src/controllers/asset.test.ts
@@ -168,31 +168,31 @@ describe("controllers/asset", () => {
       asset: { id: assetId },
       task: { id: taskId },
     });
+  });
 
-    it("should store the creator ID as an object", async () => {
-      const spec = {
-        name: "test",
-        url: "https://example.com/test.mp4",
-        creatorId: "i am creator",
-      };
-      let res = await client.post(`/asset/upload/url`, spec);
-      expect(res.status).toBe(201);
-      let {
-        asset: { id: assetId },
-        task: { id: taskId },
-      } = await res.json();
-      expect(assetId).toMatch(/^[a-f0-9-]{36}$/);
-      expect(taskId).toMatch(/^[a-f0-9-]{36}$/);
+  it("should store the creator ID as an object", async () => {
+    const spec = {
+      name: "test",
+      url: "https://example.com/test.mp4",
+      creatorId: "i am creator",
+    };
+    let res = await client.post(`/asset/upload/url`, spec);
+    expect(res.status).toBe(201);
+    let {
+      asset: { id: assetId },
+      task: { id: taskId },
+    } = await res.json();
+    expect(assetId).toMatch(/^[a-f0-9-]{36}$/);
+    expect(taskId).toMatch(/^[a-f0-9-]{36}$/);
 
-      res = await client.get(`/asset/${assetId}`);
-      expect(res.status).toBe(200);
-      await expect(res.json()).resolves.toMatchObject({
-        id: assetId,
-        creatorId: {
-          type: "unverified",
-          value: "i am creator",
-        },
-      });
+    res = await client.get(`/asset/${assetId}`);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      id: assetId,
+      creatorId: {
+        type: "unverified",
+        value: "i am creator",
+      },
     });
   });
 

--- a/packages/api/src/controllers/asset.test.ts
+++ b/packages/api/src/controllers/asset.test.ts
@@ -168,6 +168,32 @@ describe("controllers/asset", () => {
       asset: { id: assetId },
       task: { id: taskId },
     });
+
+    it("should store the creator ID as an object", async () => {
+      const spec = {
+        name: "test",
+        url: "https://example.com/test.mp4",
+        creatorId: "i am creator",
+      };
+      let res = await client.post(`/asset/upload/url`, spec);
+      expect(res.status).toBe(201);
+      let {
+        asset: { id: assetId },
+        task: { id: taskId },
+      } = await res.json();
+      expect(assetId).toMatch(/^[a-f0-9-]{36}$/);
+      expect(taskId).toMatch(/^[a-f0-9-]{36}$/);
+
+      res = await client.get(`/asset/${assetId}`);
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toMatchObject({
+        id: assetId,
+        creatorId: {
+          type: "unverified",
+          value: "i am creator",
+        },
+      });
+    });
   });
 
   describe("asset inline storage", () => {

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -123,12 +123,17 @@ async function validateAssetPayload(
   }
 
   // Validate playbackPolicy on creation to generate resourceId & check if unifiedAccessControlConditions is present when using lit_signing_condition
-  payload.playbackPolicy = await validateAssetPlaybackPolicy(
+  const playbackPolicy = await validateAssetPlaybackPolicy(
     payload,
     playbackId,
     userId,
     createdAt
   );
+
+  const creatorId =
+    typeof payload.creatorId === "string"
+      ? ({ type: "unverified", value: payload.creatorId } as const)
+      : payload.creatorId;
 
   return {
     id,
@@ -142,7 +147,8 @@ async function validateAssetPayload(
     name: payload.name,
     source,
     staticMp4: payload.staticMp4,
-    playbackPolicy: payload.playbackPolicy,
+    creatorId,
+    playbackPolicy,
     objectStoreId: payload.objectStoreId || defaultObjectStoreId,
     storage: storageInputToState(payload.storage),
   };

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1438,6 +1438,12 @@ components:
           example: true
         playbackPolicy:
           $ref: "#/components/schemas/playback-policy"
+        creatorId:
+          oneOf:
+            - $ref: "#/components/schemas/asset/properties/creatorId"
+            - type: string
+              description:
+                Developer-managed (unverified) creator ID of the asset
         storage:
           additionalProperties: false
           properties:

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1112,6 +1112,18 @@ components:
           description: Object store ID where the asset is stored
           writeOnly: true
           example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
+        creatorId:
+          oneOf:
+            - additionalProperties: false
+              required: [type, value]
+              properties:
+                type:
+                  type: string
+                  enum: [unverified]
+                value:
+                  type: string
+                  description:
+                    Developer-managed ID of the user who created the asset.
         source:
           oneOf:
             - additionalProperties: false

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -1114,7 +1114,8 @@ components:
           example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
         creatorId:
           oneOf:
-            - additionalProperties: false
+            - type: object
+              additionalProperties: false
               required: [type, value]
               properties:
                 type:
@@ -1443,8 +1444,10 @@ components:
             - $ref: "#/components/schemas/asset/properties/creatorId"
             - type: string
               description:
-                Developer-managed (unverified) creator ID of the asset
+                Helper syntax to specify an unverified creator ID, fully managed
+                by the developer.
         storage:
+          type: object
           additionalProperties: false
           properties:
             ipfs:


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This adds the `creatorId` field to assets, which right now is an unverified value
provided by the caller. We store it in an object with a `type` and `value` for 
future-proofness.

**Specific updates (required)**
 - Add `creatorId` field to `asset` as an object
 - Add `creatorId` field to `new-asset-payload` as the same object or also just a string for ergonomy
 - Map the field to the asset object on creation

**How did you test each of these updates (required)**
`yarn test`

**Does this pull request close any open issues?**
Implements DAT-65

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
