### PR TITLE
api: Add stream health hook handler

### DIFF
--- a/packages/api/src/controllers/stream.test.ts
+++ b/packages/api/src/controllers/stream.test.ts
@@ -997,6 +997,8 @@ describe("controllers/stream", () => {
     });
 
     describe("stream health hook", () => {
+      let stream: Stream;
+
       const samplePayload = (isActive: boolean, isHealthy: boolean) => ({
         stream_name: "video+" + stream.playbackId,
         session_id: "sampleSessionId",
@@ -1036,6 +1038,8 @@ describe("controllers/stream", () => {
           name: "videorec+samplePlaybackId",
         });
         expect(res.status).toBe(201);
+        stream = await res.json();
+        expect(stream.id).toBeDefined();
       });
 
       it("updates the stream's isHealthy and issues fields", async () => {

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -828,7 +828,8 @@ app.post(
     const patch: Partial<DBSession & DBStream> = {
       isHealthy: payload.is_active ? payload.is_healthy : undefined,
       issues: payload.is_active && payload.issues ? payload.issues : undefined,
-      lastSeen: Date.now(),
+      // do not clear the `lastSeen` field when the stream is not active
+      ...(payload.is_active ? { lastSeen: Date.now() } : null),
     };
 
     // Since we might need to delete some fields, use replace instead of update

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -801,7 +801,7 @@ app.post(
 );
 
 app.post(
-  "/hook/stream-health",
+  "/hook/health",
   authorizer({ anyAdmin: true }),
   validatePost("stream-health-payload"),
   async (req, res) => {
@@ -838,12 +838,13 @@ app.post(
       const session = await db.session.get(payload.session_id, {
         useReplica: false,
       });
-      if (!session) {
+      if (session) {
+        await db.session.replace({ ...session, ...patch });
+      } else {
         logger.warn(
           `stream-health-payload: session not found for stream_id=${stream.id} session_id=${payload.session_id}`
         );
       }
-      await db.session.replace({ ...session, ...patch });
     }
 
     // Log all the received payload for internal debugging (we don't expose all

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -971,6 +971,8 @@ app.put(
     const ingest = await getIngestBase(req);
     const patch = {
       isActive: active,
+      // initialize isHealthy to true on stream initialization
+      isHealthy: stream.isHealthy ?? (active ? true : undefined),
       lastSeen: Date.now(),
       mistHost: hostName,
       region: req.config.ownRegion,

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -801,7 +801,7 @@ app.post(
 );
 
 app.post(
-  "/:streamId/stream-health",
+  "/hook/stream-health",
   authorizer({ anyAdmin: true }),
   validatePost("stream-health-payload"),
   async (req, res) => {

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -858,7 +858,7 @@ app.post(
         `issues=${payload.issues} tracks=${JSON.stringify(payload.tracks)}`
     );
 
-    return res.status(204);
+    res.status(204).end();
   }
 );
 

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -673,7 +673,7 @@ components:
             A human-readable string describing issues affecting the stream, if
             any.
         tracks:
-          type: array
+          type: object
           description:
             A map of track objects containing information about the stream's
             tracks. The keys are the unique track ID from Mist.

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -416,6 +416,10 @@ components:
           type: boolean
           description: If currently active
           index: true
+        isHealthy:
+          $ref: "#/components/schemas/stream-health-payload/properties/is_healthy"
+        issues:
+          $ref: "#/components/schemas/stream-health-payload/properties/issues"
         createdByTokenName:
           type: string
           readOnly: true
@@ -635,6 +639,70 @@ components:
           type: number
           description: Timestamp (in milliseconds) at which the stream started.
           example: 1587667174725
+
+    stream-health-payload:
+      type: object
+      description:
+        Payload received from Catalyst about the health of livestreams currently
+        or recently active on Mist.
+      required:
+        - stream_name
+        - is_active
+        - is_healthy
+      properties:
+        stream_name:
+          type: string
+          description:
+            The name of the stream within Catalyst/Mist, normally comprised of
+            the base stream name with the playback ID after the + sign.
+          example: videorec+eaw4nk06ts2d0mzb
+        session_id:
+          description:
+            The unique identifier for the specific session, created by Mist and
+            used for creating the session object in the DB.
+          type: string
+        is_active:
+          type: boolean
+          description: Indicates whether the stream is currently live or not.
+        is_healthy:
+          type: boolean
+          description: Indicates whether the stream is healthy or not.
+        issues:
+          type: string
+          description:
+            A human-readable string describing issues affecting the stream, if
+            any.
+        tracks:
+          type: array
+          description:
+            A map of track objects containing information about the stream's
+            tracks. The keys are the unique track ID from Mist.
+          additionalProperties:
+            type: object
+            properties:
+              codec:
+                type: string
+                description: The codec being used for the track.
+              kbits:
+                type: number
+                description: The bitrate of the track, in kilobits per second.
+              keys:
+                type: object
+                description:
+                  An object containing additional track-specific metrics.
+                additionalProperties:
+                  type: number
+              fpks:
+                type: number
+                description:
+                  The framerate of the track, in frames per thousand seconds
+                  (kilo-second).
+              height:
+                type: number
+                description: The height of the track's video resolution.
+              width:
+                type: number
+                description: The width of the track's video resolution.
 
     asset-patch-payload:
       type: object
@@ -861,6 +929,10 @@ components:
         broadcasterHost:
           type: string
           description: Hostname of the broadcaster that transcodes that stream
+        isHealthy:
+          $ref: "#/components/schemas/stream-health-payload/properties/is_healthy"
+        issues:
+          $ref: "#/components/schemas/stream-health-payload/properties/issues"
         deleted:
           type: boolean
           description: Set to true when stream deleted


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Following up on https://github.com/livepeer/catalyst-api/pull/638 create the 
stream health hook handler on the API to handle the STREAM_BUFFER
trigger data being sent by Catalyst/mapic now.

**Specific updates (required)**
 - Create new handler
 - Create new tests
 - profit

**How did you test each of these updates (required)**
`yarn test` and testing on staging after this

**Does this pull request close any open issues?**
Implements DX-168

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
