### PR TITLE
api: Add creatorId to streams

### DIFF
--- a/packages/api/src/controllers/stream.test.ts
+++ b/packages/api/src/controllers/stream.test.ts
@@ -409,6 +409,18 @@ describe("controllers/stream", () => {
         expect(server.db.stream.addDefaultFields(document)).toEqual(stream);
       });
 
+      it("should create a stream with creator ID", async () => {
+        const now = Date.now();
+        const res = await client.post("/stream", {
+          ...postMockStream,
+          creatorId: "jest",
+        });
+        expect(res.status).toBe(201);
+        const stream = await res.json();
+        expect(stream.id).toBeDefined();
+        expect(stream.creatorId).toEqual({ type: "unverified", value: "jest" });
+      });
+
       it("should create stream with valid multistream target ID", async () => {
         const res = await client.post("/stream", {
           ...postMockStream,

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -939,11 +939,17 @@ app.post(
       }
     }
 
-    const doc: DBStream = wowzaHydrate({
+    const creatorId =
+      typeof payload.creatorId === "string"
+        ? ({ type: "unverified", value: payload.creatorId } as const)
+        : payload.creatorId;
+
+    let doc: DBStream = {
       ...DEFAULT_STREAM_FIELDS,
       ...payload,
       kind: "stream",
       userId: req.user.id,
+      creatorId,
       renditions: {},
       objectStoreId,
       id,
@@ -954,7 +960,9 @@ app.post(
       createdByTokenId: req.token?.id,
       isActive: false,
       lastSeen: 0,
-    });
+    };
+    doc = wowzaHydrate(doc);
+
     await validateStreamPlaybackPolicy(doc.playbackPolicy, req.user.id);
 
     doc.profiles = hackMistSettings(req, doc.profiles);

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -12,6 +12,7 @@ import { geolocateMiddleware } from "../middleware";
 import { CliArgs } from "../parse-cli";
 import {
   DetectionWebhookPayload,
+  NewStreamPayload,
   StreamHealthPayload,
   StreamPatchPayload,
   StreamSetActivePayload,
@@ -913,67 +914,66 @@ app.post(
   }
 );
 
-app.post("/", authorizer({}), validatePost("stream"), async (req, res) => {
-  if (!req.body || !req.body.name) {
-    res.status(422);
-    return res.json({
-      errors: ["missing name"],
-    });
-  }
-  const id = uuid();
-  const createdAt = Date.now();
-  const streamKey = await generateUniqueStreamKey(id);
-  let playbackId = await generateUniquePlaybackId(id, [streamKey]);
-  if (req.user.isTestUser) {
-    playbackId += "-test";
-  }
+app.post(
+  "/",
+  authorizer({}),
+  validatePost("new-stream-payload"),
+  async (req, res) => {
+    const payload = req.body as NewStreamPayload;
 
-  let objectStoreId;
-  if (req.body.objectStoreId) {
-    const store = await db.objectStore.get(req.body.objectStoreId);
-    if (!store || store.deleted || store.disabled) {
-      return res.status(400).json({
-        errors: [
-          `object store ${req.body.objectStoreId} not found or disabled`,
-        ],
-      });
+    const id = uuid();
+    const createdAt = Date.now();
+    const streamKey = await generateUniqueStreamKey(id);
+    let playbackId = await generateUniquePlaybackId(id, [streamKey]);
+    if (req.user.isTestUser) {
+      playbackId += "-test";
     }
+
+    const { objectStoreId } = payload;
+    if (objectStoreId) {
+      const store = await db.objectStore.get(objectStoreId);
+      if (!store || store.deleted || store.disabled) {
+        return res.status(400).json({
+          errors: [`object store ${objectStoreId} not found or disabled`],
+        });
+      }
+    }
+
+    const doc: DBStream = wowzaHydrate({
+      ...DEFAULT_STREAM_FIELDS,
+      ...payload,
+      kind: "stream",
+      userId: req.user.id,
+      renditions: {},
+      objectStoreId,
+      id,
+      createdAt,
+      streamKey,
+      playbackId,
+      createdByTokenName: req.token?.name,
+      createdByTokenId: req.token?.id,
+      isActive: false,
+      lastSeen: 0,
+    });
+    await validateStreamPlaybackPolicy(doc.playbackPolicy, req.user.id);
+
+    doc.profiles = hackMistSettings(req, doc.profiles);
+    doc.multistream = await validateMultistreamOpts(
+      req.user.id,
+      doc.profiles,
+      doc.multistream
+    );
+
+    await db.stream.create(doc);
+
+    res.status(201);
+    res.json(
+      db.stream.addDefaultFields(
+        db.stream.removePrivateFields(doc, req.user.admin)
+      )
+    );
   }
-
-  const doc: DBStream = wowzaHydrate({
-    ...DEFAULT_STREAM_FIELDS,
-    ...req.body,
-    kind: "stream",
-    userId: req.user.id,
-    renditions: {},
-    objectStoreId,
-    id,
-    createdAt,
-    streamKey,
-    playbackId,
-    createdByTokenName: req.token?.name,
-    createdByTokenId: req.token?.id,
-    isActive: false,
-    lastSeen: 0,
-  });
-  await validateStreamPlaybackPolicy(doc.playbackPolicy, req.user.id);
-
-  doc.profiles = hackMistSettings(req, doc.profiles);
-  doc.multistream = await validateMultistreamOpts(
-    req.user.id,
-    doc.profiles,
-    doc.multistream
-  );
-
-  await req.store.create(doc);
-
-  res.status(201);
-  res.json(
-    db.stream.addDefaultFields(
-      db.stream.removePrivateFields(doc, req.user.admin)
-    )
-  );
-});
+);
 
 app.put(
   "/:id/setactive",

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -210,7 +210,13 @@ components:
           type: string
           example: test_stream
         creatorId:
-          $ref: "#/components/schemas/creator-id"
+          oneOf:
+            - $ref: "#/components/schemas/creator-id"
+            - type: string
+              writeOnly: true
+              description:
+                Helper syntax to specify an unverified creator ID, fully managed
+                by the developer.
         lastSeen:
           type: number
           example: 1587667174725

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -209,6 +209,8 @@ components:
         name:
           type: string
           example: test_stream
+        creatorId:
+          $ref: "#/components/schemas/creator-id"
         lastSeen:
           type: number
           example: 1587667174725
@@ -729,18 +731,7 @@ components:
                 encryption:
                   $ref: "#/components/schemas/new-asset-payload/properties/encryption"
         creatorId:
-          oneOf:
-            - type: object
-              additionalProperties: false
-              required: [type, value]
-              properties:
-                type:
-                  type: string
-                  enum: [unverified]
-                value:
-                  type: string
-                  description:
-                    Developer-managed ID of the user who created the asset.
+          $ref: "#/components/schemas/creator-id"
         storage:
           additionalProperties: false
           properties:
@@ -1006,7 +997,7 @@ components:
           $ref: "#/components/schemas/playback-policy"
         creatorId:
           oneOf:
-            - $ref: "#/components/schemas/asset/properties/creatorId"
+            - $ref: "#/components/schemas/creator-id"
             - type: string
               description:
                 Helper syntax to specify an unverified creator ID, fully managed
@@ -1487,6 +1478,20 @@ components:
                     assetSpec:
                       type: object
                       $ref: "#/components/schemas/asset"
+    creator-id:
+      type: object
+      oneOf:
+        - type: object
+          additionalProperties: false
+          required: [type, value]
+          properties:
+            type:
+              type: string
+              enum: [unverified]
+            value:
+              type: string
+              description:
+                Developer-managed ID of the user who created the resource.
     export-task-params:
       description: Parameters for the export task
       oneOf:

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -367,7 +367,12 @@ components:
         name:
           $ref: "#/components/schemas/stream/properties/name"
         creatorId:
-          $ref: "#/components/schemas/creator-id"
+          oneOf:
+            - $ref: "#/components/schemas/creator-id"
+            - type: string
+              description:
+                Helper syntax to specify an unverified creator ID, fully managed
+                by the developer.
         playbackPolicy:
           $ref: "#/components/schemas/playback-policy"
         profiles:

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -210,13 +210,7 @@ components:
           type: string
           example: test_stream
         creatorId:
-          oneOf:
-            - $ref: "#/components/schemas/creator-id"
-            - type: string
-              writeOnly: true
-              description:
-                Helper syntax to specify an unverified creator ID, fully managed
-                by the developer.
+          $ref: "#/components/schemas/creator-id"
         lastSeen:
           type: number
           example: 1587667174725

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -358,6 +358,24 @@ components:
         suspended:
           type: boolean
           description: If currently suspended
+    new-stream-payload:
+      type: object
+      required:
+        - name
+      additionalProperties: false
+      properties:
+        name:
+          $ref: "#/components/schemas/stream/properties/name"
+        creatorId:
+          $ref: "#/components/schemas/creator-id"
+        playbackPolicy:
+          $ref: "#/components/schemas/playback-policy"
+        profiles:
+          $ref: "#/components/schemas/stream/properties/profiles"
+        record:
+          $ref: "#/components/schemas/stream/properties/record"
+        multistream:
+          $ref: "#/components/schemas/stream/properties/multistream"
     deactivate-many-payload:
       type: object
       additionalProperties: false
@@ -1863,7 +1881,7 @@ paths:
           application/json:
             schema:
               type: object
-              $ref: "#/components/schemas/stream"
+              $ref: "#/components/schemas/new-stream-payload"
       responses:
         "200":
           description: Success

--- a/packages/api/src/schema/db-schema.yaml
+++ b/packages/api/src/schema/db-schema.yaml
@@ -729,6 +729,12 @@ components:
         deleted:
           type: boolean
           description: Set to true when stream deleted
+    new-stream-payload:
+      properties:
+        recordObjectStoreId:
+          $ref: "#/components/schemas/stream/properties/recordObjectStoreId"
+        objectStoreId:
+          $ref: "#/components/schemas/stream/properties/objectStoreId"
     playback-policy:
       properties:
         type:


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->
## [Review with "ignore whitespace" for cleaner diff](https://github.com/livepeer/studio/pull/1743/files?w=1)

**What does this pull request do? Explain your changes. (required)**

This is to add the same `creatorId` field from assets to streams. A small refactor was required
in the schema since we didn't separate the "new stream payload" schema today. On the good
side our API reference is much more cleaner now.

**Specific updates (required)**
 - Create separate creator-id schema to be reused
 - Create separate new-stream-payload schema
 - Update stream creation API to use it + handle the creatorId

**How did you test each of these updates (required)**
`yarn test`

**Does this pull request close any open issues?**
Implements API-54

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
