### PR TITLE
api/playback: Stop returning assets from other users on playback info

### DIFF
--- a/packages/api/src/controllers/auth.test.ts
+++ b/packages/api/src/controllers/auth.test.ts
@@ -473,6 +473,7 @@ describe("controller/auth", () => {
         id: uuid(),
         playbackId: await generateUniquePlaybackId(uuid()),
         userId: nonAdminUser.id,
+        status: { phase: "ready" },
       } as any);
       adminStream = await db.stream.create({
         id: uuid(),
@@ -483,6 +484,7 @@ describe("controller/auth", () => {
         id: uuid(),
         playbackId: await generateUniquePlaybackId(uuid()),
         userId: adminUser.id,
+        status: { phase: "ready" },
       } as any);
     });
 

--- a/packages/api/src/controllers/playback.ts
+++ b/packages/api/src/controllers/playback.ts
@@ -26,7 +26,7 @@ import { NotFoundError, UnprocessableEntityError } from "../store/errors";
  */
 export const CROSS_USER_ASSETS_CUTOFF_DATE = new Date(2023, 5, 10).getTime();
 
-var embeddablePlayerOrigin = /^https:\/\/(.+\.)?lvpr.tv\/$/;
+var embeddablePlayerOrigin = /^https:\/\/(.+\.)?lvpr.tv$/;
 
 // This should be compatible with the Mist format: https://gist.github.com/iameli/3e9d20c2b7f11365ea8785c5a8aa6aa6
 type PlaybackInfo = {

--- a/packages/api/src/controllers/playback.ts
+++ b/packages/api/src/controllers/playback.ts
@@ -123,6 +123,13 @@ export async function getResourceByPlaybackId(
     if (asset.status.phase !== "ready") {
       throw new UnprocessableEntityError("asset is not ready for playback");
     }
+    if (asset.userId !== user?.id && !isCrossUserQuery) {
+      console.log(
+        `Returning cross-user asset for playback. ` +
+          `userId=${user?.id} userEmail=${user?.email} ` +
+          `assetId=${asset.id} assetUserId=${asset.userId} playbackId=${asset.playbackId}`
+      );
+    }
     return { asset };
   }
 

--- a/packages/api/src/store/asset-table.ts
+++ b/packages/api/src/store/asset-table.ts
@@ -98,9 +98,11 @@ export default class AssetTable extends Table<WithID<Asset>> {
       }
     }
 
-    return await findOnce([
-      sql`coalesce((asset.data->'createdAt')::bigint, 0) < ${crossUserCutoffDate}`,
-    ]);
+    return !crossUserCutoffDate
+      ? findOnce([])
+      : findOnce([
+          sql`coalesce((asset.data->'createdAt')::bigint, 0) < ${crossUserCutoffDate}`,
+        ]);
   }
 
   async getBySessionId(sessionId: string): Promise<WithID<Asset>> {

--- a/packages/api/src/test-helpers.ts
+++ b/packages/api/src/test-helpers.ts
@@ -140,8 +140,8 @@ export class TestClient {
     return res;
   }
 
-  async get(path: string) {
-    return await this.fetch(path, { method: "GET" });
+  async get(path: string, args?: RequestInit) {
+    return await this.fetch(path, { method: "GET", ...args });
   }
 
   async delete(path: string, data?: any) {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This is to stop returning assets from other users on the playback info endpoint.
This is a breaking change so we're doing it with a cut-off date logic instead
of breaking existing assets that might be used cross-user today.

**Specific updates (required)**
 - Add cut-off date to search for cross-user assets
 - Allow lvpr.tv to access any asset to continue to have CID support for embeddable player 
 - Add a log when we return old assets to a different user, to evaluate fixing this

**How did you test each of these updates (required)**
`yarn test` with the new tests

**Does this pull request close any open issues?**
Fixes API-45

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
