### PR TITLE
api/auth: Add capacity to authorize via playback ID

### DIFF
--- a/packages/api/src/controllers/auth.test.ts
+++ b/packages/api/src/controllers/auth.test.ts
@@ -11,6 +11,7 @@ import {
 import serverPromise, { TestServer } from "../test-server";
 import { pathJoin2 } from "./helpers";
 import { v4 as uuid } from "uuid";
+import { generateUniquePlaybackId } from "./generate-keys";
 
 let server: TestServer;
 let mockAdminUserInput: User;
@@ -465,29 +466,38 @@ describe("controller/auth", () => {
 
       nonAdminStream = await db.stream.create({
         id: uuid(),
+        playbackId: await generateUniquePlaybackId(uuid()),
         userId: nonAdminUser.id,
       } as any);
       nonAdminAsset = await db.asset.create({
         id: uuid(),
+        playbackId: await generateUniquePlaybackId(uuid()),
         userId: nonAdminUser.id,
       } as any);
       adminStream = await db.stream.create({
         id: uuid(),
+        playbackId: await generateUniquePlaybackId(uuid()),
         userId: adminUser.id,
       } as any);
       adminAsset = await db.asset.create({
         id: uuid(),
+        playbackId: await generateUniquePlaybackId(uuid()),
         userId: adminUser.id,
       } as any);
     });
 
-    const fetchAuth = async (ids: { streamId?: string; assetId?: string }) => {
+    const fetchAuth = async (ids: {
+      streamId?: string;
+      assetId?: string;
+      pid?: string;
+    }) => {
       const res = await client.fetch("/auth", {
         method: "GET",
         headers: {
           "x-original-uri": "https://livepeer.studio/api/data/views/1234/total",
           ...(ids.streamId ? { "x-livepeer-stream-id": ids.streamId } : null),
           ...(ids.assetId ? { "x-livepeer-asset-id": ids.assetId } : null),
+          ...(ids.pid ? { "x-livepeer-playback-id": ids.pid } : null),
         },
       });
       return res.status;
@@ -496,27 +506,46 @@ describe("controller/auth", () => {
     it("should disallow access to non-existent resources", async () => {
       await expect(fetchAuth({ streamId: "1234" })).resolves.toBe(404);
       await expect(fetchAuth({ assetId: "1234" })).resolves.toBe(404);
+      await expect(fetchAuth({ pid: "1234" })).resolves.toBe(404);
     });
 
     it("should disallow access to deleted resources", async () => {
       await db.stream.markDeleted(nonAdminStream.id);
       await db.asset.markDeleted(nonAdminAsset.id);
+
       await expect(fetchAuth({ streamId: nonAdminStream.id })).resolves.toBe(
         404
       );
+      await expect(fetchAuth({ pid: nonAdminStream.playbackId })).resolves.toBe(
+        404
+      );
+
       await expect(fetchAuth({ assetId: nonAdminAsset.id })).resolves.toBe(404);
+      await expect(fetchAuth({ pid: nonAdminAsset.playbackId })).resolves.toBe(
+        404
+      );
     });
 
     it("should disallow access to other users resources", async () => {
       await expect(fetchAuth({ streamId: adminStream.id })).resolves.toBe(403);
       await expect(fetchAuth({ assetId: adminAsset.id })).resolves.toBe(403);
+      await expect(fetchAuth({ pid: adminAsset.playbackId })).resolves.toBe(
+        403
+      );
     });
 
     it("should allow access to own resources", async () => {
       await expect(fetchAuth({ streamId: nonAdminStream.id })).resolves.toBe(
         204
       );
+      await expect(fetchAuth({ pid: nonAdminStream.playbackId })).resolves.toBe(
+        204
+      );
+
       await expect(fetchAuth({ assetId: nonAdminAsset.id })).resolves.toBe(204);
+      await expect(fetchAuth({ pid: nonAdminAsset.playbackId })).resolves.toBe(
+        204
+      );
     });
 
     it("should allow admins to access to other users resources", async () => {
@@ -524,7 +553,14 @@ describe("controller/auth", () => {
       await expect(fetchAuth({ streamId: nonAdminStream.id })).resolves.toBe(
         204
       );
+      await expect(fetchAuth({ pid: nonAdminStream.playbackId })).resolves.toBe(
+        204
+      );
+
       await expect(fetchAuth({ assetId: nonAdminAsset.id })).resolves.toBe(204);
+      await expect(fetchAuth({ pid: nonAdminAsset.playbackId })).resolves.toBe(
+        204
+      );
     });
   });
 });

--- a/packages/api/src/controllers/auth.ts
+++ b/packages/api/src/controllers/auth.ts
@@ -40,6 +40,8 @@ app.all(
   async (req, res) => {
     await checkUserOwned(req, "x-livepeer-stream-id", db.stream);
     await checkUserOwned(req, "x-livepeer-asset-id", db.asset);
+
+    res.header("x-livepeer-user-id", req.user.id);
     res.status(204).end();
   }
 );

--- a/packages/api/src/controllers/auth.ts
+++ b/packages/api/src/controllers/auth.ts
@@ -2,12 +2,12 @@
  * Special controller for forwarding all incoming requests to a geolocated API region
  */
 
-import { Request, Response, Router } from "express";
+import { Request, Router } from "express";
 import { authorizer } from "../middleware";
 import { db } from "../store";
 import { ForbiddenError, NotFoundError } from "../store/errors";
 import Table from "../store/table";
-import { dStorageUrlFromAsset, getResourceByPlaybackId } from "./playback";
+import { getResourceByPlaybackId } from "./playback";
 
 type UserOwnedObj = { id: string; deleted?: boolean; userId?: string };
 
@@ -35,22 +35,12 @@ async function checkUserOwned(
   }
 }
 
-function playbackIdGetter(req: Request, res?: Response) {
-  return async (id: string) => {
+function playbackIdGetter(req: Request) {
+  return async (id: string): Promise<UserOwnedObj> => {
     const { asset, stream, session } = await getResourceByPlaybackId(
       id,
       req.user
     );
-    if (asset || stream) {
-      const pid = (asset || stream).playbackId;
-      res.header("x-livepeer-canonical-playback-id", pid);
-    }
-    if (asset) {
-      const dStorageUrl = dStorageUrlFromAsset(asset);
-      if (dStorageUrl) {
-        res.header("x-livepeer-playback-dstorage-url", dStorageUrl);
-      }
-    }
     return asset || stream || session;
   };
 }
@@ -68,7 +58,7 @@ app.all(
     await Promise.all([
       checkUserOwned(req, "x-livepeer-stream-id", tableGetter(db.stream)),
       checkUserOwned(req, "x-livepeer-asset-id", tableGetter(db.asset)),
-      checkUserOwned(req, "x-livepeer-playback-id", playbackIdGetter(req, res)),
+      checkUserOwned(req, "x-livepeer-playback-id", playbackIdGetter(req)),
     ]);
 
     res.header("x-livepeer-user-id", req.user.id);

--- a/packages/api/src/controllers/playback.test.ts
+++ b/packages/api/src/controllers/playback.test.ts
@@ -355,17 +355,25 @@ describe("controllers/playback", () => {
       });
     });
 
-    it("should return playback URL for top-level streams", async () => {
-      await db.stream.update(stream.id, {
+    it("should return playback URL for user sessions", async () => {
+      // delete the child stream just to make sure we use the user session (they have the same id)
+      await db.stream.delete(childStream.id);
+      await db.session.update(session.id, {
         record: true,
         recordObjectStoreId: "mock_store",
         lastSeen: Date.now() - 60 * 60 * 1000,
       });
-      let res = await client.get(`/playback/${stream.id}`);
+
+      const res = await client.get(`/playback/${session.id}`);
       expect(res.status).toBe(200);
       await expect(res.json()).resolves.toMatchObject({
         type: "recording",
       });
+    });
+
+    it("should return playback URL for top-level streams by playbackId", async () => {
+      let res = await client.get(`/playback/${stream.id}`);
+      expect(res.status).toBe(404);
 
       res = await client.get(`/playback/${stream.playbackId}`);
       expect(res.status).toBe(200);

--- a/packages/api/src/controllers/playback.test.ts
+++ b/packages/api/src/controllers/playback.test.ts
@@ -359,6 +359,7 @@ describe("controllers/playback", () => {
       // delete the child stream just to make sure we use the user session (they have the same id)
       await db.stream.delete(childStream.id);
       await db.session.update(session.id, {
+        version: "v1",
         record: true,
         recordObjectStoreId: "mock_store",
         lastSeen: Date.now() - 60 * 60 * 1000,

--- a/packages/api/src/controllers/playback.ts
+++ b/packages/api/src/controllers/playback.ts
@@ -95,9 +95,9 @@ const getAssetPlaybackInfo = async (
   );
 };
 
-async function getResourceByPlaybackId(
+export async function getResourceByPlaybackId(
   id: string,
-  user?: User
+  user: User
 ): Promise<{ stream?: DBStream; session?: DBSession; asset?: WithID<Asset> }> {
   let asset =
     (await db.asset.getByPlaybackId(id)) ??

--- a/packages/api/src/controllers/playback.ts
+++ b/packages/api/src/controllers/playback.ts
@@ -72,7 +72,7 @@ function newPlaybackInfo(
 }
 
 const getAssetPlaybackInfo = async (
-  config: Request["config"],
+  config: CliArgs,
   ingest: string,
   asset: WithID<Asset>
 ) => {

--- a/packages/api/src/controllers/playback.ts
+++ b/packages/api/src/controllers/playback.ts
@@ -17,7 +17,6 @@ import { DBStream } from "../store/stream-table";
 import { WithID } from "../store/types";
 
 // This should be compatible with the Mist format: https://gist.github.com/iameli/3e9d20c2b7f11365ea8785c5a8aa6aa6
-// Update: 1 year later found out I copied it wrong from the start. `source` is on the root, on mist schema, not inside `meta`.
 type PlaybackInfo = {
   type: "live" | "vod" | "recording";
   meta: {
@@ -96,22 +95,10 @@ const getAssetPlaybackInfo = async (
   );
 };
 
-export function dStorageUrlFromAsset(asset: WithID<Asset>) {
-  if (asset.storage?.ipfs?.cid) {
-    return "ipfs://" + asset.storage.ipfs.cid;
-  }
-  const { source } = asset;
-  if (source.type === "url" && source.url.match(/^(ar|ipfs):\/\//)) {
-    return source.url;
-  }
-  return undefined;
-}
-
 export async function getResourceByPlaybackId(
   id: string,
   user: User
 ): Promise<{ stream?: DBStream; session?: DBSession; asset?: WithID<Asset> }> {
-  // logic matches dStorageUrlFromAsset above
   let asset =
     (await db.asset.getByPlaybackId(id)) ??
     (await db.asset.getByIpfsCid(id, user)) ??

--- a/packages/api/src/controllers/playback.ts
+++ b/packages/api/src/controllers/playback.ts
@@ -12,8 +12,9 @@ import {
 import { CliArgs } from "../parse-cli";
 import { NotFoundError } from "@cloudflare/kv-asset-handler";
 import { DBSession } from "../store/db";
-import Table from "../store/table";
 import { Asset, Stream, User } from "../schema/types";
+import { DBStream } from "../store/stream-table";
+import { WithID } from "../store/types";
 
 // This should be compatible with the Mist format: https://gist.github.com/iameli/3e9d20c2b7f11365ea8785c5a8aa6aa6
 type PlaybackInfo = {
@@ -70,62 +71,80 @@ function newPlaybackInfo(
   return playbackInfo;
 }
 
-const getAssetPlaybackUrl = async (
+const getAssetPlaybackInfo = async (
   config: Request["config"],
   ingest: string,
-  id: string,
-  user: User
+  asset: WithID<Asset>
 ) => {
-  const asset =
-    (await db.asset.getByPlaybackId(id)) ??
-    (await db.asset.getByIpfsCid(id, user)) ??
-    (await db.asset.getBySourceURL("ipfs://" + id, user)) ??
-    (await db.asset.getBySourceURL("ar://" + id, user));
-  if (!asset || asset.deleted) {
-    return null;
-  }
   const os = await db.objectStore.get(asset.objectStoreId);
   if (!os || os.deleted || os.disabled) {
     return null;
   }
+
   const playbackUrl = assetPlaybackUrl(config, ingest, asset, os);
-  const staticFilesPlaybackInfo = getStaticPlaybackInfo(asset, os);
 
-  return !playbackUrl
-    ? null
-    : {
-        staticFilesPlaybackInfo,
-        playbackUrl,
-        playbackPolicy: asset.playbackPolicy || null,
-      };
-};
-
-const getRecordingPlaybackUrl = async (
-  config: CliArgs,
-  ingest: string,
-  id: string,
-  table: Table<DBSession>
-) => {
-  const session = await table.get(id);
-  if (!session || session.deleted) {
+  if (!playbackUrl) {
     return null;
   }
-  const { recordingUrl } = await getRecordingFields(
-    config,
-    ingest,
-    session,
-    false
+
+  return newPlaybackInfo(
+    "vod",
+    playbackUrl,
+    asset.playbackPolicy || null,
+    getStaticPlaybackInfo(asset, os)
   );
-  return recordingUrl;
 };
+
+async function getResourceByPlaybackId(
+  id: string,
+  user?: User
+): Promise<{ stream?: DBStream; session?: DBSession; asset?: WithID<Asset> }> {
+  let asset =
+    (await db.asset.getByPlaybackId(id)) ??
+    (await db.asset.getByIpfsCid(id, user)) ??
+    (await db.asset.getBySourceURL("ipfs://" + id, user)) ??
+    (await db.asset.getBySourceURL("ar://" + id, user));
+
+  if (asset && !asset.deleted) {
+    return { asset };
+  }
+
+  let stream = await db.stream.getByPlaybackId(id);
+  if (!stream) {
+    stream = await db.stream.get(id);
+  }
+  if (stream && !stream.deleted && !stream.suspended) {
+    return { stream };
+  }
+
+  const session = await db.session.get(id);
+  if (session && !session.deleted) {
+    return { session };
+  }
+
+  return {};
+}
 
 async function getPlaybackInfo(
   { config, user }: Request,
   ingest: string,
   id: string
 ): Promise<PlaybackInfo> {
-  const stream = await db.stream.getByPlaybackId(id);
-  if (stream && !stream.deleted) {
+  let { stream, asset, session } = await getResourceByPlaybackId(id, user);
+
+  if (asset) {
+    return await getAssetPlaybackInfo(config, ingest, asset);
+  }
+
+  // Streams represent "transcoding sessions" when they are a child stream, in
+  // which case they are used to playback old recordings and not the livestream.
+  const isChildStream = stream?.parentId || !stream?.playbackId;
+  if (isChildStream) {
+    session = stream;
+    stream = null;
+  }
+
+  if (stream) {
     return newPlaybackInfo(
       "live",
       streamPlaybackUrl(ingest, stream),
@@ -135,21 +154,16 @@ async function getPlaybackInfo(
     );
   }
 
-  const recordingUrl =
-    (await getRecordingPlaybackUrl(config, ingest, id, db.session)) ??
-    (await getRecordingPlaybackUrl(config, ingest, id, db.stream));
-  if (recordingUrl) {
-    return newPlaybackInfo("recording", recordingUrl);
-  }
-
-  const asset = await getAssetPlaybackUrl(config, ingest, id, user);
-  if (asset) {
-    return newPlaybackInfo(
-      "vod",
-      asset.playbackUrl,
-      asset.playbackPolicy,
-      asset.staticFilesPlaybackInfo
+  if (session) {
+    const { recordingUrl } = await getRecordingFields(
+      config,
+      ingest,
+      session,
+      false
     );
+    if (recordingUrl) {
+      return newPlaybackInfo("recording", recordingUrl);
+    }
   }
 
   throw new NotFoundError(`No playback URL found for ${id}`);

--- a/packages/api/src/controllers/playback.ts
+++ b/packages/api/src/controllers/playback.ts
@@ -17,6 +17,7 @@ import { DBStream } from "../store/stream-table";
 import { WithID } from "../store/types";
 
 // This should be compatible with the Mist format: https://gist.github.com/iameli/3e9d20c2b7f11365ea8785c5a8aa6aa6
+// Update: 1 year later found out I copied it wrong from the start. `source` is on the root, on mist schema, not inside `meta`.
 type PlaybackInfo = {
   type: "live" | "vod" | "recording";
   meta: {
@@ -95,10 +96,22 @@ const getAssetPlaybackInfo = async (
   );
 };
 
+export function dStorageUrlFromAsset(asset: WithID<Asset>) {
+  if (asset.storage?.ipfs?.cid) {
+    return "ipfs://" + asset.storage.ipfs.cid;
+  }
+  const { source } = asset;
+  if (source.type === "url" && source.url.match(/^(ar|ipfs):\/\//)) {
+    return source.url;
+  }
+  return undefined;
+}
+
 export async function getResourceByPlaybackId(
   id: string,
   user: User
 ): Promise<{ stream?: DBStream; session?: DBSession; asset?: WithID<Asset> }> {
+  // logic matches dStorageUrlFromAsset above
   let asset =
     (await db.asset.getByPlaybackId(id)) ??
     (await db.asset.getByIpfsCid(id, user)) ??

--- a/packages/api/src/controllers/playback.ts
+++ b/packages/api/src/controllers/playback.ts
@@ -69,11 +69,12 @@ function newPlaybackInfo(
 
   return playbackInfo;
 }
+
 const getAssetPlaybackUrl = async (
   config: Request["config"],
   ingest: string,
   id: string,
-  user?: User
+  user: User
 ) => {
   const asset =
     (await db.asset.getByPlaybackId(id)) ??
@@ -141,7 +142,7 @@ async function getPlaybackInfo(
     return newPlaybackInfo("recording", recordingUrl);
   }
 
-  const asset = await getAssetPlaybackUrl(config, ingest, id);
+  const asset = await getAssetPlaybackUrl(config, ingest, id, user);
   if (asset) {
     return newPlaybackInfo(
       "vod",

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -218,7 +218,11 @@ export const corsApiKeyAccessRules: AuthRule[] = [
   // Data
   {
     methods: ["get"],
-    resources: ["/data/views/:id/total"],
+    resources: [
+      "/data/views/:id/total",
+      "/data/views/query/total/:id",
+      "/data/views/query/creator",
+    ],
   },
 ];
 


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This is to increment the `/api/auth` API, used by external services that need to
build on top of the API authorization, to also support authorizing access to a 
given playback ID. This playback ID can not only be the canonical playback ID of
assets/streams, but can also be the "aliased" IDs like a dStorage ID.

This will be used in the viewership v2 API when it is accessed with a playback ID filter.

**Specific updates (required)**
 - Refactor "playback info" implementation to have a separate "get resource by playback ID" function
 - Add `x-livepeer-playback-id` header support to auth API
 - Parallelize the authorization checks just in case 
   - (also need to optimize the `getResourceByPlaybackId` at some point)

**How did you test each of these updates (required)**
`yarn test`

**Does this pull request close any open issues?**
Implements API-50

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
