### PR TITLE
[DX-123] seprated db and api schemas

### DIFF
--- a/packages/api/src/compile-schemas.js
+++ b/packages/api/src/compile-schemas.js
@@ -2,6 +2,7 @@ import Ajv from "ajv";
 import pack from "ajv-pack";
 import { safeLoad as parseYaml } from "js-yaml";
 import fs from "fs-extra";
+import _ from "lodash";
 import path from "path";
 import { compile as generateTypes } from "json-schema-to-typescript";
 import $RefParser from "json-schema-ref-parser";
@@ -28,11 +29,17 @@ const schemaDistDir = path.resolve(__dirname, "..", "dist", "schema");
 fs.ensureDirSync(validatorDir);
 fs.ensureDirSync(schemaDistDir);
 
-const schemaStr = fs.readFileSync(
-  path.resolve(schemaDir, "schema.yaml"),
+const apiSchemaStr = fs.readFileSync(
+  path.resolve(schemaDir, "api-schema.yaml"),
   "utf8"
 );
-const data = parseYaml(schemaStr);
+const dbSchemaStr = fs.readFileSync(
+  path.resolve(schemaDir, "db-schema.yaml"),
+  "utf8"
+);
+const apiData = parseYaml(apiSchemaStr);
+const dbData = parseYaml(dbSchemaStr);
+const data = _.merge({}, apiData, dbData);
 
 (async () => {
   await $RefParser.dereference({ components: data.components });

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -66,11 +66,13 @@ components:
       properties:
         id:
           type: string
+          readOnly: true
           example: de7818e7-610a-4057-8f6f-b785dc1e6f88
         name:
           type: string
         createdAt:
           type: number
+          readOnly: true
           description:
             Timestamp (in milliseconds) at which stream object was created
           example: 1587667174725
@@ -111,26 +113,32 @@ components:
           description: streamId of the stream on which the webhook is applied
         status:
           type: object
+          readOnly: true
           description: status of webhook
           properties:
             lastFailure:
               type: object
+              readOnly: true
               description: failure timestamp and error message with status code
               properties:
                 timestamp:
                   type: number
+                  readOnly: true
                   example: 1587667174725
                   description:
                     Timestamp (in milliseconds) at which the webhook last failed
                 error:
+                  readOnly: true
                   type: string
                   description: Webhook failure error message
                   example: Error message
                 response:
+                  readOnly: true
                   type: string
                   description: Webhook failure response
                   example: Response body
                 statusCode:
+                  readOnly: true
                   type: number
                   description: Webhook failure status code
                   example: 500
@@ -149,12 +157,16 @@ components:
       properties:
         id:
           type: string
+          readOnly: true
           example: de7818e7-610a-4057-8f6f-b785dc1e6f88
         webhookId:
+          readOnly: true
           type: string
         eventId:
+          readOnly: true
           type: string
         createdAt:
+          readOnly: true
           type: number
           description: >-
             Timestamp (in milliseconds) at which webhook response object was
@@ -191,11 +203,11 @@ components:
       properties:
         id:
           type: string
+          readOnly: true
           example: de7818e7-610a-4057-8f6f-b785dc1e6f88
         name:
           type: string
           example: test_stream
-
         lastSeen:
           type: number
           example: 1587667174725
@@ -232,9 +244,11 @@ components:
           description: If currently active
         createdByTokenName:
           type: string
+          readOnly: true
           description: Name of the token used to create this object
         createdAt:
           type: number
+          readOnly: true
           description:
             Timestamp (in milliseconds) at which stream object was created
           example: 1587667174725
@@ -428,11 +442,11 @@ components:
       properties:
         id:
           type: string
+          readOnly: true
           example: de7818e7-610a-4057-8f6f-b785dc1e6f88
         name:
           type: string
           example: test_session
-
         lastSeen:
           type: number
           example: 1587667174725
@@ -465,6 +479,7 @@ components:
           example: 2
           description: Rate at which transcodedBytes increases (bytes/second)
         createdAt:
+          readOnly: true
           type: number
           description:
             Timestamp (in milliseconds) at which stream object was created
@@ -480,6 +495,7 @@ components:
           type: boolean
           example: false
         recordingStatus:
+          readOnly: true
           type: string
           description: Status of the recording process of this stream session.
           enum:
@@ -488,9 +504,11 @@ components:
             - none
         recordingUrl:
           type: string
+          readOnly: true
           description: URL for accessing the recording of this stream session.
         mp4Url:
           type: string
+          readOnly: true
           description: URL for the stream session recording packaged in an mp4.
         playbackId:
           type: string
@@ -521,6 +539,7 @@ components:
       properties:
         id:
           type: string
+          readOnly: true
           example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
         name:
           type: string
@@ -537,9 +556,9 @@ components:
           description: >-
             If true then this multistream target will not be used for pushing
             even if it is configured in a stream object.
-
         createdAt:
           type: number
+          readOnly: true
           description: >-
             Timestamp (in milliseconds) at which multistream target object was
             created
@@ -554,6 +573,7 @@ components:
       properties:
         id:
           type: string
+          readOnly: true
           example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
         type:
           type: string
@@ -571,11 +591,13 @@ components:
           writeOnly: true
           description: Whether to generate MP4s for the asset.
         playbackUrl:
+          readOnly: true
           type: string
           example: >-
             https://livepeercdn.com/asset/ea03f37e-f861-4cdd-b495-0e60b6d753ad/index.m3u8
           description: URL for HLS playback
         downloadUrl:
+          readOnly: true
           type: string
           example: "https://livepeercdn.com/asset/eaw4nk06ts2d0mzb/video"
           description: URL to manually download the asset if desired
@@ -666,12 +688,14 @@ components:
                 nftMetadata:
                   $ref: "#/components/schemas/ipfs-file-info"
                 updatedAt:
+                  readOnly: true
                   type: number
                   description: >-
                     Timestamp (in milliseconds) at which IPFS export task was
                     updated
                   example: 1587667174725
             status:
+              readOnly: true
               additionalProperties: false
               required:
                 - phase
@@ -711,6 +735,7 @@ components:
                       type: string
                       description: ID of the last task to fail execution.
         status:
+          readOnly: true
           type: object
           additionalProperties: false
           required:
@@ -745,10 +770,12 @@ components:
             custom name or title
           example: filename.mp4
         createdAt:
+          readOnly: true
           type: number
           description: Timestamp (in milliseconds) at which asset was created
           example: 1587667174725
         size:
+          readOnly: true
           type: number
           description: Size of the asset in bytes
           example: 84934509
@@ -769,6 +796,7 @@ components:
                 description: Hash algorithm used to compute the hash
                 example: sha256
         videoSpec:
+          readOnly: true
           type: object
           additionalProperties: false
           description: Video metadata
@@ -861,9 +889,11 @@ components:
           type: string
           description: CID of the file on IPFS
         url:
+          readOnly: true
           type: string
           description: URL with IPFS scheme for the file
         gatewayUrl:
+          readOnly: true
           type: string
           description: URL to access file via HTTP through an IPFS gateway
     new-signing-key-payload:
@@ -1116,8 +1146,8 @@ components:
         id:
           type: string
           description: Task ID
+          readOnly: true
           example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
-
         type:
           type: string
           description: Type of the task
@@ -1128,10 +1158,12 @@ components:
             - transcode
             - transcode-file
         createdAt:
+          readOnly: true
           type: number
           description: Timestamp (in milliseconds) at which task was created
           example: 1587667174725
         scheduledAt:
+          readOnly: true
           type: number
           description: |
             Timestamp (in milliseconds) at which the task was scheduled for
@@ -1238,6 +1270,7 @@ components:
                     How many seconds the duration of each output segment should
                     be
         status:
+          readOnly: true
           type: object
           additionalProperties: false
           description: Status of the task
@@ -1308,8 +1341,10 @@ components:
                       description: IPFS CID of the exported video file
                     videoFileUrl:
                       type: string
+                      readOnly: true
                       description: URL for the file with the IPFS protocol
                     videoFileGatewayUrl:
+                      readOnly: true
                       type: string
                       description:
                         URL to access file via HTTP through an IPFS gateway
@@ -1318,10 +1353,12 @@ components:
                       description:
                         IPFS CID of the default metadata exported for the video
                     nftMetadataUrl:
+                      readOnly: true
                       type: string
                       description:
                         URL for the metadata file with the IPFS protocol
                     nftMetadataGatewayUrl:
+                      readOnly: true
                       type: string
                       description: >-
                         URL to access metadata file via HTTP through an IPFS
@@ -1422,16 +1459,19 @@ components:
       properties:
         id:
           type: string
+          readOnly: true
           example: 78df0075-b5f3-4683-a618-1086faca35dc
         name:
           type: string
           description: Name of the signing key
         createdAt:
+          readOnly: true
           type: number
           description:
             Timestamp (in milliseconds) at which the signing-key was created
           example: 1587667174725
         lastSeen:
+          readOnly: true
           type: number
           description:
             Timestamp (in milliseconds) at which the signing-key was last used
@@ -1482,6 +1522,7 @@ components:
           writeOnly: true
         id:
           type: string
+          readOnly: true
           example: abc123
         firstName:
           type: string
@@ -1537,6 +1578,7 @@ components:
           example: 2021-01-30T00:00:00.000Z
         date:
           type: number
+          readOnly: true
           example: usage
         sourceSegments:
           type: number

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -183,29 +183,6 @@ components:
               type: number
             statusText:
               type: string
-    detection-webhook-payload:
-      type: object
-      required:
-        - manifestID
-        - seqNo
-        - sceneClassification
-      properties:
-        manifestID:
-          type: string
-        seqNo:
-          type: number
-        sceneClassification:
-          type: array
-          items:
-            type: object
-            required:
-              - name
-              - probability
-            properties:
-              name:
-                type: string
-              probability:
-                type: number
     stream:
       type: object
       required:
@@ -418,6 +395,7 @@ components:
           $ref: "#/components/schemas/object-store/properties/publicUrl"
     multistream-target-patch-payload:
       $ref: "#/components/schemas/multistream-target"
+      required: []
     webhook-patch-payload:
       type: object
       additionalProperties: false
@@ -915,19 +893,21 @@ components:
           additionalProperties: false
           properties:
             ipfs:
+              description: >-
+                Set to true to make default export to IPFS. To customize the
+                pinned files, specify an object with a spec field. False or null
+                means to unpin from IPFS, but it's unsupported right now.
               oneOf:
                 - type: object
                   additionalProperties: false
                   properties:
                     spec:
                       oneOf:
-                        - type: string
+                        - type: "null"
                         - $ref: >-
                             #/components/schemas/asset/properties/storage/properties/ipfs/properties/spec
                 - type: boolean
-                  description: >-
-                    Set to true to make default export to IPFS. False or null
-                    means to unpin from IPFS, but is unsupported right now.
+                - type: "null"
         url:
           type: string
           format: uri

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -1,0 +1,3102 @@
+openapi: 3.0.1
+info:
+  title: Livepeer API Reference
+  description: >-
+    This API reference provides documentation for the Livepeer API - the world's
+    open video infrastructure
+  version: 1.0.0
+  termsOfService: "https://livepeer.org/terms-of-service"
+servers:
+  - url: "https://livepeer.studio/api"
+components:
+  schemas:
+    ffmpeg-profile:
+      type: object
+      description: LMPS ffmpeg profile
+      additionalProperties: false
+      required:
+        - width
+        - name
+        - height
+        - bitrate
+        - fps
+      properties:
+        width:
+          type: integer
+          minimum: 128
+        name:
+          type: string
+          minLength: 1
+          maxLength: 500
+          example: 720p
+        height:
+          type: integer
+          minimum: 128
+        bitrate:
+          type: integer
+          minimum: 400
+        fps:
+          type: integer
+          minimum: 0
+        fpsDen:
+          type: integer
+          minimum: 1
+        gop:
+          type: string
+        profile:
+          type: string
+          enum:
+            - H264Baseline
+            - H264Main
+            - H264High
+            - H264ConstrainedHigh
+        encoder:
+          type: string
+          enum:
+            - h264
+            - hevc
+            - vp8
+            - vp9
+    cdn-data-row:
+      type: object
+      description: >-
+        Fields names taken from log format description
+        https://support.highwinds.com/hc/en-us/articles/360052181571-Raw-Log-Access-through-GCS
+      additionalProperties: false
+      required:
+        - unique_client_ips
+        - total_sc_bytes
+      properties:
+        stream_id:
+          type: string
+          description: Session UUID. Used in recordings URLs.
+        playback_id:
+          type: string
+          description: Playback ID.
+        unique_client_ips:
+          type: number
+          description: >-
+            Number of unique IP addresses of clients. Not accurate because
+            StackPath zeroes last part of the IP address.
+        total_filesize:
+          type: number
+          description: Size of the asset being delivered.
+        total_cs_bytes:
+          type: number
+          description: The total size of the request header.
+        total_sc_bytes:
+          type: number
+          description: Total bytes in the response to the client.
+        count:
+          type: number
+          description: Number of parsed log lines
+    cdn-data-payload:
+      type: array
+      items:
+        type: object
+        additionalProperties: false
+        required:
+          - region
+          - file_name
+          - date
+          - data
+        properties:
+          region:
+            type: string
+          file_name:
+            type: string
+          date:
+            type: number
+          data:
+            type: array
+            minItems: 1
+            items:
+              $ref: "#/components/schemas/cdn-data-row"
+    cdn-usage-last:
+      type: object
+      required:
+        - region
+        - fileName
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          example: de7818e7-610a-4057-8f6f-b785dc1e6f88
+        fileName:
+          type: number
+        region:
+          type: string
+    webhook:
+      type: object
+      required:
+        - name
+        - url
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          example: de7818e7-610a-4057-8f6f-b785dc1e6f88
+        kind:
+          type: string
+          example: webhook
+        name:
+          type: string
+        userId:
+          type: string
+        createdAt:
+          type: number
+          description:
+            Timestamp (in milliseconds) at which stream object was created
+          example: 1587667174725
+        event:
+          writeOnly: true
+          deprecated: true
+          description:
+            "@deprecated Non-persisted field. To be used on creation API only."
+          $ref: "#/components/schemas/webhook/properties/events/items"
+        events:
+          type: array
+          items:
+            type: string
+            enum:
+              - stream.started
+              - stream.detection
+              - stream.idle
+              - recording.ready
+              - recording.started
+              - multistream.connected
+              - multistream.error
+              - multistream.disconnected
+              - playback.user.new
+              - playback.accessControl
+              - asset.created
+              - asset.updated
+              - asset.failed
+              - asset.ready
+              - asset.deleted
+              - task.spawned
+              - task.updated
+              - task.completed
+              - task.failed
+        url:
+          type: string
+          format: uri
+          pattern: "^http(s)?://"
+        deleted:
+          type: boolean
+          default: false
+        sharedSecret:
+          type: string
+          writeOnly: true
+          description: shared secret used to sign the webhook payload
+        streamId:
+          type: string
+          description: streamId of the stream on which the webhook is applied
+        status:
+          type: object
+          description: status of webhook
+          properties:
+            lastFailure:
+              type: object
+              description: failure timestamp and error message with status code
+              properties:
+                timestamp:
+                  type: number
+                  example: 1587667174725
+                  description:
+                    Timestamp (in milliseconds) at which the webhook last failed
+                error:
+                  type: string
+                  description: Webhook failure error message
+                  example: Error message
+                response:
+                  type: string
+                  description: Webhook failure response
+                  example: Response body
+                statusCode:
+                  type: number
+                  description: Webhook failure status code
+                  example: 500
+            lastTriggeredAt:
+              type: number
+              description: >-
+                Timestamp (in milliseconds) at which the webhook last was
+                triggered
+              example: 1587667174725
+    webhook-response:
+      type: object
+      required:
+        - webhookId
+        - statusCode
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          example: de7818e7-610a-4057-8f6f-b785dc1e6f88
+        kind:
+          type: string
+          example: webhookResponse
+        webhookId:
+          type: string
+        eventId:
+          type: string
+        createdAt:
+          type: number
+          description: >-
+            Timestamp (in milliseconds) at which webhook response object was
+            created
+          example: 1587667174725
+        duration:
+          type: number
+        statusCode:
+          type: number
+          default: 0
+        response:
+          type: object
+          additionalProperties: false
+          properties:
+            body:
+              type: string
+            headers:
+              type: object
+              additionalProperties:
+                type: array
+                items:
+                  type: string
+            redirected:
+              type: boolean
+            status:
+              type: number
+            statusText:
+              type: string
+    detection-webhook-payload:
+      type: object
+      required:
+        - manifestID
+        - seqNo
+        - sceneClassification
+      properties:
+        manifestID:
+          type: string
+        seqNo:
+          type: number
+        sceneClassification:
+          type: array
+          items:
+            type: object
+            required:
+              - name
+              - probability
+            properties:
+              name:
+                type: string
+              probability:
+                type: number
+    stream:
+      type: object
+      required:
+        - name
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          example: de7818e7-610a-4057-8f6f-b785dc1e6f88
+        kind:
+          type: string
+          example: stream
+        name:
+          type: string
+          example: test_stream
+        userId:
+          type: string
+          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
+        lastSeen:
+          type: number
+          example: 1587667174725
+        sourceSegments:
+          type: number
+          example: 1
+        transcodedSegments:
+          type: number
+          example: 2
+        sourceSegmentsDuration:
+          type: number
+          example: 1
+          description: "Duration of all the source segments, sec"
+        transcodedSegmentsDuration:
+          type: number
+          example: 2
+          description: "Duration of all the transcoded segments, sec"
+        sourceBytes:
+          type: number
+          example: 1
+        transcodedBytes:
+          type: number
+          example: 2
+        ingestRate:
+          type: number
+          example: 1
+          description: Rate at which sourceBytes increases (bytes/second)
+        outgoingRate:
+          type: number
+          example: 2
+          description: Rate at which transcodedBytes increases (bytes/second)
+        deleted:
+          type: boolean
+          description: Set to true when stream deleted
+        isActive:
+          type: boolean
+          description: If currently active
+        createdByTokenName:
+          type: string
+          description: Name of the token used to create this object
+        createdByTokenId:
+          type: string
+        createdAt:
+          type: number
+          description:
+            Timestamp (in milliseconds) at which stream object was created
+          example: 1587667174725
+        parentId:
+          type: string
+          example: de7818e7-610a-4057-8f6f-b785dc1e6f88
+          description: Points to parent stream object
+        streamKey:
+          type: string
+          example: hgebdhhigq
+          description: Used to form RTMP ingest URL
+        playbackId:
+          type: string
+          example: eaw4nk06ts2d0mzb
+          description: Used to form playback URL
+        playbackPolicy:
+          $ref: "#/components/schemas/playback-policy"
+        profiles:
+          type: array
+          default:
+            - name: 240p0
+              fps: 0
+              bitrate: 250000
+              width: 426
+              height: 240
+            - name: 360p0
+              fps: 0
+              bitrate: 800000
+              width: 640
+              height: 360
+            - name: 480p0
+              fps: 0
+              bitrate: 1600000
+              width: 854
+              height: 480
+            - name: 720p0
+              fps: 0
+              bitrate: 3000000
+              width: 1280
+              height: 720
+          items:
+            $ref: "#/components/schemas/ffmpeg-profile"
+        objectStoreId:
+          type: string
+          example: D8321C3E-B29C-45EB-A1BB-A623D8BE0F65
+        presets:
+          type: array
+          items:
+            type: string
+            enum:
+              - P720p60fps16x9
+              - P720p30fps16x9
+              - P720p30fps4x3
+              - P576p30fps16x9
+              - P360p30fps16x9
+              - P360p30fps4x3
+              - P240p30fps16x9
+              - P240p30fps4x3
+              - P144p30fps16x9
+            example: P720p60fps16x9
+        record:
+          description: >-
+            Should this stream be recorded? Uses default settings. For more
+            customization, create and configure an object store.
+          type: boolean
+          example: false
+        recordObjectStoreId:
+          type: string
+          example: D8321C3E-B29C-45EB-A1BB-A623D8BE0F65
+          description:
+            ID of object store where to which this stream was recorded
+        multistream:
+          type: object
+          additionalProperties: false
+          properties:
+            targets:
+              type: array
+              example:
+                - id: PUSH123
+                  profile: 720p
+              description: >-
+                References to targets where this stream will be simultaneously
+                streamed to
+              items:
+                type: object
+                required:
+                  - profile
+                additionalProperties: false
+                properties:
+                  profile:
+                    type: string
+                    description: >-
+                      Name of transcoding profile that should be sent. Use
+                      "source" for pushing source stream data
+                    minLength: 1
+                    maxLength: 500
+                    example: 720p
+                  videoOnly:
+                    type: boolean
+                    description: >-
+                      If true, the stream audio will be muted and only silent
+                      video will be pushed to the target.
+                    default: false
+                  id:
+                    type: string
+                    description:
+                      ID of multistream target object where to push this stream
+                  spec:
+                    type: object
+                    writeOnly: true
+                    description: >-
+                      Inline multistream target object. Will automatically
+                      create the target resource to be used by the created
+                      stream.
+                    required:
+                      - url
+                    additionalProperties: false
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        $ref: "#/components/schemas/multistream-target/properties/url"
+        wowza:
+          type: object
+          required:
+            - transcoderAppConfig
+            - transcoderTemplateAppConfig
+            - streamNameGroups
+            - sourceInfo
+          additionalProperties: false
+          properties:
+            transcoderAppConfig:
+              type: object
+            transcoderTemplateAppConfig:
+              type: object
+            streamNameGroups:
+              type: array
+              items:
+                type: string
+            sourceInfo:
+              type: object
+              required:
+                - width
+                - height
+                - fps
+              additionalProperties: false
+              properties:
+                width:
+                  type: integer
+                height:
+                  type: integer
+                fps:
+                  type: integer
+        renditions:
+          type: object
+          additionalProperties:
+            type: string
+        detection:
+          type: object
+          description: >-
+            Custom configuration for audio/video detection algorithms to be run
+            on the stream. If no config is provided and a webhook is subscribed
+            to the stream.detection event, a default config will be used.
+          default:
+            sceneClassification:
+              - name: soccer
+              - name: adult
+          required:
+            - sceneClassification
+          additionalProperties: false
+          properties:
+            sceneClassification:
+              type: array
+              minItems: 1
+              items:
+                type: object
+                description: >-
+                  Scene classification options. Must contain name property with
+                  one of the well-defined classes supported by detection models.
+                additionalProperties: false
+                required:
+                  - name
+                properties:
+                  name:
+                    type: string
+                    enum:
+                      - soccer
+                      - adult
+        region:
+          type: string
+          example: fra
+          description: Region in which this session object was created
+        broadcasterHost:
+          type: string
+          description: Hostname of the broadcaster that transcodes that stream
+        mistHost:
+          type: string
+          description: Hostname of the Mist server that processes that stream
+        suspended:
+          type: boolean
+          description: If currently suspended
+    deactivate-many-payload:
+      type: object
+      additionalProperties: false
+      properties:
+        ids:
+          type: array
+          minItems: 1
+          items:
+            type: string
+    stream-set-active-payload:
+      type: object
+      required:
+        - active
+      properties:
+        active:
+          $ref: "#/components/schemas/stream/properties/isActive"
+        hostName:
+          $ref: "#/components/schemas/stream/properties/mistHost"
+        startedAt:
+          type: number
+          description: Timestamp (in milliseconds) at which the stream started.
+          example: 1587667174725
+    asset-patch-payload:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          $ref: "#/components/schemas/asset/properties/name"
+        playbackPolicy:
+          $ref: "#/components/schemas/playback-policy"
+        storage:
+          $ref: "#/components/schemas/new-asset-payload/properties/storage"
+    stream-patch-payload:
+      type: object
+      additionalProperties: false
+      properties:
+        record:
+          $ref: "#/components/schemas/stream/properties/record"
+        suspended:
+          $ref: "#/components/schemas/stream/properties/suspended"
+        multistream:
+          $ref: "#/components/schemas/stream/properties/multistream"
+        playbackPolicy:
+          $ref: "#/components/schemas/playback-policy"
+    object-store-patch-payload:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          $ref: "#/components/schemas/object-store/properties/name"
+        disabled:
+          $ref: "#/components/schemas/object-store/properties/disabled"
+        url:
+          $ref: "#/components/schemas/object-store/properties/url"
+        publicUrl:
+          $ref: "#/components/schemas/object-store/properties/publicUrl"
+    suspend-user-payload:
+      type: object
+      additionalProperties: false
+      required:
+        - suspended
+      properties:
+        suspended:
+          $ref: "#/components/schemas/user/properties/suspended"
+        emailTemplate:
+          type: string
+          description:
+            Name of template to send to the users regarding the suspension.
+          enum:
+            - copyright
+    multistream-target-patch-payload:
+      $ref: "#/components/schemas/multistream-target"
+    signing-key-patch-payload:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          $ref: "#/components/schemas/signing-key/properties/name"
+        disabled:
+          $ref: "#/components/schemas/signing-key/properties/disabled"
+    webhook-patch-payload:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          $ref: "#/components/schemas/webhook/properties/name"
+        url:
+          $ref: "#/components/schemas/webhook/properties/url"
+        events:
+          $ref: "#/components/schemas/webhook/properties/events"
+        sharedSecret:
+          $ref: "#/components/schemas/webhook/properties/sharedSecret"
+        streamId:
+          $ref: "#/components/schemas/webhook/properties/streamId"
+    webhook-status-payload:
+      type: object
+      additionalProperties: false
+      properties:
+        errorMessage:
+          type: string
+          description: Error message if the webhook failed to process the event
+        response:
+          $ref: "#/components/schemas/webhook-response"
+    access-control-gate-payload:
+      type: object
+      additionalProperties: false
+      required:
+        - type
+        - stream
+      properties:
+        type:
+          type: string
+          enum:
+            - jwt
+            - accessKey
+        stream:
+          type: string
+          description: Stream ID to which this gate applies
+        pub:
+          type: string
+          description: Base64 of Public key used for JWT verification
+        accessKey:
+          type: string
+          description: Access key used for access-control verification
+    experiment-audience-payload:
+      type: object
+      additionalProperties: false
+      properties:
+        addUsers:
+          type: array
+          items:
+            type: string
+            description:
+              Email or ID of users that should be added to the experiment
+        removeUsers:
+          type: array
+          items:
+            type: string
+            description:
+              Email or ID of users that should be removed from the experiment
+    playback-policy:
+      type: object
+      description:
+        Whether the playback policy for a asset or stream is public or signed
+      additionalProperties: false
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - public
+            - jwt
+            - lit_signing_condition
+            - webhook
+        unifiedAccessControlConditions:
+          type: array
+          description: LIT Unified Access Control Conditions
+          items:
+            type: object
+        resourceId:
+          type: object
+          description: LIT Resource ID
+          additionalProperties: false
+          required:
+            - baseUrl
+            - path
+            - orgId
+            - role
+            - extraData
+          properties:
+            baseUrl:
+              type: string
+            path:
+              type: string
+            orgId:
+              type: string
+            role:
+              type: string
+            extraData:
+              type: string
+        webhookId:
+          type: string
+          description: ID of the webhook to use for playback policy
+        webhookContext:
+          type: object
+          description: User-defined webhook context
+          additionalProperties: true
+    session:
+      type: object
+      required:
+        - name
+        - streamId
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          example: de7818e7-610a-4057-8f6f-b785dc1e6f88
+        kind:
+          type: string
+          example: stream
+        name:
+          type: string
+          example: test_session
+        userId:
+          type: string
+          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
+        lastSeen:
+          type: number
+          example: 1587667174725
+        sourceSegments:
+          type: number
+          example: 1
+        transcodedSegments:
+          type: number
+          example: 2
+        sourceSegmentsDuration:
+          type: number
+          example: 1
+          description: "Duration of all the source segments, sec"
+        transcodedSegmentsDuration:
+          type: number
+          example: 2
+          description: "Duration of all the transcoded segments, sec"
+        sourceBytes:
+          type: number
+          example: 1
+        transcodedBytes:
+          type: number
+          example: 2
+        ingestRate:
+          type: number
+          example: 1
+          description: Rate at which sourceBytes increases (bytes/second)
+        outgoingRate:
+          type: number
+          example: 2
+          description: Rate at which transcodedBytes increases (bytes/second)
+        broadcasterHost:
+          type: string
+          description: Hostname of the broadcaster that transcodes that stream
+        deleted:
+          type: boolean
+          description: Set to true when stream deleted
+        createdAt:
+          type: number
+          description:
+            Timestamp (in milliseconds) at which stream object was created
+          example: 1587667174725
+        parentId:
+          type: string
+          example: de7818e7-610a-4057-8f6f-b785dc1e6f88
+          description: Points to parent stream object
+        record:
+          description: >-
+            Should this stream be recorded? Uses default settings. For more
+            customization, create and configure an object store.
+          type: boolean
+          example: false
+        recordingStatus:
+          type: string
+          description: Status of the recording process of this stream session.
+          enum:
+            - waiting
+            - ready
+            - none
+        recordingUrl:
+          type: string
+          description: URL for accessing the recording of this stream session.
+        mp4Url:
+          type: string
+          description: URL for the stream session recording packaged in an mp4.
+        recordObjectStoreId:
+          type: string
+          example: D8321C3E-B29C-45EB-A1BB-A623D8BE0F65
+          description:
+            ID of object store where to which this stream was recorded
+        playbackId:
+          type: string
+          example: eaw4nk06ts2d0mzb
+          description: Used to form playback URL
+        profiles:
+          type: array
+          items:
+            $ref: "#/components/schemas/ffmpeg-profile"
+    error:
+      required:
+        - errors
+      type: object
+      properties:
+        errors:
+          type: array
+          minItems: 1
+          items:
+            type: string
+            example:
+              - id not provided
+              - user not found
+    object-store:
+      type: object
+      required:
+        - url
+      additionalProperties: false
+      properties:
+        url:
+          type: string
+          description: Livepeer-compatible object store URL
+          example: "s3://access-key:secret-key@us-west-2/bucket-name"
+          writeOnly: true
+        publicUrl:
+          type: string
+          description:
+            Public URL at which data in this object storage can be accessed
+          example: "https://reg-rec.livepeer.live/some/path"
+        disabled:
+          type: boolean
+          description: >-
+            If true then these object store will not be used for recording even
+            if it is configured in the API command line.
+        deleted:
+          type: boolean
+          description: Set to true when the object store is deleted
+        id:
+          type: string
+          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
+        userId:
+          type: string
+          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
+        name:
+          type: string
+        createdAt:
+          type: number
+          description:
+            Timestamp (in milliseconds) at which object store object was created
+          example: 1587667174725
+    multistream-target:
+      type: object
+      required:
+        - url
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
+        name:
+          type: string
+        url:
+          type: string
+          writeOnly: true
+          description:
+            Livepeer-compatible multistream target URL (RTMP(S) or SRT)
+          example: "rtmps://live.my-service.tv/channel/secretKey"
+          format: uri
+          pattern: "^(srt|rtmps?)://"
+        disabled:
+          type: boolean
+          description: >-
+            If true then this multistream target will not be used for pushing
+            even if it is configured in a stream object.
+        userId:
+          type: string
+          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
+        createdAt:
+          type: number
+          description: >-
+            Timestamp (in milliseconds) at which multistream target object was
+            created
+          example: 1587667174725
+    asset:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - source
+      properties:
+        id:
+          type: string
+          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
+        type:
+          type: string
+          enum:
+            - video
+            - audio
+          description: Type of the asset.
+          example: video
+        playbackId:
+          type: string
+          example: eaw4nk06ts2d0mzb
+          description: Used to form playback URL and storage folder
+        playbackRecordingId:
+          type: string
+          writeOnly: true
+          example: ea03f37e-f861-4cdd-b495-0e60b6d753ad
+          description: Used to form recording URL for HLS playback
+        staticMp4:
+          type: boolean
+          writeOnly: true
+          description: Whether to generate MP4s for the asset.
+        files:
+          type: array
+          writeOnly: true
+          description:
+            Internal field with the list of files stored in the object store
+          items:
+            type: object
+            additionalProperties: false
+            required:
+              - type
+              - path
+            properties:
+              type:
+                type: string
+                example: catalyst_hls_manifest
+                description: Type of the file in the VOD system.
+              path:
+                type: string
+                example: /path/to/file
+                description: >-
+                  Path to the file in the asset subfolder in the object store.
+                  This means that all these paths are relative to a folder in
+                  the OS the asset playback ID as the name.
+              spec:
+                type: object
+                additionalProperties: false
+                description: >-
+                  Additional information about the file. For example, for
+                  manifests it contains the list of media files.
+                properties:
+                  size:
+                    type: number
+                    example: 123456
+                    description: Size of the file in bytes.
+                  height:
+                    type: number
+                    example: 1080
+                    description: Height of the video in pixels.
+                  width:
+                    type: number
+                    example: 1920
+                    description: Width of the video in pixels.
+                  bitrate:
+                    type: number
+                    example: 1000000
+                    description: Bitrate of the video in bits per second.
+        playbackUrl:
+          type: string
+          example: >-
+            https://livepeercdn.com/asset/ea03f37e-f861-4cdd-b495-0e60b6d753ad/index.m3u8
+          description: URL for HLS playback
+        downloadUrl:
+          type: string
+          example: "https://livepeercdn.com/asset/eaw4nk06ts2d0mzb/video"
+          description: URL to manually download the asset if desired
+        playbackPolicy:
+          $ref: "#/components/schemas/playback-policy"
+        userId:
+          type: string
+          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
+          description: owner of the asset
+        deleted:
+          type: boolean
+          description: Set to true when the asset is deleted
+        deletedAt:
+          type: number
+          description:
+            Timestamp (in milliseconds) at which the asset was deleted
+          example: 1587667174725
+        objectStoreId:
+          type: string
+          description: Object store ID where the asset is stored
+          writeOnly: true
+          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
+        source:
+          oneOf:
+            - additionalProperties: false
+              required:
+                - type
+                - url
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - url
+                url:
+                  type: string
+                  description: URL from which the asset was uploaded
+                encryption:
+                  $ref: "#/components/schemas/new-asset-payload/properties/encryption"
+            - additionalProperties: false
+              required:
+                - type
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - directUpload
+                encryption:
+                  $ref: "#/components/schemas/new-asset-payload/properties/encryption"
+            - additionalProperties: false
+              required:
+                - type
+                - sessionId
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - recording
+                sessionId:
+                  type: string
+                  description:
+                    ID of the session from which this asset was created
+            - additionalProperties: false
+              required:
+                - type
+                - inputAssetId
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - transcode
+                inputAssetId:
+                  type: string
+                  description: >-
+                    ID of the source asset that was processed by a transcode
+                    task to create this asset
+        storage:
+          additionalProperties: false
+          properties:
+            ipfs:
+              type: object
+              additionalProperties: false
+              properties:
+                spec:
+                  type: object
+                  additionalProperties: false
+                  default: {}
+                  properties:
+                    nftMetadataTemplate:
+                      type: string
+                      enum:
+                        - file
+                        - player
+                      default: file
+                      description: >-
+                        Name of the NFT metadata template to export. 'player'
+                        will embed the Livepeer Player on the NFT while 'file'
+                        will reference only the immutable MP4 files.
+                    nftMetadata:
+                      type: object
+                      description: >-
+                        Additional data to add to the NFT metadata exported to
+                        IPFS. Will be deep merged with the default metadata
+                        exported.
+                $ref: "#/components/schemas/ipfs-file-info/properties"
+                nftMetadata:
+                  $ref: "#/components/schemas/ipfs-file-info"
+                updatedAt:
+                  type: number
+                  description: >-
+                    Timestamp (in milliseconds) at which IPFS export task was
+                    updated
+                  example: 1587667174725
+            status:
+              additionalProperties: false
+              required:
+                - phase
+                - tasks
+              properties:
+                phase:
+                  type: string
+                  description: Phase of the asset storage
+                  enum:
+                    - waiting
+                    - processing
+                    - ready
+                    - failed
+                    - reverted
+                progress:
+                  type: number
+                  description:
+                    Current progress of the task updating the storage.
+                errorMessage:
+                  type: string
+                  description: Error message if the last storage changed failed.
+                tasks:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    pending:
+                      type: string
+                      description: >-
+                        ID of any currently running task that is exporting this
+                        asset to IPFS.
+                    last:
+                      type: string
+                      description: >-
+                        ID of the last task to run successfully, that created
+                        the currently saved data.
+                    failed:
+                      type: string
+                      description: ID of the last task to fail execution.
+        status:
+          type: object
+          additionalProperties: false
+          required:
+            - phase
+            - updatedAt
+          description: Status of the asset
+          properties:
+            phase:
+              type: string
+              description: Phase of the asset
+              enum:
+                - uploading
+                - waiting
+                - processing
+                - ready
+                - failed
+            updatedAt:
+              type: number
+              description:
+                Timestamp (in milliseconds) at which the asset was last updated
+              example: 1587667174725
+            progress:
+              type: number
+              description: Current progress of the task creating this asset.
+            errorMessage:
+              type: string
+              description: Error message if the asset creation failed.
+        name:
+          type: string
+          description: >-
+            Name of the asset. This is not necessarily the filename, can be a
+            custom name or title
+          example: filename.mp4
+        createdAt:
+          type: number
+          description: Timestamp (in milliseconds) at which asset was created
+          example: 1587667174725
+        size:
+          type: number
+          description: Size of the asset in bytes
+          example: 84934509
+        hash:
+          type: array
+          description: Hash of the asset
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              hash:
+                type: string
+                description: Hash of the asset
+                example: >-
+                  9b560b28b85378a5004117539196ab24e21bbd75b0e9eb1a8bc7c5fd80dc5b57
+              algorithm:
+                type: string
+                description: Hash algorithm used to compute the hash
+                example: sha256
+        videoSpec:
+          type: object
+          additionalProperties: false
+          description: Video metadata
+          properties:
+            format:
+              type: string
+              description: Format of the asset
+              example: mp4
+            duration:
+              type: number
+              description: Duration of the asset in seconds (float)
+              example: 23.8328
+            bitrate:
+              type: number
+              description: Bitrate of the video in bits per second
+              example: 1000000
+            tracks:
+              type: array
+              description: >-
+                List of tracks associated with the asset when the format
+                contemplates them (e.g. mp4)
+              items:
+                type: object
+                additionalProperties: false
+                required:
+                  - type
+                  - codec
+                properties:
+                  type:
+                    type: string
+                    description: type of track
+                    enum:
+                      - video
+                      - audio
+                    example: video
+                  codec:
+                    type: string
+                    description: Codec of the track
+                    example: aac
+                  startTime:
+                    type: number
+                    description: Start time of the track in seconds
+                    example: 23.8238
+                  duration:
+                    type: number
+                    description: Duration of the track in seconds
+                    example: 23.8238
+                  bitrate:
+                    type: number
+                    description: Bitrate of the track in bits per second
+                    example: 1000000
+                  width:
+                    type: number
+                    description: Width of the track - only for video tracks
+                    example: 1920
+                  height:
+                    type: number
+                    description: Height of the track - only for video tracks
+                    example: 1080
+                  pixelFormat:
+                    type: string
+                    description:
+                      Pixel format of the track - only for video tracks
+                    example: yuv420p
+                  fps:
+                    type: number
+                    description: Frame rate of the track - only for video tracks
+                    example: 30
+                  channels:
+                    type: number
+                    description: Amount of audio channels in the track
+                    example: 2
+                  sampleRate:
+                    type: number
+                    description: >-
+                      Sample rate of the track in samples per second - only for
+                      audio tracks
+                    example: 44100
+                  bitDepth:
+                    type: number
+                    description: Bit depth of the track - only for audio tracks
+                    example: 16
+        sourceAssetId:
+          type: string
+          description:
+            "ID of the source asset (root) - If missing, this is a root asset"
+          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
+    ipfs-file-info:
+      type: object
+      required:
+        - cid
+      additionalProperties: false
+      properties:
+        cid:
+          type: string
+          description: CID of the file on IPFS
+        url:
+          type: string
+          description: URL with IPFS scheme for the file
+        gatewayUrl:
+          type: string
+          description: URL to access file via HTTP through an IPFS gateway
+    new-signing-key-payload:
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          description: Name of the signing key
+    new-asset-payload:
+      additionalProperties: false
+      required:
+        - name
+      properties:
+        objectStoreId:
+          type: string
+          description: Object store ID where the asset is stored
+          writeOnly: true
+          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
+        name:
+          type: string
+          description: >-
+            Name of the asset. This is not necessarily the filename, can be a
+            custom name or title
+          example: filename.mp4
+        staticMp4:
+          type: boolean
+          description: Whether to generate MP4s for the asset.
+          example: true
+        playbackPolicy:
+          $ref: "#/components/schemas/playback-policy"
+        storage:
+          additionalProperties: false
+          properties:
+            ipfs:
+              oneOf:
+                - type: object
+                  additionalProperties: false
+                  properties:
+                    spec:
+                      oneOf:
+                        - type: string
+                        - $ref: >-
+                            #/components/schemas/asset/properties/storage/properties/ipfs/properties/spec
+                - type: boolean
+                  description: >-
+                    Set to true to make default export to IPFS. False or null
+                    means to unpin from IPFS, but is unsupported right now.
+        url:
+          type: string
+          format: uri
+          pattern: "^(https?|ipfs|ar)://"
+          description: >-
+            URL where the asset contents can be retrieved. Only valid for the
+            import task endpoint.
+          example: "https://s3.amazonaws.com/my-bucket/path/filename.mp4"
+        encryption:
+          type: object
+          additionalProperties: false
+          required:
+            - key
+          properties:
+            key:
+              type: string
+              writeOnly: true
+              description: >-
+                Encryption key used to encrypt the asset encoded in base16. Only
+                writable in the upload asset endpoints and cannot be retrieved
+                back.
+              example: 74686973206d65616e73206e6f7468696e672120676f2061776179206672656e
+            algorithm:
+              type: string
+              description: >-
+                Encryption algorithm used to encrypt the asset, defaults to AES
+                in CBC block cipher mode.
+              enum:
+                - aes-cbc
+              default: aes-cbc
+        catalystPipelineStrategy:
+          $ref: >-
+            #/components/schemas/task/properties/params/properties/upload/properties/catalystPipelineStrategy
+    transcode-asset-payload:
+      additionalProperties: false
+      required:
+        - name
+        - profile
+      properties:
+        assetId:
+          type: string
+          description: ID of the asset to transcode
+        objectStoreId:
+          type: string
+          description: Object store ID where the asset is stored
+          writeOnly: true
+          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
+        name:
+          type: string
+          description: >-
+            Name of the asset. This is not necessarily the filename, can be a
+            custom name or title
+          example: filename.mp4
+        profile:
+          $ref: "#/components/schemas/ffmpeg-profile"
+    transcode-payload:
+      additionalProperties: false
+      required:
+        - input
+        - storage
+        - outputs
+      properties:
+        input:
+          oneOf:
+            - type: object
+              additionalProperties: false
+              description: URL input video
+              required:
+                - url
+              properties:
+                url:
+                  type: string
+                  format: uri
+                  pattern: "^(https?|ipfs|ar)://"
+                  description: URL of the video to transcode
+                  example: "https://s3.amazonaws.com/bucket/file.mp4"
+            - type: object
+              additionalProperties: false
+              description: S3-like storage input video
+              required:
+                - type
+                - endpoint
+                - bucket
+                - path
+                - credentials
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - s3
+                  description: >-
+                    Type of service. This is optional and defaults to `url` if
+                    ŚURL field is provided.
+                endpoint:
+                  type: string
+                  format: uri
+                  pattern: "^http(s)?://"
+                  description: Service endpoint URL
+                  example: "https://gateway.storjshare.io"
+                bucket:
+                  type: string
+                  description: Bucket with input file
+                  example: inputbucket
+                path:
+                  type: string
+                  description: Path to the input file inside the bucket
+                  example: /path/file.mp4
+                credentials:
+                  type: object
+                  additionalProperties: false
+                  required:
+                    - accessKeyId
+                    - secretAccessKey
+                  description: Credentials for the private input video storage
+                  properties:
+                    accessKeyId:
+                      type: string
+                      description: Access Key ID
+                      example: AKIAIOSFODNN7EXAMPLE
+                    secretAccessKey:
+                      type: string
+                      description: Secret Access Key
+                      example: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+        storage:
+          oneOf:
+            - type: object
+              additionalProperties: false
+              required:
+                - type
+                - endpoint
+                - bucket
+                - credentials
+              description: Storage for the output files
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - s3
+                  description: Type of service used for output files
+                endpoint:
+                  type: string
+                  format: uri
+                  pattern: "^http(s)?://"
+                  description: Service endpoint URL
+                  example: "https://gateway.storjshare.io"
+                bucket:
+                  type: string
+                  description: Bucket with output files
+                  example: outputbucket
+                credentials:
+                  type: object
+                  additionalProperties: false
+                  required:
+                    - accessKeyId
+                    - secretAccessKey
+                  description: Credentials for the output video storage
+                  properties:
+                    accessKeyId:
+                      type: string
+                      description: Access Key ID
+                      example: AKIAIOSFODNN7EXAMPLE
+                    secretAccessKey:
+                      type: string
+                      description: Secret Access Key
+                      example: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+            - type: object
+              additionalProperties: false
+              required:
+                - type
+                - credentials
+              description: Storage for the output files
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - web3.storage
+                  description: Type of service used for output files
+                credentials:
+                  type: object
+                  additionalProperties: false
+                  required:
+                    - proof
+                  description: >-
+                    Delegation proof for Livepeer to be able to upload to
+                    web3.storage
+                  properties:
+                    proof:
+                      type: string
+                      description: Base64 encoded UCAN delegation proof
+                      example: >-
+                        EaJlcm9vdHOAZ3ZlcnNpb24BmgIBcRIg2uxHpcPYSWNtifMKFkPC7IEDvFDCxCd3ADViv0coV7SnYXNYRO2hA0AnblHEW38s3lSlcwaDjPn
+        outputs:
+          type: object
+          additionalProperties: false
+          description: Output formats
+          properties:
+            hls:
+              type: object
+              additionalProperties: false
+              required:
+                - path
+              description: HLS output format
+              properties:
+                path:
+                  type: string
+                  description: Path for the HLS output
+                  example: /samplevideo/hls
+            mp4:
+              type: object
+              additionalProperties: false
+              required:
+                - path
+              description: MP4 output format
+              properties:
+                path:
+                  type: string
+                  description: Path for the MP4 output
+                  example: /samplevideo/mp4
+        profiles:
+          type: array
+          items:
+            $ref: "#/components/schemas/ffmpeg-profile"
+        targetSegmentSizeSecs:
+          type: number
+          description:
+            How many seconds the duration of each output segment should be
+        catalystPipelineStrategy:
+          $ref: >-
+            #/components/schemas/task/properties/params/properties/upload/properties/catalystPipelineStrategy
+    task:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          description: Task ID
+          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
+        userId:
+          type: string
+          description: User ID of the task owner
+          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
+        type:
+          type: string
+          description: Type of the task
+          enum:
+            - upload
+            - import
+            - export
+            - transcode
+            - transcode-file
+        createdAt:
+          type: number
+          description: Timestamp (in milliseconds) at which task was created
+          example: 1587667174725
+        scheduledAt:
+          type: number
+          description: |
+            Timestamp (in milliseconds) at which the task was scheduled for
+            execution (e.g. after file upload finished).
+          example: 1587667174725
+        deleted:
+          type: boolean
+          description: Set to true when the task is deleted
+        inputAssetId:
+          type: string
+          description: ID of the input asset
+          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
+        outputAssetId:
+          type: string
+          description: ID of the output asset
+          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
+        params:
+          type: object
+          additionalProperties: false
+          description: Parameters of the task
+          properties:
+            upload:
+              type: object
+              additionalProperties: false
+              description: Parameters for the upload task
+              properties:
+                url:
+                  type: string
+                  description: URL of the asset to "upload"
+                  example: "https://cdn.livepeer.com/ABC123/filename.mp4"
+                encryption:
+                  $ref: "#/components/schemas/new-asset-payload/properties/encryption"
+                recordedSessionId:
+                  type: string
+                  description: >-
+                    ID of the original recorded session to avoid re-transcoding
+                    of the same content. Only used for import task.
+                  example: 78df0075-b5f3-4683-a618-1086faca35dc
+                uploadedObjectKey:
+                  type: string
+                  description: S3 object key of the uploaded asset
+                  example: ABC123/filename.mp4
+                catalystPipelineStrategy:
+                  type: string
+                  description: >-
+                    Force to use a specific strategy in the Catalyst pipeline.
+                    If not specified, the default strategy that Catalyst is
+                    configured for will be used. This field only available for
+                    admin users, and is only used for E2E testing.
+                  enum:
+                    - catalyst
+                    - catalyst_ffmpeg
+                    - background_external
+                    - background_mist
+                    - fallback_external
+                    - external
+            import:
+              $ref: "#/components/schemas/task/properties/params/properties/upload"
+            export:
+              $ref: "#/components/schemas/export-task-params"
+            transcode:
+              type: object
+              additionalProperties: false
+              description: Parameters for the transcode task
+              properties:
+                profile:
+                  $ref: "#/components/schemas/ffmpeg-profile"
+            transcode-file:
+              type: object
+              additionalProperties: false
+              description: Parameters for the transcode-file task
+              properties:
+                input:
+                  type: object
+                  additionalProperties: false
+                  description: Input video file to transcode
+                  properties:
+                    url:
+                      type: string
+                      description: >-
+                        URL of a video to transcode, accepts object-store format
+                        "s3+https"
+                      example: "https://cdn.livepeer.com/ABC123/filename.mp4"
+                storage:
+                  type: object
+                  additionalProperties: false
+                  description: Storage for the output files
+                  properties:
+                    url:
+                      type: string
+                      description: >-
+                        URL of the output storage, accepts object-store format
+                        "s3+https"
+                      example: "s3+https://accessKeyId:secretAccessKey@s3Endpoint/bucket"
+                outputs:
+                  type: object
+                  additionalProperties: false
+                  description: Output formats
+                  properties:
+                    hls:
+                      type: object
+                      additionalProperties: false
+                      description: HLS output format
+                      properties:
+                        path:
+                          type: string
+                          description: Path for the HLS output
+                          example: /samplevideo/hls
+                    mp4:
+                      type: object
+                      additionalProperties: false
+                      description: MP4 output format
+                      properties:
+                        path:
+                          type: string
+                          description: Path for the MP4 output
+                          example: /samplevideo/mp4
+                profiles:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/ffmpeg-profile"
+                targetSegmentSizeSecs:
+                  type: number
+                  description: >-
+                    How many seconds the duration of each output segment should
+                    be
+                catalystPipelineStrategy:
+                  type: string
+                  description: >-
+                    Force to use a specific strategy in the Catalyst pipeline.
+                    If not specified, the default strategy that Catalyst is
+                    configured for will be used. This field only available for
+                    admin users, and is only used for E2E testing.
+                  enum:
+                    - catalyst
+                    - catalyst_ffmpeg
+                    - background_external
+                    - background_mist
+                    - fallback_external
+                    - external
+        status:
+          type: object
+          additionalProperties: false
+          description: Status of the task
+          required:
+            - phase
+            - updatedAt
+          properties:
+            phase:
+              type: string
+              description: Phase of the task
+              enum:
+                - pending
+                - waiting
+                - running
+                - failed
+                - completed
+                - cancelled
+            updatedAt:
+              type: number
+              description: Timestamp (in milliseconds) at which task was updated
+              example: 1587667174725
+            progress:
+              type: number
+              description: Current progress of the task in a 0-1 ratio
+            errorMessage:
+              type: string
+              description: Error message if the task failed
+            retries:
+              type: number
+              description: Number of retries done on the task
+            step:
+              type: string
+              writeOnly: true
+              description: Step of the task processing
+        output:
+          type: object
+          additionalProperties: false
+          description: Output of the task
+          properties:
+            upload:
+              type: object
+              additionalProperties: true
+              description: Output of the upload task
+              properties:
+                videoFilePath:
+                  type: string
+                  writeOnly: true
+                metadataFilePath:
+                  type: string
+                  writeOnly: true
+                assetSpec:
+                  $ref: "#/components/schemas/asset"
+            import:
+              $ref: "#/components/schemas/task/properties/output/properties/upload"
+            export:
+              type: object
+              additionalProperties: false
+              description: Output of the export task
+              properties:
+                internal:
+                  writeOnly: true
+                  description: |
+                    Internal data of the export task that should not be returned
+                    to users. Contains internal tracking information like which
+                    service was used for the export in case it is maintained by
+                    us (e.g. the first-party piñata service).
+                ipfs:
+                  type: object
+                  additionalProperties: false
+                  required:
+                    - videoFileCid
+                  properties:
+                    videoFileCid:
+                      type: string
+                      description: IPFS CID of the exported video file
+                    videoFileUrl:
+                      type: string
+                      description: URL for the file with the IPFS protocol
+                    videoFileGatewayUrl:
+                      type: string
+                      description:
+                        URL to access file via HTTP through an IPFS gateway
+                    nftMetadataCid:
+                      type: string
+                      description:
+                        IPFS CID of the default metadata exported for the video
+                    nftMetadataUrl:
+                      type: string
+                      description:
+                        URL for the metadata file with the IPFS protocol
+                    nftMetadataGatewayUrl:
+                      type: string
+                      description: >-
+                        URL to access metadata file via HTTP through an IPFS
+                        gateway
+            transcode:
+              type: object
+              additionalProperties: false
+              properties:
+                asset:
+                  type: object
+                  additionalProperties: true
+                  properties:
+                    videoFilePath:
+                      type: string
+                    metadataFilePath:
+                      type: string
+                    assetSpec:
+                      type: object
+                      $ref: "#/components/schemas/asset"
+    export-task-params:
+      description: Parameters for the export task
+      oneOf:
+        - type: object
+          additionalProperties: false
+          required:
+            - custom
+          properties:
+            custom:
+              type: object
+              description: custom URL parameters for the export task
+              additionalProperties: false
+              required:
+                - url
+              properties:
+                url:
+                  type: string
+                  format: uri
+                  pattern: "^http(s)?://"
+                  description: URL where to export the asset
+                  example: >-
+                    https://s3.amazonaws.com/my-bucket/path/filename.mp4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=LLMMB
+                method:
+                  type: string
+                  description: Method to use on the export request
+                  default: PUT
+                headers:
+                  type: object
+                  description: Headers to add to the export request
+                  additionalProperties:
+                    type: string
+        - type: object
+          additionalProperties: false
+          required:
+            - ipfs
+          properties:
+            ipfs:
+              type: object
+              additionalProperties: false
+              properties:
+                $ref: >-
+                  #/components/schemas/asset/properties/storage/properties/ipfs/properties/spec/properties
+                pinata:
+                  description: >-
+                    Custom credentials for the Piñata service. Must have either
+                    a JWT or an API key and an API secret.
+                  oneOf:
+                    - type: object
+                      additionalProperties: false
+                      required:
+                        - jwt
+                      properties:
+                        jwt:
+                          type: string
+                          writeOnly: true
+                          description: >-
+                            Will be added to the Authorization header as a
+                            Bearer token.
+                    - type: object
+                      additionalProperties: false
+                      required:
+                        - apiKey
+                        - apiSecret
+                      properties:
+                        apiKey:
+                          type: string
+                          description:
+                            Will be added to the pinata_api_key header.
+                        apiSecret:
+                          type: string
+                          writeOnly: true
+                          description:
+                            Will be added to the pinata_secret_api_key header.
+    signing-key:
+      type: object
+      additionalProperties: false
+      required:
+        - publicKey
+      properties:
+        id:
+          type: string
+          example: 78df0075-b5f3-4683-a618-1086faca35dc
+        name:
+          type: string
+          description: Name of the signing key
+        createdAt:
+          type: number
+          description:
+            Timestamp (in milliseconds) at which the signing-key was created
+          example: 1587667174725
+        lastSeen:
+          type: number
+          description:
+            Timestamp (in milliseconds) at which the signing-key was last used
+          example: 1587667174725
+        userId:
+          type: string
+          example: 78df0075-b5f3-4683-a618-1086faca35dc
+        publicKey:
+          type: string
+        deleted:
+          type: boolean
+          default: false
+        disabled:
+          type: boolean
+          description: Disable the signing key to allow rotation safely
+    signing-key-response-payload:
+      type: object
+      required:
+        - publicKey
+        - privateKey
+      properties:
+        $ref: "#/components/schemas/signing-key/properties"
+        privateKey:
+          type: string
+    api-token:
+      type: object
+      additionalProperties: false
+      properties:
+        kind:
+          type: string
+          example: user
+        id:
+          type: string
+          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
+        userId:
+          type: string
+          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
+        name:
+          type: string
+          example: Example Token
+        access:
+          type: object
+          additionalProperties: false
+          properties:
+            cors:
+              type: object
+              additionalProperties: false
+              properties:
+                fullAccess:
+                  type: boolean
+                  description: >-
+                    Whether the token grants full access to the API. If false,
+                    the token will only have access to some pre-defined
+                    endpoints, not expose the whole account from the webpage.
+                  default: false
+                allowedOrigins:
+                  type: array
+                  description: >-
+                    Origins from which the token can be used. If empty, CORS
+                    will be prohibited by default (safest). To allow all origin
+                    values set this to `[*]`.
+                  default: []
+                  items:
+                    type: string
+                    example: "https://example.com"
+            rules:
+              type: array
+              default:
+                - resources:
+                    - "*"
+              items:
+                type: object
+                additionalProperties: false
+                required:
+                  - resources
+                properties:
+                  resources:
+                    type: array
+                    minItems: 1
+                    items:
+                      type: string
+                  methods:
+                    type: array
+                    minItems: 1
+                    default:
+                      - "*"
+                    items:
+                      type: string
+                      enum:
+                        - post
+                        - get
+                        - put
+                        - patch
+                        - delete
+                        - head
+                        - options
+                        - "*"
+        lastSeen:
+          type: number
+          example: 1587667174725
+        createdAt:
+          type: number
+          description:
+            Timestamp (in milliseconds) at which token object was created
+          example: 1587667174725
+    user-verification:
+      type: object
+      required:
+        - email
+        - emailValidToken
+      additionalProperties: false
+      properties:
+        email:
+          type: string
+          description: user email address
+          example: useremail@gmail.com
+        emailValidToken:
+          type: string
+          example: E1F53135E559C253
+          writeOnly: true
+    verify-email:
+      type: object
+      required:
+        - email
+      additionalProperties: false
+      properties:
+        email:
+          type: string
+          description: user email address
+          example: useremail@gmail.com
+    make-admin:
+      type: object
+      required:
+        - email
+        - admin
+      additionalProperties: false
+      properties:
+        email:
+          type: string
+          description: user email address
+          example: useremail@gmail.com
+        admin:
+          type: boolean
+          example: true
+    password-reset-token:
+      type: object
+      required:
+        - kind
+        - userId
+        - resetToken
+        - expiration
+      additionalProperties: false
+      properties:
+        kind:
+          type: string
+          enum:
+            - password-reset-token
+        userId:
+          type: string
+          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
+        resetToken:
+          type: string
+          example: E1F53135E559C253
+          writeOnly: true
+        expiration:
+          type: number
+          description:
+            Timestamp (in milliseconds) at which reset token will be expired
+          example: 1587667174725
+    password-reset-token-request:
+      type: object
+      required:
+        - email
+      additionalProperties: false
+      properties:
+        email:
+          type: string
+          description: user email address
+          example: useremail@gmail.com
+    password-reset-confirm:
+      type: object
+      required:
+        - email
+        - resetToken
+        - password
+      additionalProperties: false
+      properties:
+        email:
+          type: string
+          description: user email address
+          example: useremail@gmail.com
+        resetToken:
+          type: string
+          example: E1F53135E559C253
+          writeOnly: true
+        password:
+          type: string
+          example: thisisapassword
+          minLength: 64
+          maxLength: 64
+        userId:
+          type: string
+          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
+    create-customer:
+      type: object
+      required:
+        - email
+      additionalProperties: false
+      properties:
+        email:
+          type: string
+          description: user email address
+          example: useremail@gmail.com
+    create-subscription:
+      type: object
+      required:
+        - stripeCustomerId
+        - stripeProductId
+      additionalProperties: false
+      properties:
+        stripeCustomerId:
+          type: string
+          description: stripe customer id
+          example: cus_xxxxxxxxxxxxxx
+        stripeCustomerPaymentMethodId:
+          type: string
+          description: stripe payment method id
+          example: src_xxxxxxxxxxxxxxxxxxxxxxxx
+        stripeProductId:
+          type: string
+          description: stripe product id
+          enum:
+            - prod_0
+            - prod_1
+            - prod_2
+    update-subscription:
+      type: object
+      required:
+        - stripeCustomerId
+        - stripeProductId
+      additionalProperties: false
+      properties:
+        stripeCustomerId:
+          type: string
+          description: stripe customer id
+          example: cus_xxxxxxxxxxxxxx
+        stripeCustomerSubscriptionId:
+          type: string
+          description: stripe subscription id
+          example: sub_xxxxxxxxxxxxxx
+        stripeCustomerPaymentMethodId:
+          type: string
+          description: stripe payment method id
+          example: pm_xxxxxxxxxxxxxxxxxxxxxxxx
+        stripeProductId:
+          type: string
+          description: stripe product id
+          enum:
+            - prod_0
+            - prod_1
+            - prod_2
+    update-customer-payment-method:
+      type: object
+      required:
+        - stripeCustomerId
+        - stripeCustomerPaymentMethodId
+      additionalProperties: false
+      properties:
+        stripeCustomerId:
+          type: string
+          description: stripe customer id
+          example: cus_xxxxxxxxxxxxxx
+        stripeCustomerPaymentMethodId:
+          type: string
+          description: stripe payment method id
+          example: pm_xxxxxxxxxxxxxxxxxxxxxxxx
+    retrieve-customer-payment-method:
+      type: object
+      required:
+        - stripeCustomerPaymentMethodId
+      additionalProperties: false
+      properties:
+        stripeCustomerPaymentMethodId:
+          type: string
+          description: stripe payment method id
+          example: src_xxxxxxxxxxxxxxxxxxxxxxxx
+    region:
+      type: object
+      required:
+        - region
+        - orchestrators
+      properties:
+        region:
+          type: string
+          description: region name
+          example: ber
+        orchestrators:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            required:
+              - address
+            properties:
+              address:
+                type: string
+    user:
+      type: object
+      required:
+        - email
+        - password
+      additionalProperties: false
+      properties:
+        email:
+          type: string
+          description: user email address
+          example: useremail@gmail.com
+        password:
+          type: string
+          example: thisisapassword
+          minLength: 64
+          maxLength: 64
+          writeOnly: true
+        emailValidToken:
+          type: string
+          example: E1F53135E559C253
+          writeOnly: true
+        emailValid:
+          type: boolean
+          example: true
+        suspended:
+          type: boolean
+        salt:
+          type: string
+          example: E1F53135E559C253
+          writeOnly: true
+        admin:
+          type: boolean
+          example: true
+        kind:
+          type: string
+          example: user
+        id:
+          type: string
+          example: abc123
+        firstName:
+          type: string
+          example: Joe
+        lastName:
+          type: string
+          example: Smith
+        organization:
+          type: string
+          example: Livepeer
+        phone:
+          type: string
+          example: 2034212122
+        stripeProductId:
+          type: string
+          enum:
+            - prod_0
+            - prod_1
+            - prod_2
+        stripeCustomerId:
+          type: string
+          example: cus_Jv6KvgT0DCH8HU
+        stripeCustomerPaymentMethodId:
+          type: string
+          example: pm_2FSSNNJfrKDAwlJ9n4EN15Du
+        stripeCustomerSubscriptionId:
+          type: string
+          example: sub_I29pdyfOTPBkjb
+        ccLast4:
+          type: string
+          example: 1234
+        ccBrand:
+          type: string
+          example: 1234
+        createdAt:
+          type: number
+          description:
+            Timestamp (in milliseconds) at which user object was created
+          example: 1587667174725
+        verifiedAt:
+          type: number
+          description:
+            Timestamp (in milliseconds) at which user object was verified
+          example: 1587667174725
+        planChangedAt:
+          type: number
+          description:
+            Timestamp (in milliseconds) at which user object was verified
+          example: 1587667174725
+        lastStreamedAt:
+          type: number
+          description: >-
+            Timestamp (in milliseconds) at which user streamed RTMP stream last
+            time
+          example: 1587667174725
+        lastSeen:
+          type: number
+          description:
+            Timestamp (in milliseconds) at which user's password was used
+          example: 1587667174725
+        recaptchaToken:
+          type: string
+          example: >-
+            03AGdBq24blDQQCyt9BSYjS0YZ3-tZapaQ5xO2-oykG_4dS_91TzH9qOziOwXbff_QiDOsXmWKxqtOrmOEx7qjijNhbexBzvNjM6HbbhXcji1rKcxxQRsL-t3SbycwZuNXos9OjnrYmfV9F3zsy1o73ia5Wlw_Zcf1jwbm3n-yQ2epifcMHXJhsUrqmUe6a1J1mPaD2heHvCOS3vYm0rWijdMl2E4bXQf75BiWvbLKxCWv5ZF8279nCMcGyJBIw1kno-A0x5KTOlEVxV369nz12lkvRfOtRABKB49jMTygAc2BKh9GBlAYGO6PBPoIk7_BCo7I_hsHoJeT4c80ucOPraZby0QJM5jcCQcqVCYrcaPKPiUMcIEixIhB5FAfDs88uYqDWMcgZdMRKCvmxEC3ONDVDtq0nLMc4rniuC5sQTz1E4D6SR_Adik
+          description: Recaptcha v3 Token
+          writeOnly: true
+        internal:
+          type: boolean
+          example: false
+          description:
+            Internal user that should be disregarded from usage information
+        isTestUser:
+          type: boolean
+          example: false
+          description:
+            User creates test streams and playbackIds should be flagged as such
+    experiment:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: Name that identifies the experiment. Must be unique
+        userId:
+          type: string
+          description: >-
+            User ID of the creator of the experiment. Only used for auditing as
+            experiment APIs is only accessible to admins, which can all
+            experiments anyway.
+        createdAt:
+          type: number
+          description:
+            Timestamp (in milliseconds) at which the experiment was created
+          example: 1587667174725
+        updatedAt:
+          type: number
+          description:
+            Timestamp (in milliseconds) at which experiment was updated
+          example: 1587667174725
+        audienceUserIds:
+          type: array
+          description: List of user IDs in the experiment
+          items:
+            type: string
+        audienceUsers:
+          type: array
+          description: User objects of users in the experiment for convenience
+          items:
+            $ref: "#/components/schemas/user"
+    usage:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          description: day associated with usage
+          example: 2021-01-30T00:00:00.000Z
+        kind:
+          type: string
+          example: usage
+        date:
+          type: number
+          example: usage
+        sourceSegments:
+          type: number
+          example: 200000
+        transcodedSegments:
+          type: number
+          example: 200000
+        sourceSegmentsDuration:
+          type: number
+          example: 200000
+        transcodedSegmentsDuration:
+          type: number
+          example: 200000
+        streamCount:
+          type: number
+          example: 200000
+paths:
+  /stream:
+    post:
+      description: Creates a stream
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              $ref: "#/components/schemas/stream"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/stream"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+    get:
+      description: Lists streams
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/stream"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+  "/stream/{id}":
+    parameters:
+      - name: id
+        description: ID of the stream
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      description: Gets a specific stream details
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/stream"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+    patch:
+      description: Patch a specific stream
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/stream-patch-payload"
+      responses:
+        "204":
+          description: Success
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+  /object-store:
+    post:
+      description: Receives store credentials
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              $ref: "#/components/schemas/object-store"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/object-store"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+    get:
+      description: Lists object store credentials by userId
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/object-store"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+  /multistream/target:
+    get:
+      description: Lists existing multistream targets
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/multistream-target"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+    post:
+      description: Creates new multistream target
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/multistream-target"
+      responses:
+        "201":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/multistream-target"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+  "/multistream/target/{id}":
+    parameters:
+      - name: id
+        description: ID of the multistream target
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      description: Gets a specific multistream target details
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/multistream-target"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+    patch:
+      description: Enables or disables an existing multistream target
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/multistream-target-patch-payload"
+      responses:
+        "204":
+          description: Success
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+    delete:
+      description: Deletes an existing multistream target
+      responses:
+        "204":
+          description: Success
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+  /user-verification:
+    post:
+      description: Verifies user email
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              $ref: "#/components/schemas/user-verification"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/user-verification"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+  /password-reset-token:
+    post:
+      description: Creates a password reset token
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              $ref: "#/components/schemas/password-reset-token-request"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/password-reset-token"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+  /password-reset:
+    post:
+      description: Confirms password reset token
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              $ref: "#/components/schemas/password-reset-confirm"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/user"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+  /verify-email:
+    post:
+      description: Resend User Email Verification
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              $ref: "#/components/schemas/verify-email"
+      responses:
+        "200":
+          description: Success
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+  /make-admin:
+    post:
+      description: Changes user admin status
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              $ref: "#/components/schemas/make-admin"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                items:
+                  $ref: "#/components/schemas/user"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+  /user/token:
+    post:
+      description: Receives user login information
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              $ref: "#/components/schemas/user"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/user"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+  /user:
+    post:
+      description: Receives user information
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              $ref: "#/components/schemas/user"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/user"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+    get:
+      description: Lists users
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/user"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+  "/user/{id}":
+    patch:
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      description: updates a user
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/user"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+  /api-token:
+    post:
+      description: Contains api token information
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              $ref: "#/components/schemas/api-token"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/api-token"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+    get:
+      description: Lists api tokens
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/api-token"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-token"
+  /webhook:
+    get:
+      description: gets a list of webhooks defined by the user
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/webhook"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+    post:
+      description: creates a new webhook
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/webhook"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+  "/webhook/{id}":
+    get:
+      description: gets a specific webhook details
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/webhook"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+    put:
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      description: updates a specific webhook
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/webhook"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+    delete:
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      description: deletes a specific webhook details
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/webhook"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+  /asset:
+    get:
+      description: gets a list of assets defined by the user
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/asset"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+  "/region/{region}":
+    get:
+      description: get a regions list of orchestrators
+      parameters:
+        - name: region
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/region"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+    put:
+      parameters:
+        - name: region
+          in: path
+          required: true
+          schema:
+            type: string
+      description: updates a specific region
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/region"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+    delete:
+      parameters:
+        - name: region
+          in: path
+          required: true
+          schema:
+            type: string
+      description: deletes a specific region
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/webhook"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+  /room:
+    post:
+      description: create a new room
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -2351,7 +2351,7 @@ components:
         planChangedAt:
           type: number
           description:
-            Timestamp (in milliseconds) at which user object was verified
+            Timestamp (in milliseconds) at which the user plan has changed
           example: 1587667174725
         lastStreamedAt:
           type: number

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -810,8 +810,7 @@ components:
           description: Points to parent stream object
         record:
           description: >-
-            Should this stream be recorded? Uses default settings. For more
-            customization, create and configure an object store.
+            Whether this session was recorded or not.
           type: boolean
           example: false
         recordingStatus:

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -1217,7 +1217,9 @@ components:
         videoSpec:
           type: object
           additionalProperties: false
-          description: Video metadata
+          description:
+            Specific video metadata about the asset. Most of these fields are only returned if a 
+            `?details=true` query-string is present on the request.
           properties:
             format:
               type: string

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -1368,7 +1368,7 @@ components:
           pattern: "^(https?|ipfs|ar)://"
           description: >-
             URL where the asset contents can be retrieved. Only valid for the
-            import task endpoint.
+            upload via URL endpoint.
           example: "https://s3.amazonaws.com/my-bucket/path/filename.mp4"
         encryption:
           type: object

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -416,8 +416,7 @@ components:
             example: P720p60fps16x9
         record:
           description: >-
-            Should this stream be recorded? Uses default settings. For more
-            customization, create and configure an object store.
+            Whether this stream should be recorded.
           type: boolean
           example: false
         recordObjectStoreId:

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -2319,6 +2319,7 @@ components:
           example: 2034212122
         stripeProductId:
           type: string
+          description: Identifier of the plan that the user is subscribed to.
           enum:
             - prod_0
             - prod_1

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -57,75 +57,6 @@ components:
             - hevc
             - vp8
             - vp9
-    cdn-data-row:
-      type: object
-      description: >-
-        Fields names taken from log format description
-        https://support.highwinds.com/hc/en-us/articles/360052181571-Raw-Log-Access-through-GCS
-      additionalProperties: false
-      required:
-        - unique_client_ips
-        - total_sc_bytes
-      properties:
-        stream_id:
-          type: string
-          description: Session UUID. Used in recordings URLs.
-        playback_id:
-          type: string
-          description: Playback ID.
-        unique_client_ips:
-          type: number
-          description: >-
-            Number of unique IP addresses of clients. Not accurate because
-            StackPath zeroes last part of the IP address.
-        total_filesize:
-          type: number
-          description: Size of the asset being delivered.
-        total_cs_bytes:
-          type: number
-          description: The total size of the request header.
-        total_sc_bytes:
-          type: number
-          description: Total bytes in the response to the client.
-        count:
-          type: number
-          description: Number of parsed log lines
-    cdn-data-payload:
-      type: array
-      items:
-        type: object
-        additionalProperties: false
-        required:
-          - region
-          - file_name
-          - date
-          - data
-        properties:
-          region:
-            type: string
-          file_name:
-            type: string
-          date:
-            type: number
-          data:
-            type: array
-            minItems: 1
-            items:
-              $ref: "#/components/schemas/cdn-data-row"
-    cdn-usage-last:
-      type: object
-      required:
-        - region
-        - fileName
-      additionalProperties: false
-      properties:
-        id:
-          type: string
-          example: de7818e7-610a-4057-8f6f-b785dc1e6f88
-        fileName:
-          type: number
-        region:
-          type: string
     webhook:
       type: object
       required:
@@ -136,24 +67,13 @@ components:
         id:
           type: string
           example: de7818e7-610a-4057-8f6f-b785dc1e6f88
-        kind:
-          type: string
-          example: webhook
         name:
-          type: string
-        userId:
           type: string
         createdAt:
           type: number
           description:
             Timestamp (in milliseconds) at which stream object was created
           example: 1587667174725
-        event:
-          writeOnly: true
-          deprecated: true
-          description:
-            "@deprecated Non-persisted field. To be used on creation API only."
-          $ref: "#/components/schemas/webhook/properties/events/items"
         events:
           type: array
           items:
@@ -182,9 +102,6 @@ components:
           type: string
           format: uri
           pattern: "^http(s)?://"
-        deleted:
-          type: boolean
-          default: false
         sharedSecret:
           type: string
           writeOnly: true
@@ -233,9 +150,6 @@ components:
         id:
           type: string
           example: de7818e7-610a-4057-8f6f-b785dc1e6f88
-        kind:
-          type: string
-          example: webhookResponse
         webhookId:
           type: string
         eventId:
@@ -301,15 +215,10 @@ components:
         id:
           type: string
           example: de7818e7-610a-4057-8f6f-b785dc1e6f88
-        kind:
-          type: string
-          example: stream
         name:
           type: string
           example: test_stream
-        userId:
-          type: string
-          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
+
         lastSeen:
           type: number
           example: 1587667174725
@@ -341,17 +250,12 @@ components:
           type: number
           example: 2
           description: Rate at which transcodedBytes increases (bytes/second)
-        deleted:
-          type: boolean
-          description: Set to true when stream deleted
         isActive:
           type: boolean
           description: If currently active
         createdByTokenName:
           type: string
           description: Name of the token used to create this object
-        createdByTokenId:
-          type: string
         createdAt:
           type: number
           description:
@@ -396,34 +300,12 @@ components:
               height: 720
           items:
             $ref: "#/components/schemas/ffmpeg-profile"
-        objectStoreId:
-          type: string
-          example: D8321C3E-B29C-45EB-A1BB-A623D8BE0F65
-        presets:
-          type: array
-          items:
-            type: string
-            enum:
-              - P720p60fps16x9
-              - P720p30fps16x9
-              - P720p30fps4x3
-              - P576p30fps16x9
-              - P360p30fps16x9
-              - P360p30fps4x3
-              - P240p30fps16x9
-              - P240p30fps4x3
-              - P144p30fps16x9
-            example: P720p60fps16x9
         record:
           description: >-
-            Whether this stream should be recorded.
+            Should this stream be recorded? Uses default settings. For more
+            customization, create and configure an object store.
           type: boolean
           example: false
-        recordObjectStoreId:
-          type: string
-          example: D8321C3E-B29C-45EB-A1BB-A623D8BE0F65
-          description:
-            ID of object store where to which this stream was recorded
         multistream:
           type: object
           additionalProperties: false
@@ -475,82 +357,6 @@ components:
                         type: string
                       url:
                         $ref: "#/components/schemas/multistream-target/properties/url"
-        wowza:
-          type: object
-          required:
-            - transcoderAppConfig
-            - transcoderTemplateAppConfig
-            - streamNameGroups
-            - sourceInfo
-          additionalProperties: false
-          properties:
-            transcoderAppConfig:
-              type: object
-            transcoderTemplateAppConfig:
-              type: object
-            streamNameGroups:
-              type: array
-              items:
-                type: string
-            sourceInfo:
-              type: object
-              required:
-                - width
-                - height
-                - fps
-              additionalProperties: false
-              properties:
-                width:
-                  type: integer
-                height:
-                  type: integer
-                fps:
-                  type: integer
-        renditions:
-          type: object
-          additionalProperties:
-            type: string
-        detection:
-          type: object
-          description: >-
-            Custom configuration for audio/video detection algorithms to be run
-            on the stream. If no config is provided and a webhook is subscribed
-            to the stream.detection event, a default config will be used.
-          default:
-            sceneClassification:
-              - name: soccer
-              - name: adult
-          required:
-            - sceneClassification
-          additionalProperties: false
-          properties:
-            sceneClassification:
-              type: array
-              minItems: 1
-              items:
-                type: object
-                description: >-
-                  Scene classification options. Must contain name property with
-                  one of the well-defined classes supported by detection models.
-                additionalProperties: false
-                required:
-                  - name
-                properties:
-                  name:
-                    type: string
-                    enum:
-                      - soccer
-                      - adult
-        region:
-          type: string
-          example: fra
-          description: Region in which this session object was created
-        broadcasterHost:
-          type: string
-          description: Hostname of the broadcaster that transcodes that stream
-        mistHost:
-          type: string
-          description: Hostname of the Mist server that processes that stream
         suspended:
           type: boolean
           description: If currently suspended
@@ -610,30 +416,8 @@ components:
           $ref: "#/components/schemas/object-store/properties/url"
         publicUrl:
           $ref: "#/components/schemas/object-store/properties/publicUrl"
-    suspend-user-payload:
-      type: object
-      additionalProperties: false
-      required:
-        - suspended
-      properties:
-        suspended:
-          $ref: "#/components/schemas/user/properties/suspended"
-        emailTemplate:
-          type: string
-          description:
-            Name of template to send to the users regarding the suspension.
-          enum:
-            - copyright
     multistream-target-patch-payload:
       $ref: "#/components/schemas/multistream-target"
-    signing-key-patch-payload:
-      type: object
-      additionalProperties: false
-      properties:
-        name:
-          $ref: "#/components/schemas/signing-key/properties/name"
-        disabled:
-          $ref: "#/components/schemas/signing-key/properties/disabled"
     webhook-patch-payload:
       type: object
       additionalProperties: false
@@ -657,91 +441,6 @@ components:
           description: Error message if the webhook failed to process the event
         response:
           $ref: "#/components/schemas/webhook-response"
-    access-control-gate-payload:
-      type: object
-      additionalProperties: false
-      required:
-        - type
-        - stream
-      properties:
-        type:
-          type: string
-          enum:
-            - jwt
-            - accessKey
-        stream:
-          type: string
-          description: Stream ID to which this gate applies
-        pub:
-          type: string
-          description: Base64 of Public key used for JWT verification
-        accessKey:
-          type: string
-          description: Access key used for access-control verification
-    experiment-audience-payload:
-      type: object
-      additionalProperties: false
-      properties:
-        addUsers:
-          type: array
-          items:
-            type: string
-            description:
-              Email or ID of users that should be added to the experiment
-        removeUsers:
-          type: array
-          items:
-            type: string
-            description:
-              Email or ID of users that should be removed from the experiment
-    playback-policy:
-      type: object
-      description:
-        Whether the playback policy for a asset or stream is public or signed
-      additionalProperties: false
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - public
-            - jwt
-            - lit_signing_condition
-            - webhook
-        unifiedAccessControlConditions:
-          type: array
-          description: LIT Unified Access Control Conditions
-          items:
-            type: object
-        resourceId:
-          type: object
-          description: LIT Resource ID
-          additionalProperties: false
-          required:
-            - baseUrl
-            - path
-            - orgId
-            - role
-            - extraData
-          properties:
-            baseUrl:
-              type: string
-            path:
-              type: string
-            orgId:
-              type: string
-            role:
-              type: string
-            extraData:
-              type: string
-        webhookId:
-          type: string
-          description: ID of the webhook to use for playback policy
-        webhookContext:
-          type: object
-          description: User-defined webhook context
-          additionalProperties: true
     session:
       type: object
       required:
@@ -752,15 +451,10 @@ components:
         id:
           type: string
           example: de7818e7-610a-4057-8f6f-b785dc1e6f88
-        kind:
-          type: string
-          example: stream
         name:
           type: string
           example: test_session
-        userId:
-          type: string
-          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
+
         lastSeen:
           type: number
           example: 1587667174725
@@ -792,12 +486,6 @@ components:
           type: number
           example: 2
           description: Rate at which transcodedBytes increases (bytes/second)
-        broadcasterHost:
-          type: string
-          description: Hostname of the broadcaster that transcodes that stream
-        deleted:
-          type: boolean
-          description: Set to true when stream deleted
         createdAt:
           type: number
           description:
@@ -809,7 +497,8 @@ components:
           description: Points to parent stream object
         record:
           description: >-
-            Whether this session was recorded or not.
+            Should this stream be recorded? Uses default settings. For more
+            customization, create and configure an object store.
           type: boolean
           example: false
         recordingStatus:
@@ -825,11 +514,6 @@ components:
         mp4Url:
           type: string
           description: URL for the stream session recording packaged in an mp4.
-        recordObjectStoreId:
-          type: string
-          example: D8321C3E-B29C-45EB-A1BB-A623D8BE0F65
-          description:
-            ID of object store where to which this stream was recorded
         playbackId:
           type: string
           example: eaw4nk06ts2d0mzb
@@ -851,43 +535,6 @@ components:
             example:
               - id not provided
               - user not found
-    object-store:
-      type: object
-      required:
-        - url
-      additionalProperties: false
-      properties:
-        url:
-          type: string
-          description: Livepeer-compatible object store URL
-          example: "s3://access-key:secret-key@us-west-2/bucket-name"
-          writeOnly: true
-        publicUrl:
-          type: string
-          description:
-            Public URL at which data in this object storage can be accessed
-          example: "https://reg-rec.livepeer.live/some/path"
-        disabled:
-          type: boolean
-          description: >-
-            If true then these object store will not be used for recording even
-            if it is configured in the API command line.
-        deleted:
-          type: boolean
-          description: Set to true when the object store is deleted
-        id:
-          type: string
-          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
-        userId:
-          type: string
-          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
-        name:
-          type: string
-        createdAt:
-          type: number
-          description:
-            Timestamp (in milliseconds) at which object store object was created
-          example: 1587667174725
     multistream-target:
       type: object
       required:
@@ -912,9 +559,7 @@ components:
           description: >-
             If true then this multistream target will not be used for pushing
             even if it is configured in a stream object.
-        userId:
-          type: string
-          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
+
         createdAt:
           type: number
           description: >-
@@ -943,61 +588,10 @@ components:
           type: string
           example: eaw4nk06ts2d0mzb
           description: Used to form playback URL and storage folder
-        playbackRecordingId:
-          type: string
-          writeOnly: true
-          example: ea03f37e-f861-4cdd-b495-0e60b6d753ad
-          description: Used to form recording URL for HLS playback
         staticMp4:
           type: boolean
           writeOnly: true
           description: Whether to generate MP4s for the asset.
-        files:
-          type: array
-          writeOnly: true
-          description:
-            Internal field with the list of files stored in the object store
-          items:
-            type: object
-            additionalProperties: false
-            required:
-              - type
-              - path
-            properties:
-              type:
-                type: string
-                example: catalyst_hls_manifest
-                description: Type of the file in the VOD system.
-              path:
-                type: string
-                example: /path/to/file
-                description: >-
-                  Path to the file in the asset subfolder in the object store.
-                  This means that all these paths are relative to a folder in
-                  the OS the asset playback ID as the name.
-              spec:
-                type: object
-                additionalProperties: false
-                description: >-
-                  Additional information about the file. For example, for
-                  manifests it contains the list of media files.
-                properties:
-                  size:
-                    type: number
-                    example: 123456
-                    description: Size of the file in bytes.
-                  height:
-                    type: number
-                    example: 1080
-                    description: Height of the video in pixels.
-                  width:
-                    type: number
-                    example: 1920
-                    description: Width of the video in pixels.
-                  bitrate:
-                    type: number
-                    example: 1000000
-                    description: Bitrate of the video in bits per second.
         playbackUrl:
           type: string
           example: >-
@@ -1009,23 +603,6 @@ components:
           description: URL to manually download the asset if desired
         playbackPolicy:
           $ref: "#/components/schemas/playback-policy"
-        userId:
-          type: string
-          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
-          description: owner of the asset
-        deleted:
-          type: boolean
-          description: Set to true when the asset is deleted
-        deletedAt:
-          type: number
-          description:
-            Timestamp (in milliseconds) at which the asset was deleted
-          example: 1587667174725
-        objectStoreId:
-          type: string
-          description: Object store ID where the asset is stored
-          writeOnly: true
-          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
         source:
           oneOf:
             - additionalProperties: false
@@ -1216,9 +793,7 @@ components:
         videoSpec:
           type: object
           additionalProperties: false
-          description:
-            Specific video metadata about the asset. Most of these fields are only returned if a 
-            `?details=true` query-string is present on the request.
+          description: Video metadata
           properties:
             format:
               type: string
@@ -1298,11 +873,6 @@ components:
                     type: number
                     description: Bit depth of the track - only for audio tracks
                     example: 16
-        sourceAssetId:
-          type: string
-          description:
-            "ID of the source asset (root) - If missing, this is a root asset"
-          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
     ipfs-file-info:
       type: object
       required:
@@ -1329,11 +899,6 @@ components:
       required:
         - name
       properties:
-        objectStoreId:
-          type: string
-          description: Object store ID where the asset is stored
-          writeOnly: true
-          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
         name:
           type: string
           description: >-
@@ -1369,7 +934,7 @@ components:
           pattern: "^(https?|ipfs|ar)://"
           description: >-
             URL where the asset contents can be retrieved. Only valid for the
-            upload via URL endpoint.
+            import task endpoint.
           example: "https://s3.amazonaws.com/my-bucket/path/filename.mp4"
         encryption:
           type: object
@@ -1393,31 +958,6 @@ components:
               enum:
                 - aes-cbc
               default: aes-cbc
-        catalystPipelineStrategy:
-          $ref: >-
-            #/components/schemas/task/properties/params/properties/upload/properties/catalystPipelineStrategy
-    transcode-asset-payload:
-      additionalProperties: false
-      required:
-        - name
-        - profile
-      properties:
-        assetId:
-          type: string
-          description: ID of the asset to transcode
-        objectStoreId:
-          type: string
-          description: Object store ID where the asset is stored
-          writeOnly: true
-          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
-        name:
-          type: string
-          description: >-
-            Name of the asset. This is not necessarily the filename, can be a
-            custom name or title
-          example: filename.mp4
-        profile:
-          $ref: "#/components/schemas/ffmpeg-profile"
     transcode-payload:
       additionalProperties: false
       required:
@@ -1589,9 +1129,6 @@ components:
           type: number
           description:
             How many seconds the duration of each output segment should be
-        catalystPipelineStrategy:
-          $ref: >-
-            #/components/schemas/task/properties/params/properties/upload/properties/catalystPipelineStrategy
     task:
       type: object
       additionalProperties: false
@@ -1600,10 +1137,7 @@ components:
           type: string
           description: Task ID
           example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
-        userId:
-          type: string
-          description: User ID of the task owner
-          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
+
         type:
           type: string
           description: Type of the task
@@ -1623,9 +1157,6 @@ components:
             Timestamp (in milliseconds) at which the task was scheduled for
             execution (e.g. after file upload finished).
           example: 1587667174725
-        deleted:
-          type: boolean
-          description: Set to true when the task is deleted
         inputAssetId:
           type: string
           description: ID of the input asset
@@ -1656,24 +1187,6 @@ components:
                     ID of the original recorded session to avoid re-transcoding
                     of the same content. Only used for import task.
                   example: 78df0075-b5f3-4683-a618-1086faca35dc
-                uploadedObjectKey:
-                  type: string
-                  description: S3 object key of the uploaded asset
-                  example: ABC123/filename.mp4
-                catalystPipelineStrategy:
-                  type: string
-                  description: >-
-                    Force to use a specific strategy in the Catalyst pipeline.
-                    If not specified, the default strategy that Catalyst is
-                    configured for will be used. This field only available for
-                    admin users, and is only used for E2E testing.
-                  enum:
-                    - catalyst
-                    - catalyst_ffmpeg
-                    - background_external
-                    - background_mist
-                    - fallback_external
-                    - external
             import:
               $ref: "#/components/schemas/task/properties/params/properties/upload"
             export:
@@ -1744,20 +1257,6 @@ components:
                   description: >-
                     How many seconds the duration of each output segment should
                     be
-                catalystPipelineStrategy:
-                  type: string
-                  description: >-
-                    Force to use a specific strategy in the Catalyst pipeline.
-                    If not specified, the default strategy that Catalyst is
-                    configured for will be used. This field only available for
-                    admin users, and is only used for E2E testing.
-                  enum:
-                    - catalyst
-                    - catalyst_ffmpeg
-                    - background_external
-                    - background_mist
-                    - fallback_external
-                    - external
         status:
           type: object
           additionalProperties: false
@@ -1818,13 +1317,6 @@ components:
               additionalProperties: false
               description: Output of the export task
               properties:
-                internal:
-                  writeOnly: true
-                  description: |
-                    Internal data of the export task that should not be returned
-                    to users. Contains internal tracking information like which
-                    service was used for the export in case it is maintained by
-                    us (e.g. the first-party piñata service).
                 ipfs:
                   type: object
                   additionalProperties: false
@@ -1964,14 +1456,8 @@ components:
           description:
             Timestamp (in milliseconds) at which the signing-key was last used
           example: 1587667174725
-        userId:
-          type: string
-          example: 78df0075-b5f3-4683-a618-1086faca35dc
         publicKey:
           type: string
-        deleted:
-          type: boolean
-          default: false
         disabled:
           type: boolean
           description: Disable the signing key to allow rotation safely
@@ -1984,288 +1470,6 @@ components:
         $ref: "#/components/schemas/signing-key/properties"
         privateKey:
           type: string
-    api-token:
-      type: object
-      additionalProperties: false
-      properties:
-        kind:
-          type: string
-          example: user
-        id:
-          type: string
-          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
-        userId:
-          type: string
-          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
-        name:
-          type: string
-          example: Example Token
-        access:
-          type: object
-          additionalProperties: false
-          properties:
-            cors:
-              type: object
-              additionalProperties: false
-              properties:
-                fullAccess:
-                  type: boolean
-                  description: >-
-                    Whether the token grants full access to the API. If false,
-                    the token will only have access to some pre-defined
-                    endpoints, not expose the whole account from the webpage.
-                  default: false
-                allowedOrigins:
-                  type: array
-                  description: >-
-                    Origins from which the token can be used. If empty, CORS
-                    will be prohibited by default (safest). To allow all origin
-                    values set this to `[*]`.
-                  default: []
-                  items:
-                    type: string
-                    example: "https://example.com"
-            rules:
-              type: array
-              default:
-                - resources:
-                    - "*"
-              items:
-                type: object
-                additionalProperties: false
-                required:
-                  - resources
-                properties:
-                  resources:
-                    type: array
-                    minItems: 1
-                    items:
-                      type: string
-                  methods:
-                    type: array
-                    minItems: 1
-                    default:
-                      - "*"
-                    items:
-                      type: string
-                      enum:
-                        - post
-                        - get
-                        - put
-                        - patch
-                        - delete
-                        - head
-                        - options
-                        - "*"
-        lastSeen:
-          type: number
-          example: 1587667174725
-        createdAt:
-          type: number
-          description:
-            Timestamp (in milliseconds) at which token object was created
-          example: 1587667174725
-    user-verification:
-      type: object
-      required:
-        - email
-        - emailValidToken
-      additionalProperties: false
-      properties:
-        email:
-          type: string
-          description: user email address
-          example: useremail@gmail.com
-        emailValidToken:
-          type: string
-          example: E1F53135E559C253
-          writeOnly: true
-    verify-email:
-      type: object
-      required:
-        - email
-      additionalProperties: false
-      properties:
-        email:
-          type: string
-          description: user email address
-          example: useremail@gmail.com
-    make-admin:
-      type: object
-      required:
-        - email
-        - admin
-      additionalProperties: false
-      properties:
-        email:
-          type: string
-          description: user email address
-          example: useremail@gmail.com
-        admin:
-          type: boolean
-          example: true
-    password-reset-token:
-      type: object
-      required:
-        - kind
-        - userId
-        - resetToken
-        - expiration
-      additionalProperties: false
-      properties:
-        kind:
-          type: string
-          enum:
-            - password-reset-token
-        userId:
-          type: string
-          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
-        resetToken:
-          type: string
-          example: E1F53135E559C253
-          writeOnly: true
-        expiration:
-          type: number
-          description:
-            Timestamp (in milliseconds) at which reset token will be expired
-          example: 1587667174725
-    password-reset-token-request:
-      type: object
-      required:
-        - email
-      additionalProperties: false
-      properties:
-        email:
-          type: string
-          description: user email address
-          example: useremail@gmail.com
-    password-reset-confirm:
-      type: object
-      required:
-        - email
-        - resetToken
-        - password
-      additionalProperties: false
-      properties:
-        email:
-          type: string
-          description: user email address
-          example: useremail@gmail.com
-        resetToken:
-          type: string
-          example: E1F53135E559C253
-          writeOnly: true
-        password:
-          type: string
-          example: thisisapassword
-          minLength: 64
-          maxLength: 64
-        userId:
-          type: string
-          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
-    create-customer:
-      type: object
-      required:
-        - email
-      additionalProperties: false
-      properties:
-        email:
-          type: string
-          description: user email address
-          example: useremail@gmail.com
-    create-subscription:
-      type: object
-      required:
-        - stripeCustomerId
-        - stripeProductId
-      additionalProperties: false
-      properties:
-        stripeCustomerId:
-          type: string
-          description: stripe customer id
-          example: cus_xxxxxxxxxxxxxx
-        stripeCustomerPaymentMethodId:
-          type: string
-          description: stripe payment method id
-          example: src_xxxxxxxxxxxxxxxxxxxxxxxx
-        stripeProductId:
-          type: string
-          description: stripe product id
-          enum:
-            - prod_0
-            - prod_1
-            - prod_2
-    update-subscription:
-      type: object
-      required:
-        - stripeCustomerId
-        - stripeProductId
-      additionalProperties: false
-      properties:
-        stripeCustomerId:
-          type: string
-          description: stripe customer id
-          example: cus_xxxxxxxxxxxxxx
-        stripeCustomerSubscriptionId:
-          type: string
-          description: stripe subscription id
-          example: sub_xxxxxxxxxxxxxx
-        stripeCustomerPaymentMethodId:
-          type: string
-          description: stripe payment method id
-          example: pm_xxxxxxxxxxxxxxxxxxxxxxxx
-        stripeProductId:
-          type: string
-          description: stripe product id
-          enum:
-            - prod_0
-            - prod_1
-            - prod_2
-    update-customer-payment-method:
-      type: object
-      required:
-        - stripeCustomerId
-        - stripeCustomerPaymentMethodId
-      additionalProperties: false
-      properties:
-        stripeCustomerId:
-          type: string
-          description: stripe customer id
-          example: cus_xxxxxxxxxxxxxx
-        stripeCustomerPaymentMethodId:
-          type: string
-          description: stripe payment method id
-          example: pm_xxxxxxxxxxxxxxxxxxxxxxxx
-    retrieve-customer-payment-method:
-      type: object
-      required:
-        - stripeCustomerPaymentMethodId
-      additionalProperties: false
-      properties:
-        stripeCustomerPaymentMethodId:
-          type: string
-          description: stripe payment method id
-          example: src_xxxxxxxxxxxxxxxxxxxxxxxx
-    region:
-      type: object
-      required:
-        - region
-        - orchestrators
-      properties:
-        region:
-          type: string
-          description: region name
-          example: ber
-        orchestrators:
-          type: array
-          items:
-            type: object
-            additionalProperties: false
-            required:
-              - address
-            properties:
-              address:
-                type: string
     user:
       type: object
       required:
@@ -2296,12 +1500,6 @@ components:
           type: string
           example: E1F53135E559C253
           writeOnly: true
-        admin:
-          type: boolean
-          example: true
-        kind:
-          type: string
-          example: user
         id:
           type: string
           example: abc123
@@ -2317,22 +1515,6 @@ components:
         phone:
           type: string
           example: 2034212122
-        stripeProductId:
-          type: string
-          description: Identifier of the plan that the user is subscribed to.
-          enum:
-            - prod_0
-            - prod_1
-            - prod_2
-        stripeCustomerId:
-          type: string
-          example: cus_Jv6KvgT0DCH8HU
-        stripeCustomerPaymentMethodId:
-          type: string
-          example: pm_2FSSNNJfrKDAwlJ9n4EN15Du
-        stripeCustomerSubscriptionId:
-          type: string
-          example: sub_I29pdyfOTPBkjb
         ccLast4:
           type: string
           example: 1234
@@ -2352,7 +1534,7 @@ components:
         planChangedAt:
           type: number
           description:
-            Timestamp (in milliseconds) at which the user plan has changed
+            Timestamp (in milliseconds) at which user object was verified
           example: 1587667174725
         lastStreamedAt:
           type: number
@@ -2365,57 +1547,6 @@ components:
           description:
             Timestamp (in milliseconds) at which user's password was used
           example: 1587667174725
-        recaptchaToken:
-          type: string
-          example: >-
-            03AGdBq24blDQQCyt9BSYjS0YZ3-tZapaQ5xO2-oykG_4dS_91TzH9qOziOwXbff_QiDOsXmWKxqtOrmOEx7qjijNhbexBzvNjM6HbbhXcji1rKcxxQRsL-t3SbycwZuNXos9OjnrYmfV9F3zsy1o73ia5Wlw_Zcf1jwbm3n-yQ2epifcMHXJhsUrqmUe6a1J1mPaD2heHvCOS3vYm0rWijdMl2E4bXQf75BiWvbLKxCWv5ZF8279nCMcGyJBIw1kno-A0x5KTOlEVxV369nz12lkvRfOtRABKB49jMTygAc2BKh9GBlAYGO6PBPoIk7_BCo7I_hsHoJeT4c80ucOPraZby0QJM5jcCQcqVCYrcaPKPiUMcIEixIhB5FAfDs88uYqDWMcgZdMRKCvmxEC3ONDVDtq0nLMc4rniuC5sQTz1E4D6SR_Adik
-          description: Recaptcha v3 Token
-          writeOnly: true
-        internal:
-          type: boolean
-          example: false
-          description:
-            Internal user that should be disregarded from usage information
-        isTestUser:
-          type: boolean
-          example: false
-          description:
-            User creates test streams and playbackIds should be flagged as such
-    experiment:
-      type: object
-      additionalProperties: false
-      required:
-        - name
-      properties:
-        name:
-          type: string
-          description: Name that identifies the experiment. Must be unique
-        userId:
-          type: string
-          description: >-
-            User ID of the creator of the experiment. Only used for auditing as
-            experiment APIs is only accessible to admins, which can all
-            experiments anyway.
-        createdAt:
-          type: number
-          description:
-            Timestamp (in milliseconds) at which the experiment was created
-          example: 1587667174725
-        updatedAt:
-          type: number
-          description:
-            Timestamp (in milliseconds) at which experiment was updated
-          example: 1587667174725
-        audienceUserIds:
-          type: array
-          description: List of user IDs in the experiment
-          items:
-            type: string
-        audienceUsers:
-          type: array
-          description: User objects of users in the experiment for convenience
-          items:
-            $ref: "#/components/schemas/user"
     usage:
       type: object
       additionalProperties: false
@@ -2424,9 +1555,6 @@ components:
           type: string
           description: day associated with usage
           example: 2021-01-30T00:00:00.000Z
-        kind:
-          type: string
-          example: usage
         date:
           type: number
           example: usage
@@ -2445,6 +1573,27 @@ components:
         streamCount:
           type: number
           example: 200000
+    playback-policy:
+      type: object
+      description:
+        Whether the playback policy for a asset or stream is public or signed
+      additionalProperties: false
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - public
+            - jwt
+            - webhook
+        webhookId:
+          type: string
+          description: ID of the webhook to use for playback policy
+        webhookContext:
+          type: object
+          description: User-defined webhook context
+          additionalProperties: true
 paths:
   /stream:
     post:
@@ -2522,48 +1671,6 @@ paths:
       responses:
         "204":
           description: Success
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/error"
-  /object-store:
-    post:
-      description: Receives store credentials
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              $ref: "#/components/schemas/object-store"
-      responses:
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/object-store"
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/error"
-    get:
-      description: Lists object store credentials by userId
-      responses:
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/object-store"
         default:
           description: Error
           content:
@@ -2662,256 +1769,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/error"
-  /user-verification:
-    post:
-      description: Verifies user email
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              $ref: "#/components/schemas/user-verification"
-      responses:
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/user-verification"
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/error"
-  /password-reset-token:
-    post:
-      description: Creates a password reset token
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              $ref: "#/components/schemas/password-reset-token-request"
-      responses:
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/password-reset-token"
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/error"
-  /password-reset:
-    post:
-      description: Confirms password reset token
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              $ref: "#/components/schemas/password-reset-confirm"
-      responses:
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/user"
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/error"
-  /verify-email:
-    post:
-      description: Resend User Email Verification
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              $ref: "#/components/schemas/verify-email"
-      responses:
-        "200":
-          description: Success
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/error"
-  /make-admin:
-    post:
-      description: Changes user admin status
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              $ref: "#/components/schemas/make-admin"
-      responses:
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: object
-                items:
-                  $ref: "#/components/schemas/user"
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/error"
-  /user/token:
-    post:
-      description: Receives user login information
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              $ref: "#/components/schemas/user"
-      responses:
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/user"
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/error"
-  /user:
-    post:
-      description: Receives user information
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              $ref: "#/components/schemas/user"
-      responses:
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/user"
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/error"
-    get:
-      description: Lists users
-      responses:
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/user"
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/error"
-  "/user/{id}":
-    patch:
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-      description: updates a user
-      responses:
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/user"
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/error"
-  /api-token:
-    post:
-      description: Contains api token information
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              $ref: "#/components/schemas/api-token"
-      responses:
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/api-token"
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/error"
-    get:
-      description: Lists api tokens
-      responses:
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/api-token"
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/api-token"
   /webhook:
     get:
       description: gets a list of webhooks defined by the user
@@ -3021,70 +1878,6 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/asset"
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/error"
-  "/region/{region}":
-    get:
-      description: get a regions list of orchestrators
-      parameters:
-        - name: region
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/region"
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/error"
-    put:
-      parameters:
-        - name: region
-          in: path
-          required: true
-          schema:
-            type: string
-      description: updates a specific region
-      responses:
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/region"
-        default:
-          description: Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/error"
-    delete:
-      parameters:
-        - name: region
-          in: path
-          required: true
-          schema:
-            type: string
-      description: deletes a specific region
-      responses:
-        "200":
-          description: Success
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/webhook"
         default:
           description: Error
           content:

--- a/packages/api/src/schema/db-schema.yaml
+++ b/packages/api/src/schema/db-schema.yaml
@@ -1,24 +1,554 @@
 components:
   schemas:
+    cdn-data-row:
+      type: object
+      description: >-
+        Fields names taken from log format description
+        https://support.highwinds.com/hc/en-us/articles/360052181571-Raw-Log-Access-through-GCS
+      additionalProperties: false
+      required:
+        - unique_client_ips
+        - total_sc_bytes
+      properties:
+        stream_id:
+          type: string
+          description: Session UUID. Used in recordings URLs.
+        playback_id:
+          type: string
+          description: Playback ID.
+        unique_client_ips:
+          type: number
+          description: >-
+            Number of unique IP addresses of clients. Not accurate because
+            StackPath zeroes last part of the IP address.
+        total_filesize:
+          type: number
+          description: Size of the asset being delivered.
+        total_cs_bytes:
+          type: number
+          description: The total size of the request header.
+        total_sc_bytes:
+          type: number
+          description: Total bytes in the response to the client.
+        count:
+          type: number
+          description: Number of parsed log lines
+    cdn-data-payload:
+      type: array
+      items:
+        type: object
+        additionalProperties: false
+        required:
+          - region
+          - file_name
+          - date
+          - data
+        properties:
+          region:
+            type: string
+          file_name:
+            type: string
+          date:
+            type: number
+          data:
+            type: array
+            minItems: 1
+            items:
+              $ref: "#/components/schemas/cdn-data-row"
     cdn-usage-last:
       table: cdn_usage_last
+      type: object
+      required:
+        - region
+        - fileName
+      additionalProperties: false
       properties:
         id:
+          type: string
           readOnly: true
+          example: de7818e7-610a-4057-8f6f-b785dc1e6f88
         fileName:
           index: true
+          type: number
         region:
           index: true
           unique: true
+          type: string
+    access-control-gate-payload:
+      type: object
+      additionalProperties: false
+      required:
+        - type
+        - stream
+      properties:
+        type:
+          type: string
+          enum:
+            - jwt
+            - accessKey
+        stream:
+          type: string
+          description: Stream ID to which this gate applies
+        pub:
+          type: string
+          description: Base64 of Public key used for JWT verification
+        accessKey:
+          type: string
+          description: Access key used for access-control verification
+    experiment-audience-payload:
+      type: object
+      additionalProperties: false
+      properties:
+        addUsers:
+          type: array
+          items:
+            type: string
+            description:
+              Email or ID of users that should be added to the experiment
+        removeUsers:
+          type: array
+          items:
+            type: string
+            description:
+              Email or ID of users that should be removed from the experiment
+    object-store:
+      table: object_store
+      type: object
+      required:
+        - url
+      additionalProperties: false
+      properties:
+        url:
+          type: string
+          description: Livepeer-compatible object store URL
+          example: "s3://access-key:secret-key@us-west-2/bucket-name"
+          writeOnly: true
+        publicUrl:
+          type: string
+          description:
+            Public URL at which data in this object storage can be accessed
+          example: "https://reg-rec.livepeer.live/some/path"
+        disabled:
+          type: boolean
+          description: >-
+            If true then these object store will not be used for recording even
+            if it is configured in the API command line.
+        deleted:
+          type: boolean
+          description: Set to true when the object store is deleted
+        id:
+          type: string
+          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
+        userId:
+          type: string
+          index: true
+          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
+        name:
+          type: string
+        createdAt:
+          type: number
+          readOnly: true
+          description:
+            Timestamp (in milliseconds) at which object store object was created
+          example: 1587667174725
+    user-verification:
+      type: object
+      required:
+        - email
+        - emailValidToken
+      additionalProperties: false
+      properties:
+        email:
+          unique: true
+          index: true
+          type: string
+          description: user email address
+          example: useremail@gmail.com
+        emailValidToken:
+          type: string
+          example: E1F53135E559C253
+          writeOnly: true
+    verify-email:
+      type: object
+      required:
+        - email
+      additionalProperties: false
+      properties:
+        email:
+          type: string
+          unique: true
+          description: user email address
+          example: useremail@gmail.com
+    make-admin:
+      type: object
+      required:
+        - email
+        - admin
+      additionalProperties: false
+      properties:
+        email:
+          type: string
+          description: user email address
+          example: useremail@gmail.com
+        admin:
+          type: boolean
+          example: true
+    password-reset-token:
+      table: password_reset_token
+      type: object
+      required:
+        - kind
+        - userId
+        - resetToken
+        - expiration
+      additionalProperties: false
+      properties:
+        kind:
+          readOnly: true
+          type: string
+          enum:
+            - password-reset-token
+        userId:
+          readOnly: true
+          index: true
+          type: string
+          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
+        resetToken:
+          type: string
+          example: E1F53135E559C253
+          writeOnly: true
+        expiration:
+          readOnly: true
+          type: number
+          description:
+            Timestamp (in milliseconds) at which reset token will be expired
+          example: 1587667174725
+    password-reset-token-request:
+      type: object
+      required:
+        - email
+      additionalProperties: false
+      properties:
+        email:
+          type: string
+          description: user email address
+          example: useremail@gmail.com
+    password-reset-confirm:
+      type: object
+      required:
+        - email
+        - resetToken
+        - password
+      additionalProperties: false
+      properties:
+        email:
+          index: true
+          type: string
+          description: user email address
+          example: useremail@gmail.com
+        resetToken:
+          type: string
+          example: E1F53135E559C253
+          writeOnly: true
+        password:
+          type: string
+          example: thisisapassword
+          minLength: 64
+          maxLength: 64
+        userId:
+          type: string
+          index: true
+          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
+    create-customer:
+      type: object
+      required:
+        - email
+      additionalProperties: false
+      properties:
+        email:
+          type: string
+          description: user email address
+          example: useremail@gmail.com
+    create-subscription:
+      type: object
+      required:
+        - stripeCustomerId
+        - stripeProductId
+      additionalProperties: false
+      properties:
+        stripeCustomerId:
+          type: string
+          description: stripe customer id
+          example: cus_xxxxxxxxxxxxxx
+        stripeCustomerPaymentMethodId:
+          type: string
+          description: stripe payment method id
+          example: src_xxxxxxxxxxxxxxxxxxxxxxxx
+        stripeProductId:
+          type: string
+          description: stripe product id
+          enum:
+            - prod_0
+            - prod_1
+            - prod_2
+    update-subscription:
+      type: object
+      required:
+        - stripeCustomerId
+        - stripeProductId
+      additionalProperties: false
+      properties:
+        stripeCustomerId:
+          type: string
+          description: stripe customer id
+          example: cus_xxxxxxxxxxxxxx
+        stripeCustomerSubscriptionId:
+          type: string
+          description: stripe subscription id
+          example: sub_xxxxxxxxxxxxxx
+        stripeCustomerPaymentMethodId:
+          type: string
+          description: stripe payment method id
+          example: pm_xxxxxxxxxxxxxxxxxxxxxxxx
+        stripeProductId:
+          type: string
+          description: stripe product id
+          enum:
+            - prod_0
+            - prod_1
+            - prod_2
+    update-customer-payment-method:
+      type: object
+      required:
+        - stripeCustomerId
+        - stripeCustomerPaymentMethodId
+      additionalProperties: false
+      properties:
+        stripeCustomerId:
+          type: string
+          description: stripe customer id
+          example: cus_xxxxxxxxxxxxxx
+        stripeCustomerPaymentMethodId:
+          type: string
+          description: stripe payment method id
+          example: pm_xxxxxxxxxxxxxxxxxxxxxxxx
+    retrieve-customer-payment-method:
+      type: object
+      required:
+        - stripeCustomerPaymentMethodId
+      additionalProperties: false
+      properties:
+        stripeCustomerPaymentMethodId:
+          type: string
+          description: stripe payment method id
+          example: src_xxxxxxxxxxxxxxxxxxxxxxxx
+    region:
+      table: regions
+      type: object
+      required:
+        - region
+        - orchestrators
+      properties:
+        region:
+          type: string
+          unique: true
+          index: true
+          description: region name
+          example: ber
+        orchestrators:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            required:
+              - address
+            properties:
+              address:
+                type: string
+    experiment:
+      type: object
+      table: experiment
+      additionalProperties: false
+      required:
+        - name
+      properties:
+        name:
+          index: true
+          unique: true
+          type: string
+          description: Name that identifies the experiment. Must be unique
+        userId:
+          index: true
+          type: string
+          description: >-
+            User ID of the creator of the experiment. Only used for auditing as
+            experiment APIs is only accessible to admins, which can all
+            experiments anyway.
+        createdAt:
+          type: number
+          readOnly: true
+          description:
+            Timestamp (in milliseconds) at which the experiment was created
+          example: 1587667174725
+        updatedAt:
+          type: number
+          readOnly: true
+          description:
+            Timestamp (in milliseconds) at which experiment was updated
+          example: 1587667174725
+        audienceUserIds:
+          type: array
+          index: true
+          description: List of user IDs in the experiment
+          items:
+            type: string
+        audienceUsers:
+          readOnly: true
+          type: array
+          description: User objects of users in the experiment for convenience
+          items:
+            $ref: "#/components/schemas/user"
+    api-token:
+      type: object
+      table: api_token
+      additionalProperties: false
+      properties:
+        kind:
+          type: string
+          example: user
+          readOnly: true
+        id:
+          type: string
+          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
+        userId:
+          type: string
+          index: true
+          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
+        name:
+          type: string
+          example: Example Token
+        access:
+          type: object
+          additionalProperties: false
+          properties:
+            cors:
+              type: object
+              additionalProperties: false
+              properties:
+                fullAccess:
+                  type: boolean
+                  description: >-
+                    Whether the token grants full access to the API. If false,
+                    the token will only have access to some pre-defined
+                    endpoints, not expose the whole account from the webpage.
+                  default: false
+                allowedOrigins:
+                  type: array
+                  description: >-
+                    Origins from which the token can be used. If empty, CORS
+                    will be prohibited by default (safest). To allow all origin
+                    values set this to `[*]`.
+                  default: []
+                  items:
+                    type: string
+                    example: "https://example.com"
+            rules:
+              type: array
+              default:
+                - resources:
+                    - "*"
+              items:
+                type: object
+                additionalProperties: false
+                required:
+                  - resources
+                properties:
+                  resources:
+                    type: array
+                    minItems: 1
+                    items:
+                      type: string
+                  methods:
+                    type: array
+                    minItems: 1
+                    default:
+                      - "*"
+                    items:
+                      type: string
+                      enum:
+                        - post
+                        - get
+                        - put
+                        - patch
+                        - delete
+                        - head
+                        - options
+                        - "*"
+        lastSeen:
+          type: number
+          example: 1587667174725
+        createdAt:
+          type: number
+          readOnly: true
+          description:
+            Timestamp (in milliseconds) at which token object was created
+          example: 1587667174725
+    transcode-asset-payload:
+      additionalProperties: false
+      required:
+        - name
+        - profile
+      properties:
+        assetId:
+          type: string
+          description: ID of the asset to transcode
+        objectStoreId:
+          type: string
+          description: Object store ID where the asset is stored
+          writeOnly: true
+          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
+        name:
+          type: string
+          description: >-
+            Name of the asset. This is not necessarily the filename, can be a
+            custom name or title
+          example: filename.mp4
+        profile:
+          $ref: "#/components/schemas/ffmpeg-profile"
+    signing-key-patch-payload:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          $ref: "#/components/schemas/signing-key/properties/name"
+        disabled:
+          $ref: "#/components/schemas/signing-key/properties/disabled"
+    suspend-user-payload:
+      type: object
+      additionalProperties: false
+      required:
+        - suspended
+      properties:
+        suspended:
+          $ref: "#/components/schemas/user/properties/suspended"
+        emailTemplate:
+          type: string
+          description:
+            Name of template to send to the users regarding the suspension.
+          enum:
+            - copyright
     webhook:
       table: webhook
       properties:
         id:
           readOnly: true
         kind:
+          type: string
+          example: webhook
           readOnly: true
         userId:
           readOnly: true
+          type: string
           index: true
         createdAt:
           readOnly: true
@@ -41,6 +571,15 @@ components:
                   readOnly: true
             lastTriggeredAt:
               readyOnly: true
+        event:
+          writeOnly: true
+          deprecated: true
+          description:
+            "@deprecated Non-persisted field. To be used on creation API only."
+          $ref: "#/components/schemas/webhook/properties/events/items"
+        deleted:
+          type: boolean
+          default: false
     webhook-response:
       table: webhook_response
       properties:
@@ -48,6 +587,8 @@ components:
           readOnly: true
         kind:
           readOnly: true
+          type: string
+          example: webhookResponse
         webhookId:
           readOnly: true
           index: true
@@ -85,16 +626,18 @@ components:
         id:
           readOnly: true
         kind:
+          type: string
+          example: stream
           readOnly: true
         userId:
           index: true
+          type: string
+          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
         lastSeen:
           index: true
         isActive:
           index: true
         createdByTokenName:
-          readOnly: true
-        createdByTokenId:
           readOnly: true
         createdAt:
           readOnly: true
@@ -105,16 +648,145 @@ components:
           unique: true
         playbackId:
           unique: true
+        mistHost:
+          type: string
+          description: Hostname of the Mist server that processes that stream
+        broadcasterHost:
+          type: string
+          description: Hostname of the broadcaster that transcodes that stream
+        createdByTokenId:
+          readOnly: true
+          type: string
+        recordObjectStoreId:
+          type: string
+          example: D8321C3E-B29C-45EB-A1BB-A623D8BE0F65
+          description:
+            ID of object store where to which this stream was recorded
+        objectStoreId:
+          type: string
+          example: D8321C3E-B29C-45EB-A1BB-A623D8BE0F65
+        presets:
+          type: array
+          items:
+            type: string
+            enum:
+              - P720p60fps16x9
+              - P720p30fps16x9
+              - P720p30fps4x3
+              - P576p30fps16x9
+              - P360p30fps16x9
+              - P360p30fps4x3
+              - P240p30fps16x9
+              - P240p30fps4x3
+              - P144p30fps16x9
+            example: P720p60fps16x9
         wowza:
+          type: object
+          required:
+            - transcoderAppConfig
+            - transcoderTemplateAppConfig
+            - streamNameGroups
+            - sourceInfo
+          additionalProperties: false
           properties:
+            transcoderAppConfig:
+              type: object
+            transcoderTemplateAppConfig:
+              type: object
+            streamNameGroups:
+              type: array
+              items:
+                type: string
             sourceInfo:
+              type: object
+              required:
+                - width
+                - height
+                - fps
+              additionalProperties: false
               properties:
                 width:
+                  type: integer
                   minValue: 1
                 height:
+                  type: integer
                   minValue: 1
                 fps:
+                  type: integer
                   minValue: 1
+        renditions:
+          type: object
+          additionalProperties:
+            type: string
+        detection:
+          type: object
+          description: >-
+            Custom configuration for audio/video detection algorithms to be run
+            on the stream. If no config is provided and a webhook is subscribed
+            to the stream.detection event, a default config will be used.
+          default:
+            sceneClassification:
+              - name: soccer
+              - name: adult
+          required:
+            - sceneClassification
+          additionalProperties: false
+          properties:
+            sceneClassification:
+              type: array
+              minItems: 1
+              items:
+                type: object
+                description: >-
+                  Scene classification options. Must contain name property with
+                  one of the well-defined classes supported by detection models.
+                additionalProperties: false
+                required:
+                  - name
+                properties:
+                  name:
+                    type: string
+                    enum:
+                      - soccer
+                      - adult
+        region:
+          type: string
+          example: fra
+          description: Region in which this session object was created
+        deleted:
+          type: boolean
+          description: Set to true when stream deleted
+    playback-policy:
+      properties:
+        type:
+          enum:
+            - lit_signing_condition
+        unifiedAccessControlConditions:
+          type: array
+          description: LIT Unified Access Control Conditions
+          items:
+            type: object
+        resourceId:
+          type: object
+          description: LIT Resource ID
+          additionalProperties: false
+          required:
+            - baseUrl
+            - path
+            - orgId
+            - role
+            - extraData
+          properties:
+            baseUrl:
+              type: string
+            path:
+              type: string
+            orgId:
+              type: string
+            role:
+              type: string
+            extraData:
+              type: string
     multistream-target-patch-payload:
       table: null
     session:
@@ -123,8 +795,12 @@ components:
         id:
           readOnly: true
         kind:
+          type: string
+          example: stream
           readOnly: true
         userId:
+          type: string
+          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
           index: true
         lastSeen:
           index: true
@@ -133,26 +809,32 @@ components:
           index: true
         parentId:
           index: true
-        record:
+        record: false
         recordingStatus:
-          readonly: true
-        recordingUrl:
-          readonly: true
-        mp4Url:
-          readonly: true
-    object-store:
-      table: object_store
-      properties:
-        userId:
-          index: true
-        createdAt:
           readOnly: true
+        recordingUrl:
+          readOnly: true
+        deleted:
+          type: boolean
+          description: Set to true when stream deleted
+        mp4Url:
+          readOnly: true
+        recordObjectStoreId:
+          type: string
+          example: D8321C3E-B29C-45EB-A1BB-A623D8BE0F65
+          description:
+            ID of object store where to which this stream was recorded
+        broadcasterHost:
+          type: string
+          description: Hostname of the broadcaster that transcodes that stream
     multistream-target:
       table: multistream_target
       properties:
         id:
           readOnly: true
         userId:
+          type: string
+          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
           readOnly: true
           index: true
         createdAt:
@@ -165,8 +847,6 @@ components:
           index: true
         playbackId:
           index: true
-        playbackRecordingId:
-          index: true
         playbackUrl:
           readOnly: true
         downloadUrl:
@@ -174,6 +854,9 @@ components:
         userId:
           readOnly: true
           index: true
+          type: string
+          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
+          description: owner of the asset
         source:
           oneOf:
             - additionalProperties: false
@@ -196,9 +879,87 @@ components:
           readOnly: true
         videoSpec:
           readOnly: true
+        deleted:
+          type: boolean
+          description: Set to true when the asset is deleted
+        playbackRecordingId:
+          type: string
+          writeOnly: true
+          example: ea03f37e-f861-4cdd-b495-0e60b6d753ad
+          description: Used to form recording URL for HLS playback
+          index: true
+        files:
+          type: array
+          writeOnly: true
+          description:
+            Internal field with the list of files stored in the object store
+          items:
+            type: object
+            additionalProperties: false
+            required:
+              - type
+              - path
+            properties:
+              type:
+                type: string
+                example: catalyst_hls_manifest
+                description: Type of the file in the VOD system.
+              path:
+                type: string
+                example: /path/to/file
+                description: >-
+                  Path to the file in the asset subfolder in the object store.
+                  This means that all these paths are relative to a folder in
+                  the OS the asset playback ID as the name.
+              spec:
+                type: object
+                additionalProperties: false
+                description: >-
+                  Additional information about the file. For example, for
+                  manifests it contains the list of media files.
+                properties:
+                  size:
+                    type: number
+                    example: 123456
+                    description: Size of the file in bytes.
+                  height:
+                    type: number
+                    example: 1080
+                    description: Height of the video in pixels.
+                  width:
+                    type: number
+                    example: 1920
+                    description: Width of the video in pixels.
+                  bitrate:
+                    type: number
+                    example: 1000000
+                    description: Bitrate of the video in bits per second.
+        deletedAt:
+          type: number
+          description:
+            Timestamp (in milliseconds) at which the asset was deleted
+          example: 1587667174725
+        objectStoreId:
+          type: string
+          description: Object store ID where the asset is stored
+          writeOnly: true
+          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
         sourceAssetId:
+          type: string
+          description:
+            "ID of the source asset (root) - If missing, this is a root asset"
+          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
           index: true
           readOnly: true
+    new-asset-payload:
+      properties:
+        objectStoreId:
+          type: string
+          description: Object store ID where the asset is stored
+          writeOnly: true
+          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
+        catalystPipelineStrategy:
+          $ref: "#/components/schemas/task/properties/params/properties/upload/properties/catalystPipelineStrategy"
     ipfs-file-info:
       properties:
         cid:
@@ -216,6 +977,9 @@ components:
         userId:
           readOnly: true
           index: true
+          type: string
+          description: User ID of the task owner
+          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
         createdAt:
           readOnly: true
         scheduledAt:
@@ -230,6 +994,13 @@ components:
           properties:
             export:
               properties:
+                internal:
+                  writeOnly: true
+                  description: |
+                    Internal data of the export task that should not be returned
+                    to users. Contains internal tracking information like which
+                    service was used for the export in case it is maintained by
+                    us (e.g. the first-party piñata service).
                 ipfs:
                   properties:
                     videoFileUrl:
@@ -240,6 +1011,96 @@ components:
                       readOnly: true
                     nftMetadataGatewayUrl:
                       readOnly: true
+        params:
+          properties:
+            upload:
+              properties:
+                uploadedObjectKey:
+                  type: string
+                  description: S3 object key of the uploaded asset
+                  example: ABC123/filename.mp4
+                catalystPipelineStrategy:
+                  type: string
+                  description: >-
+                    Force to use a specific strategy in the Catalyst pipeline.
+                    If not specified, the default strategy that Catalyst is
+                    configured for will be used. This field only available for
+                    admin users, and is only used for E2E testing.
+                  enum:
+                    - catalyst
+                    - catalyst_ffmpeg
+                    - background_external
+                    - background_mist
+                    - fallback_external
+                    - external
+            transcode-file:
+              catalystPipelineStrategy:
+                type: string
+                description: >-
+                  Force to use a specific strategy in the Catalyst pipeline. If
+                  not specified, the default strategy that Catalyst is
+                  configured for will be used. This field only available for
+                  admin users, and is only used for E2E testing.
+                enum:
+                  - catalyst
+                  - catalyst_ffmpeg
+                  - background_external
+                  - background_mist
+                  - fallback_external
+                  - external
+        deleted:
+          type: boolean
+          description: Set to true when the task is deleted
+    user:
+      table: users
+      properties:
+        email:
+          unique: true
+          index: true
+        kind:
+          type: string
+          readOnly: true
+          example: user
+        id:
+          readOnly: true
+        stripeProductId:
+          type: string
+          enum:
+            - prod_0
+            - prod_1
+            - prod_2
+        stripeCustomerId:
+          type: string
+          example: cus_Jv6KvgT0DCH8HU
+          unique: true
+        stripeCustomerPaymentMethodId:
+          type: string
+          example: pm_2FSSNNJfrKDAwlJ9n4EN15Du
+        stripeCustomerSubscriptionId:
+          type: string
+          example: sub_I29pdyfOTPBkjb
+        ccLast4:
+          type: string
+          example: 1234
+        ccBrand:
+          type: string
+          example: 1234
+        recaptchaToken:
+          type: string
+          example: >-
+            03AGdBq24blDQQCyt9BSYjS0YZ3-tZapaQ5xO2-oykG_4dS_91TzH9qOziOwXbff_QiDOsXmWKxqtOrmOEx7qjijNhbexBzvNjM6HbbhXcji1rKcxxQRsL-t3SbycwZuNXos9OjnrYmfV9F3zsy1o73ia5Wlw_Zcf1jwbm3n-yQ2epifcMHXJhsUrqmUe6a1J1mPaD2heHvCOS3vYm0rWijdMl2E4bXQf75BiWvbLKxCWv5ZF8279nCMcGyJBIw1kno-A0x5KTOlEVxV369nz12lkvRfOtRABKB49jMTygAc2BKh9GBlAYGO6PBPoIk7_BCo7I_hsHoJeT4c80ucOPraZby0QJM5jcCQcqVCYrcaPKPiUMcIEixIhB5FAfDs88uYqDWMcgZdMRKCvmxEC3ONDVDtq0nLMc4rniuC5sQTz1E4D6SR_Adik
+          description: Recaptcha v3 Token
+          writeOnly: true
+        internal:
+          type: boolean
+          example: false
+          description:
+            Internal user that should be disregarded from usage information
+        isTestUser:
+          type: boolean
+          example: false
+          description:
+            User creates test streams and playbackIds should be flagged as such
     signing-key:
       table: signing_key
       properties:
@@ -253,77 +1114,11 @@ components:
         userId:
           readOnly: true
           index: true
-    api-token:
-      table: api_token
-      properties:
-        kind:
-          readOnly: true
-        userId:
-          index: true
-        createdAt:
-          readOnly: true
-    user-verification:
-      properties:
-        email:
-          unique: true
-          index: true
-    verify-email:
-      properties:
-        email:
-          unique: true
-    password-reset-token:
-      table: password_reset_token
-      properties:
-        kind:
-          readOnly: true
-        userId:
-          readOnly: true
-          index: true
-        expiration:
-          readOnly: true
-    password-reset-confirm:
-      properties:
-        email:
-          index: true
-        userId:
-          index: true
-    region:
-      table: regions
-      properties:
-        region:
-          unique: true
-          index: true
-    user:
-      table: users # 'user' is a keyword in postgres, this causes problems otherwise
-      properties:
-        email:
-          unique: true
-          index: true
-        kind:
-          readOnly: true
-        id:
-          readOnly: true
-        stripeCustomerId:
-          unique: true
-        createdAt:
-          readOnly: true
-    experiment:
-      table: experiment
-      properties:
-        name:
-          index: true
-          unique: true
-        userId:
-          index: true
-        createdAt:
-          readOnly: true
-        updatedAt:
-          readOnly: true
-        audienceUserIds:
-          index: true
-          indexType: gin
-        audienceUsers:
-          readonly: true
+          type: string
+          example: 78df0075-b5f3-4683-a618-1086faca35dc
+        deleted:
+          type: boolean
+          default: false
     usage:
       table: usage
       properties:
@@ -331,6 +1126,12 @@ components:
           unique: true
           index: true
         kind:
+          type: string
+          example: usage
           readOnly: true
         date:
           readOnly: true
+    transcode-payload:
+      properties:
+        catalystPipelineStrategy:
+          $ref: "#/components/schemas/task/properties/params/properties/upload/properties/catalystPipelineStrategy"

--- a/packages/api/src/schema/db-schema.yaml
+++ b/packages/api/src/schema/db-schema.yaml
@@ -541,8 +541,6 @@ components:
     webhook:
       table: webhook
       properties:
-        id:
-          readOnly: true
         kind:
           type: string
           example: webhook
@@ -551,27 +549,9 @@ components:
           readOnly: true
           type: string
           index: true
-        createdAt:
-          readOnly: true
         events:
           index: true
           indexType: gin
-        status:
-          readOnly: true
-          properties:
-            lastFailure:
-              readOnly: true
-              properties:
-                timestamp:
-                  readOnly: true
-                error:
-                  readOnly: true
-                response:
-                  readOnly: true
-                statusCode:
-                  readOnly: true
-            lastTriggeredAt:
-              readOnly: true
         event:
           writeOnly: true
           deprecated: true
@@ -584,20 +564,14 @@ components:
     webhook-response:
       table: webhook_response
       properties:
-        id:
-          readOnly: true
         kind:
           readOnly: true
           type: string
           example: webhookResponse
         webhookId:
-          readOnly: true
           index: true
         eventId:
-          readOnly: true
           index: true
-        createdAt:
-          readOnly: true
     detection-webhook-payload:
       type: object
       required:
@@ -624,8 +598,6 @@ components:
     stream:
       table: stream
       properties:
-        id:
-          readOnly: true
         kind:
           type: string
           example: stream
@@ -638,10 +610,7 @@ components:
           index: true
         isActive:
           index: true
-        createdByTokenName:
-          readOnly: true
         createdAt:
-          readOnly: true
           index: true
         parentId:
           index: true
@@ -758,7 +727,6 @@ components:
     playback-policy:
       properties:
         type:
-          # We need to repeat all values here since _.merge will not concat arrays
           enum:
             - public
             - jwt
@@ -795,8 +763,6 @@ components:
     session:
       table: session
       properties:
-        id:
-          readOnly: true
         kind:
           type: string
           example: stream
@@ -808,19 +774,12 @@ components:
         lastSeen:
           index: true
         createdAt:
-          readOnly: true
           index: true
         parentId:
           index: true
-        recordingStatus:
-          readOnly: true
-        recordingUrl:
-          readOnly: true
         deleted:
           type: boolean
           description: Set to true when stream deleted
-        mp4Url:
-          readOnly: true
         recordObjectStoreId:
           type: string
           example: D8321C3E-B29C-45EB-A1BB-A623D8BE0F65
@@ -832,27 +791,18 @@ components:
     multistream-target:
       table: multistream_target
       properties:
-        id:
-          readOnly: true
         userId:
           type: string
           example: 66E2161C-7670-4D05-B71D-DA2D6979556F
           readOnly: true
           index: true
-        createdAt:
-          readOnly: true
     asset:
       table: asset
       properties:
         id:
-          readOnly: true
           index: true
         playbackId:
           index: true
-        playbackUrl:
-          readOnly: true
-        downloadUrl:
-          readOnly: true
         userId:
           readOnly: true
           index: true
@@ -865,22 +815,6 @@ components:
               properties:
                 url:
                   index: true
-        storage:
-          properties:
-            ipfs:
-              properties:
-                updatedAt:
-                  readOnly: true
-            status:
-              readOnly: true
-        status:
-          readOnly: true
-        createdAt:
-          readOnly: true
-        size:
-          readOnly: true
-        videoSpec:
-          readOnly: true
         deleted:
           type: boolean
           description: Set to true when the asset is deleted
@@ -966,15 +900,10 @@ components:
       properties:
         cid:
           index: true
-        url:
-          readOnly: true
-        gatewayUrl:
-          readOnly: true
     task:
       table: task
       properties:
         id:
-          readOnly: true
           index: true
         userId:
           readOnly: true
@@ -982,16 +911,10 @@ components:
           type: string
           description: User ID of the task owner
           example: 66E2161C-7670-4D05-B71D-DA2D6979556F
-        createdAt:
-          readOnly: true
-        scheduledAt:
-          readOnly: true
         inputAssetId:
           index: true
         outputAssetId:
           index: true
-        status:
-          readOnly: true
         output:
           properties:
             export:
@@ -1003,16 +926,6 @@ components:
                     to users. Contains internal tracking information like which
                     service was used for the export in case it is maintained by
                     us (e.g. the first-party piñata service).
-                ipfs:
-                  properties:
-                    videoFileUrl:
-                      readOnly: true
-                    videoFileGatewayUrl:
-                      readOnly: true
-                    nftMetadataUrl:
-                      readOnly: true
-                    nftMetadataGatewayUrl:
-                      readOnly: true
         params:
           properties:
             upload:
@@ -1064,8 +977,6 @@ components:
           type: string
           readOnly: true
           example: user
-        id:
-          readOnly: true
         stripeProductId:
           type: string
           enum:
@@ -1111,12 +1022,7 @@ components:
       table: signing_key
       properties:
         id:
-          readOnly: true
           index: true
-        createdAt:
-          readOnly: true
-        lastSeen:
-          readOnly: true
         userId:
           readOnly: true
           index: true
@@ -1134,8 +1040,6 @@ components:
         kind:
           type: string
           example: usage
-          readOnly: true
-        date:
           readOnly: true
     transcode-payload:
       properties:

--- a/packages/api/src/schema/db-schema.yaml
+++ b/packages/api/src/schema/db-schema.yaml
@@ -1091,6 +1091,9 @@ components:
             03AGdBq24blDQQCyt9BSYjS0YZ3-tZapaQ5xO2-oykG_4dS_91TzH9qOziOwXbff_QiDOsXmWKxqtOrmOEx7qjijNhbexBzvNjM6HbbhXcji1rKcxxQRsL-t3SbycwZuNXos9OjnrYmfV9F3zsy1o73ia5Wlw_Zcf1jwbm3n-yQ2epifcMHXJhsUrqmUe6a1J1mPaD2heHvCOS3vYm0rWijdMl2E4bXQf75BiWvbLKxCWv5ZF8279nCMcGyJBIw1kno-A0x5KTOlEVxV369nz12lkvRfOtRABKB49jMTygAc2BKh9GBlAYGO6PBPoIk7_BCo7I_hsHoJeT4c80ucOPraZby0QJM5jcCQcqVCYrcaPKPiUMcIEixIhB5FAfDs88uYqDWMcgZdMRKCvmxEC3ONDVDtq0nLMc4rniuC5sQTz1E4D6SR_Adik
           description: Recaptcha v3 Token
           writeOnly: true
+        admin:
+          type: boolean
+          example: true
         internal:
           type: boolean
           example: false

--- a/packages/api/src/schema/db-schema.yaml
+++ b/packages/api/src/schema/db-schema.yaml
@@ -1,0 +1,336 @@
+components:
+  schemas:
+    cdn-usage-last:
+      table: cdn_usage_last
+      properties:
+        id:
+          readOnly: true
+        fileName:
+          index: true
+        region:
+          index: true
+          unique: true
+    webhook:
+      table: webhook
+      properties:
+        id:
+          readOnly: true
+        kind:
+          readOnly: true
+        userId:
+          readOnly: true
+          index: true
+        createdAt:
+          readOnly: true
+        events:
+          index: true
+          indexType: gin
+        status:
+          readOnly: true
+          properties:
+            lastFailure:
+              readOnly: true
+              properties:
+                timestamp:
+                  readOnly: true
+                error:
+                  readOnly: true
+                response:
+                  readOnly: true
+                statusCode:
+                  readOnly: true
+            lastTriggeredAt:
+              readyOnly: true
+    webhook-response:
+      table: webhook_response
+      properties:
+        id:
+          readOnly: true
+        kind:
+          readOnly: true
+        webhookId:
+          readOnly: true
+          index: true
+        eventId:
+          readOnly: true
+          index: true
+        createdAt:
+          readOnly: true
+    detection-webhook-payload:
+      type: object
+      required:
+        - manifestID
+        - seqNo
+        - sceneClassification
+      properties:
+        manifestID:
+          type: string
+        seqNo:
+          type: number
+        sceneClassification:
+          type: array
+          items:
+            type: object
+            required:
+              - name
+              - probability
+            properties:
+              name:
+                type: string
+              probability:
+                type: number
+    stream:
+      table: stream
+      properties:
+        id:
+          readOnly: true
+        kind:
+          readOnly: true
+        userId:
+          index: true
+        lastSeen:
+          index: true
+        isActive:
+          index: true
+        createdByTokenName:
+          readOnly: true
+        createdByTokenId:
+          readOnly: true
+        createdAt:
+          readOnly: true
+          index: true
+        parentId:
+          index: true
+        streamKey:
+          unique: true
+        playbackId:
+          unique: true
+        wowza:
+          properties:
+            sourceInfo:
+              properties:
+                width:
+                  minValue: 1
+                height:
+                  minValue: 1
+                fps:
+                  minValue: 1
+    multistream-target-patch-payload:
+      table: null
+    session:
+      table: session
+      properties:
+        id:
+          readOnly: true
+        kind:
+          readOnly: true
+        userId:
+          index: true
+        lastSeen:
+          index: true
+        createdAt:
+          readOnly: true
+          index: true
+        parentId:
+          index: true
+        record:
+        recordingStatus:
+          readonly: true
+        recordingUrl:
+          readonly: true
+        mp4Url:
+          readonly: true
+    object-store:
+      table: object_store
+      properties:
+        userId:
+          index: true
+        createdAt:
+          readOnly: true
+    multistream-target:
+      table: multistream_target
+      properties:
+        id:
+          readOnly: true
+        userId:
+          readOnly: true
+          index: true
+        createdAt:
+          readOnly: true
+    asset:
+      table: asset
+      properties:
+        id:
+          readOnly: true
+          index: true
+        playbackId:
+          index: true
+        playbackRecordingId:
+          index: true
+        playbackUrl:
+          readOnly: true
+        downloadUrl:
+          readOnly: true
+        userId:
+          readOnly: true
+          index: true
+        source:
+          oneOf:
+            - additionalProperties: false
+              properties:
+                url:
+                  index: true
+        storage:
+          properties:
+            ipfs:
+              properties:
+                updatedAt:
+                  readOnly: true
+            status:
+              readOnly: true
+        status:
+          readOnly: true
+        createdAt:
+          readOnly: true
+        size:
+          readOnly: true
+        videoSpec:
+          readOnly: true
+        sourceAssetId:
+          index: true
+          readOnly: true
+    ipfs-file-info:
+      properties:
+        cid:
+          index: true
+        url:
+          readOnly: true
+        gatewayUrl:
+          readOnly: true
+    task:
+      table: task
+      properties:
+        id:
+          readOnly: true
+          index: true
+        userId:
+          readOnly: true
+          index: true
+        createdAt:
+          readOnly: true
+        scheduledAt:
+          readOnly: true
+        inputAssetId:
+          index: true
+        outputAssetId:
+          index: true
+        status:
+          readOnly: true
+        output:
+          properties:
+            export:
+              properties:
+                ipfs:
+                  properties:
+                    videoFileUrl:
+                      readOnly: true
+                    videoFileGatewayUrl:
+                      readOnly: true
+                    nftMetadataUrl:
+                      readOnly: true
+                    nftMetadataGatewayUrl:
+                      readOnly: true
+    signing-key:
+      table: signing_key
+      properties:
+        id:
+          readOnly: true
+          index: true
+        createdAt:
+          readOnly: true
+        lastSeen:
+          readOnly: true
+        userId:
+          readOnly: true
+          index: true
+    api-token:
+      table: api_token
+      properties:
+        kind:
+          readOnly: true
+        userId:
+          index: true
+        createdAt:
+          readOnly: true
+    user-verification:
+      properties:
+        email:
+          unique: true
+          index: true
+    verify-email:
+      properties:
+        email:
+          unique: true
+    password-reset-token:
+      table: password_reset_token
+      properties:
+        kind:
+          readOnly: true
+        userId:
+          readOnly: true
+          index: true
+        expiration:
+          readOnly: true
+    password-reset-confirm:
+      properties:
+        email:
+          index: true
+        userId:
+          index: true
+    region:
+      table: regions
+      properties:
+        region:
+          unique: true
+          index: true
+    user:
+      table: users # 'user' is a keyword in postgres, this causes problems otherwise
+      properties:
+        email:
+          unique: true
+          index: true
+        kind:
+          readOnly: true
+        id:
+          readOnly: true
+        stripeCustomerId:
+          unique: true
+        createdAt:
+          readOnly: true
+    experiment:
+      table: experiment
+      properties:
+        name:
+          index: true
+          unique: true
+        userId:
+          index: true
+        createdAt:
+          readOnly: true
+        updatedAt:
+          readOnly: true
+        audienceUserIds:
+          index: true
+          indexType: gin
+        audienceUsers:
+          readonly: true
+    usage:
+      table: usage
+      properties:
+        id:
+          unique: true
+          index: true
+        kind:
+          readOnly: true
+        date:
+          readOnly: true

--- a/packages/api/src/schema/db-schema.yaml
+++ b/packages/api/src/schema/db-schema.yaml
@@ -399,6 +399,7 @@ components:
         audienceUserIds:
           type: array
           index: true
+          indexType: gin
           description: List of user IDs in the experiment
           items:
             type: string
@@ -570,7 +571,7 @@ components:
                 statusCode:
                   readOnly: true
             lastTriggeredAt:
-              readyOnly: true
+              readOnly: true
         event:
           writeOnly: true
           deprecated: true
@@ -695,8 +696,6 @@ components:
               type: object
             streamNameGroups:
               type: array
-              items:
-                type: string
             sourceInfo:
               type: object
               required:
@@ -759,7 +758,11 @@ components:
     playback-policy:
       properties:
         type:
+          # We need to repeat all values here since _.merge will not concat arrays
           enum:
+            - public
+            - jwt
+            - webhook
             - lit_signing_condition
         unifiedAccessControlConditions:
           type: array
@@ -809,7 +812,6 @@ components:
           index: true
         parentId:
           index: true
-        record: false
         recordingStatus:
           readOnly: true
         recordingUrl:
@@ -1034,20 +1036,21 @@ components:
                     - fallback_external
                     - external
             transcode-file:
-              catalystPipelineStrategy:
-                type: string
-                description: >-
-                  Force to use a specific strategy in the Catalyst pipeline. If
-                  not specified, the default strategy that Catalyst is
-                  configured for will be used. This field only available for
-                  admin users, and is only used for E2E testing.
-                enum:
-                  - catalyst
-                  - catalyst_ffmpeg
-                  - background_external
-                  - background_mist
-                  - fallback_external
-                  - external
+              properties:
+                catalystPipelineStrategy:
+                  type: string
+                  description: >-
+                    Force to use a specific strategy in the Catalyst pipeline.
+                    If not specified, the default strategy that Catalyst is
+                    configured for will be used. This field only available for
+                    admin users, and is only used for E2E testing.
+                  enum:
+                    - catalyst
+                    - catalyst_ffmpeg
+                    - background_external
+                    - background_mist
+                    - fallback_external
+                    - external
         deleted:
           type: boolean
           description: Set to true when the task is deleted


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Separated database and API schemas. Instead of one schema, we now have two schemas, the `api-schema.yaml` is the schema for API references, and `db-schema.yaml` is similar to API schema except it has keys that open API doesn't validate but it is needed for db such as `readOnly`, `table`.

> @victorges This PR is just for the separation of the schemas,  I will open two other follow-up PRs for including other APIs that are missing here and another one for API references 


**Specific updates (required)**

- Separated database and API schemas


**Does this pull request close any open issues?**
Linear - DX 123



**Checklist**


- [X] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
