### PR TITLE
api: Allow updating `creatorId` on streams and assets

### DIFF
--- a/packages/api/src/controllers/asset.test.ts
+++ b/packages/api/src/controllers/asset.test.ts
@@ -226,6 +226,20 @@ describe("controllers/asset", () => {
       });
     });
 
+    it("should allow editing asset creator ID", async () => {
+      const res = await client.patch(`/asset/${asset.id}`, {
+        creatorId: "0xjest",
+      });
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body).toMatchObject({
+        ...asset,
+        creatorId: { type: "unverified", value: "0xjest" },
+        status: { ...asset.status, updatedAt: expect.any(Number) },
+      });
+    });
+
     it("should allow editing asset playback policy", async () => {
       let playbackPolicy = {
         type: "public",

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -16,6 +16,7 @@ import {
   getObjectStoreS3Config,
   reqUseReplica,
   isValidBase64,
+  mapInputCreatorId,
 } from "./helpers";
 import { db } from "../store";
 import sql from "sql-template-strings";
@@ -131,11 +132,6 @@ async function validateAssetPayload(
     createdAt
   );
 
-  const creatorId =
-    typeof payload.creatorId === "string"
-      ? ({ type: "unverified", value: payload.creatorId } as const)
-      : payload.creatorId;
-
   return {
     id,
     playbackId,
@@ -148,7 +144,7 @@ async function validateAssetPayload(
     name: payload.name,
     source,
     staticMp4: payload.staticMp4,
-    creatorId,
+    creatorId: mapInputCreatorId(payload.creatorId),
     playbackPolicy,
     objectStoreId: payload.objectStoreId || defaultObjectStoreId,
     storage: storageInputToState(payload.storage),

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -1069,6 +1069,7 @@ app.patch(
       name,
       playbackPolicy,
       storage: storageInput,
+      creatorId,
     } = req.body as AssetPatchPayload;
 
     // update a specific asset
@@ -1122,6 +1123,7 @@ app.patch(
       name,
       storage,
       playbackPolicy,
+      creatorId: mapInputCreatorId(creatorId),
     });
     const updated = await db.asset.get(id, { useReplica: false });
     res.status(200).json(updated);

--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -11,9 +11,7 @@ import { S3Client, PutObjectCommand, S3ClientConfig } from "@aws-sdk/client-s3";
 import { S3StoreOptions as TusS3Opts } from "tus-node-server";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import base64url from "base64url";
-
-import { WithID } from "../store/types";
-import { ObjectStore, Task } from "../schema/types";
+import { CreatorId, ObjectStore } from "../schema/types";
 
 const ITERATIONS = 10000;
 
@@ -511,4 +509,10 @@ export function isValidBase64(str: string) {
     // If there's an error during decoding, it's not a valid base64 string
     return false;
   }
+}
+
+export function mapInputCreatorId(inputId: string | CreatorId): CreatorId {
+  return typeof inputId === "string"
+    ? { type: "unverified", value: inputId }
+    : inputId;
 }

--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -11,7 +11,7 @@ import { S3Client, PutObjectCommand, S3ClientConfig } from "@aws-sdk/client-s3";
 import { S3StoreOptions as TusS3Opts } from "tus-node-server";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import base64url from "base64url";
-import { CreatorId, ObjectStore } from "../schema/types";
+import { CreatorId, InputCreatorId, ObjectStore } from "../schema/types";
 
 const ITERATIONS = 10000;
 
@@ -511,7 +511,7 @@ export function isValidBase64(str: string) {
   }
 }
 
-export function mapInputCreatorId(inputId: string | CreatorId): CreatorId {
+export function mapInputCreatorId(inputId: InputCreatorId): CreatorId {
   return typeof inputId === "string"
     ? { type: "unverified", value: inputId }
     : inputId;

--- a/packages/api/src/controllers/stream.test.ts
+++ b/packages/api/src/controllers/stream.test.ts
@@ -548,14 +548,14 @@ describe("controllers/stream", () => {
 
       it("should disallow setting suspended streams or users", async () => {
         client.jwtAuth = nonAdminToken;
-        let res = await client.post("/stream", {
-          ...postMockStream,
-          suspended: true,
-        });
+        let res = await client.post("/stream", postMockStream);
         expect(res.status).toBe(201);
         const stream = await res.json();
-        client.jwtAuth = adminToken;
 
+        res = await client.patch(`/stream/${stream.id}`, { suspended: true });
+        expect(res.status).toBe(204);
+
+        client.jwtAuth = adminToken;
         await expectError(stream.id, "stream is suspended");
 
         await db.stream.update(stream.id, { suspended: false });
@@ -1263,7 +1263,6 @@ describe("controllers/stream", () => {
       client.jwtAuth = nonAdminToken;
 
       stream = {
-        kind: "stream",
         name: "test stream",
         profiles: [
           {
@@ -1541,7 +1540,6 @@ describe("controllers/stream", () => {
 });
 
 const smallStream = {
-  id: "231e7a49-8351-400b-a3df-0bcde13754e4",
   name: "small01",
   record: true,
   profiles: [

--- a/packages/api/src/controllers/stream.test.ts
+++ b/packages/api/src/controllers/stream.test.ts
@@ -655,6 +655,17 @@ describe("controllers/stream", () => {
         expect(res.status).toBe(204);
       });
 
+      it("should allow patch of creator ID", async () => {
+        const res = await client.patch(patchPath, {
+          creatorId: "0xjest",
+        });
+        expect(res.status).toBe(204);
+
+        await expect(db.stream.get(stream.id)).resolves.toMatchObject({
+          creatorId: { type: "unverified", value: "0xjest" },
+        });
+      });
+
       it("should allow patch of playbackPolicy", async () => {
         const res = await client.patch(patchPath, {
           playbackPolicy: {
@@ -671,6 +682,7 @@ describe("controllers/stream", () => {
         });
         expect(res.status).toBe(400);
       });
+
       it("should disallow additional fields", async () => {
         const res = await client.patch(patchPath, {
           name: "the stream name is immutable",

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -41,6 +41,7 @@ import {
   pathJoin,
   FieldsMap,
   toStringValues,
+  mapInputCreatorId,
 } from "./helpers";
 import { terminateStream, listActiveStreams } from "./mist-api";
 import wowzaHydrate from "./wowza-hydrate";
@@ -939,17 +940,12 @@ app.post(
       }
     }
 
-    const creatorId =
-      typeof payload.creatorId === "string"
-        ? ({ type: "unverified", value: payload.creatorId } as const)
-        : payload.creatorId;
-
     let doc: DBStream = {
       ...DEFAULT_STREAM_FIELDS,
       ...payload,
       kind: "stream",
       userId: req.user.id,
-      creatorId,
+      creatorId: mapInputCreatorId(payload.creatorId),
       renditions: {},
       objectStoreId,
       id,

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -1497,8 +1497,8 @@ components:
         - $ref: "#/components/schemas/creator-id"
         - type: string
           description:
-            Helper syntax to specify an unverified creator ID, fully managed
-            by the developer.
+            Helper syntax to specify an unverified creator ID, fully managed by
+            the developer.
     creator-id:
       type: object
       oneOf:

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -367,12 +367,7 @@ components:
         name:
           $ref: "#/components/schemas/stream/properties/name"
         creatorId:
-          oneOf:
-            - $ref: "#/components/schemas/creator-id"
-            - type: string
-              description:
-                Helper syntax to specify an unverified creator ID, fully managed
-                by the developer.
+          $ref: "#/components/schemas/input-creator-id"
         playbackPolicy:
           $ref: "#/components/schemas/playback-policy"
         profiles:
@@ -409,6 +404,8 @@ components:
       properties:
         name:
           $ref: "#/components/schemas/asset/properties/name"
+        creatorId:
+          $ref: "#/components/schemas/input-creator-id"
         playbackPolicy:
           $ref: "#/components/schemas/playback-policy"
         storage:
@@ -417,6 +414,8 @@ components:
       type: object
       additionalProperties: false
       properties:
+        creatorId:
+          $ref: "#/components/schemas/input-creator-id"
         record:
           $ref: "#/components/schemas/stream/properties/record"
         suspended:
@@ -1019,12 +1018,7 @@ components:
         playbackPolicy:
           $ref: "#/components/schemas/playback-policy"
         creatorId:
-          oneOf:
-            - $ref: "#/components/schemas/creator-id"
-            - type: string
-              description:
-                Helper syntax to specify an unverified creator ID, fully managed
-                by the developer.
+          $ref: "#/components/schemas/input-creator-id"
         storage:
           additionalProperties: false
           properties:
@@ -1498,6 +1492,13 @@ components:
                     assetSpec:
                       type: object
                       $ref: "#/components/schemas/asset"
+    input-creator-id:
+      oneOf:
+        - $ref: "#/components/schemas/creator-id"
+        - type: string
+          description:
+            Helper syntax to specify an unverified creator ID, fully managed
+            by the developer.
     creator-id:
       type: object
       oneOf:

--- a/packages/api/src/schema/db-schema.yaml
+++ b/packages/api/src/schema/db-schema.yaml
@@ -739,6 +739,12 @@ components:
           description: Set to true when stream deleted
     new-stream-payload:
       properties:
+        wowza:
+          $ref: "#/components/schemas/stream/properties/wowza"
+        presets:
+          $ref: "#/components/schemas/stream/properties/presets"
+        renditions:
+          $ref: "#/components/schemas/stream/properties/renditions"
         recordObjectStoreId:
           $ref: "#/components/schemas/stream/properties/recordObjectStoreId"
         objectStoreId:

--- a/packages/api/src/schema/db-schema.yaml
+++ b/packages/api/src/schema/db-schema.yaml
@@ -749,6 +749,8 @@ components:
           $ref: "#/components/schemas/stream/properties/recordObjectStoreId"
         objectStoreId:
           $ref: "#/components/schemas/stream/properties/objectStoreId"
+        detection:
+          $ref: "#/components/schemas/stream/properties/detection"
     playback-policy:
       properties:
         type:


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This is to add support for updating the `creatorId` of assets and stream objects on the API.

Will allow customers to migrate existing assets to the new creatorId-based system.

**Specific updates (required)**
 - Create some common schemas and helpers to allow that custom `string` input helper everywhere
 - Add support for `creatorId` patching on stream and asset PATCH endpoints

**How did you test each of these updates (required)**
Still missing some unit tests, on it

**Does this pull request close any open issues?**
Implements API-61

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
