### PR TITLE
api/schema: Move attestation to public schema

### DIFF
--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -1931,6 +1931,73 @@ components:
                     example: 449890
             attestation:
               $ref: "#/components/schemas/attestation"
+    attestation:
+      type: object
+      additionalProperties: false
+      required:
+        - primaryType
+        - domain
+        - message
+        - signature
+      properties:
+        primaryType:
+          type: string
+          description: Video Metadata EIP-712 primaryType
+          enum:
+            - VideoAttestation
+        domain:
+          type: object
+          description: Video Metadata EIP-712 domain
+          additionalProperties: false
+          required:
+            - name
+            - version
+          properties:
+            name:
+              type: string
+              enum:
+                - "Verifiable Video"
+            version:
+              type: string
+              enum:
+                - "1"
+        message:
+          type: object
+          additionalProperties: false
+          description: Video Metadata EIP-712 message content
+          required:
+            - video
+            - attestations
+            - signer
+            - timestamp
+          properties:
+            video:
+              type: string
+            attestations:
+              type: array
+              items:
+                type: object
+                additionalProperties: false
+                required:
+                  - role
+                  - address
+                properties:
+                  role:
+                    type: string
+                  address:
+                    type: string
+            signer:
+              type: string
+            timestamp:
+              type: number
+        signature:
+          type: string
+          description: Video Metadata EIP-712 message signature
+        createdAt:
+          type: number
+          readOnly: true
+          description:
+            Timestamp (in milliseconds) at which the object was created
 
 paths:
   /stream:

--- a/packages/api/src/schema/db-schema.yaml
+++ b/packages/api/src/schema/db-schema.yaml
@@ -379,73 +379,7 @@ components:
               address:
                 type: string
     attestation:
-      type: object
       table: attestation
-      additionalProperties: false
-      required:
-        - primaryType
-        - domain
-        - message
-        - signature
-      properties:
-        primaryType:
-          type: string
-          description: Video Metadata EIP-712 primaryType
-          enum:
-            - VideoAttestation
-        domain:
-          type: object
-          description: Video Metadata EIP-712 domain
-          additionalProperties: false
-          required:
-            - name
-            - version
-          properties:
-            name:
-              type: string
-              enum:
-                - "Verifiable Video"
-            version:
-              type: string
-              enum:
-                - "1"
-        message:
-          type: object
-          additionalProperties: false
-          description: Video Metadata EIP-712 message content
-          required:
-            - video
-            - attestations
-            - signer
-            - timestamp
-          properties:
-            video:
-              type: string
-            attestations:
-              type: array
-              items:
-                type: object
-                additionalProperties: false
-                required:
-                  - role
-                  - address
-                properties:
-                  role:
-                    type: string
-                  address:
-                    type: string
-            signer:
-              type: string
-            timestamp:
-              type: number
-        signature:
-          type: string
-          description: Video Metadata EIP-712 message signature
-        createdAt:
-          type: number
-          readOnly: true
-          description:
-            Timestamp (in milliseconds) at which the object was created
     experiment:
       type: object
       table: experiment


### PR DESCRIPTION
It cannot be referenced by an API schema as it
would break the API scchema itself. Only the
other way around can be done.