### PR TITLE
api/db: Create indexes concurrently

### DIFF
--- a/packages/api/src/store/table.ts
+++ b/packages/api/src/store/table.ts
@@ -387,7 +387,7 @@ export default class Table<T extends DBObject> {
     const propAccessor = `data${parentsAcc}${propAccessOp}'${propName}'`;
     try {
       await this.db.query(`
-          CREATE ${unique} INDEX "${indexName}" ON "${this.name}" USING ${indexType} ((${propAccessor}));
+          CREATE ${unique} INDEX CONCURRENTLY "${indexName}" ON "${this.name}" USING ${indexType} ((${propAccessor}));
         `);
     } catch (e) {
       if (!e.message.includes("already exists")) {

--- a/packages/api/src/store/table.ts
+++ b/packages/api/src/store/table.ts
@@ -349,9 +349,11 @@ export default class Table<T extends DBObject> {
   async ensureIndex(propName: string, prop: FieldSpec, parents: string[] = []) {
     if (
       process.env.NODE_ENV !== "test" &&
-      !["asset", "experiment", "room"].includes(this.name)
+      ["stream", "session"].includes(this.name)
     ) {
-      // avoid creating indexes in production right now...
+      // avoid creating stream indexes in production right now. since the tables
+      // are large they can take 15+ minutes to index which hangs deployments.
+      // TODO: create an init container to create indexes before the server.
       return;
     }
     if (prop.oneOf?.length) {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This is to fix the index creation query which didn't use the CONCURRENTLY
option for the command. It avoids blocking the whole table for Write operations
while the index is being created, which is possibly what has caused issues
for us in the past.

Still tho, stream and session tables are huge, with millions of entries, and creating
indexes on those tables might need some attention. They may also lock deploys
as the API servers could be unavailable for minutes while creating indexes.

So I still kept the limitation for indexing tables, but inverted the check. Instead of
an allow-list of tables to index, just block the specific `stream` and `session` tables.

**Specific updates (required)**
 - Add `CONCURRENTLY` to create index query
 - Invert the condition for which tables to create indexes
 - Add a little more context in the comment

**How did you test each of these updates (required)**
We just created the stream.sessionId index in prod with this.

**Does this pull request close any open issues?**
No.

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
