### PR TITLE
api/health: Add estimate playback latency for streams

### DIFF
--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -920,7 +920,7 @@ const currMultiNodeHopCount = 2;
 
 function streamPlaybackLatencies(
   health: StreamHealthPayload
-): Pick<DBStream, "hlsPlaybackLatency" | "webrtcPlaybackLatency"> {
+): Pick<DBStream, "hlsPlaybackLatencyMs" | "webrtcPlaybackLatencyMs"> {
   const jitter = health.extra?.jitter as number;
 
   const maxGopMs = Object.values(health.tracks ?? [])
@@ -933,8 +933,8 @@ function streamPlaybackLatencies(
 
   // 100 and 50 below are guesstimations of the average ping between regions
   return {
-    hlsPlaybackLatency: jitter + 100 * currMultiNodeHopCount + 7 * maxGopMs,
-    webrtcPlaybackLatency: jitter + 50 * currMultiNodeHopCount,
+    hlsPlaybackLatencyMs: jitter + 100 * currMultiNodeHopCount + 7 * maxGopMs,
+    webrtcPlaybackLatencyMs: jitter + 50 * currMultiNodeHopCount,
   };
 }
 

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -246,6 +246,16 @@ components:
           $ref: "#/components/schemas/stream-health-payload/properties/is_healthy"
         issues:
           $ref: "#/components/schemas/stream-health-payload/properties/human_issues"
+        hlsPlaybackLatencyMs:
+          type: number
+          description:
+            Estimated end-to-end latency with the current stream configuration
+            for HLS playback.
+        webrtcPlaybackLatencyMs:
+          type: number
+          description:
+            Estimated end-to-end latency with the current stream configuration
+            for WebRTC playback.
         createdByTokenName:
           type: string
           readOnly: true
@@ -563,6 +573,10 @@ components:
           $ref: "#/components/schemas/stream-health-payload/properties/is_healthy"
         issues:
           $ref: "#/components/schemas/stream-health-payload/properties/human_issues"
+        hlsPlaybackLatencyMs:
+          $ref: "#/components/schemas/stream/properties/hlsPlaybackLatencyMs"
+        webrtcPlaybackLatencyMs:
+          $ref: "#/components/schemas/stream/properties/webrtcPlaybackLatencyMs"
         createdAt:
           readOnly: true
           type: number


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
Adds the missing fields for the stream health exposure regarding an estimation
of the playback latency on HLS and WebRTC playback protocols.

**Specific updates (required)**
 - Create new fields in the schema
 - Calculate them on the API
 - Fix a log that was missing whitespace

**How did you test each of these updates (required)**
Checked the new field gets returned on the API.

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
