### PR TITLE
playback: Fix cross-user assets cut-off date

### DIFF
--- a/packages/api/src/controllers/playback.test.ts
+++ b/packages/api/src/controllers/playback.test.ts
@@ -5,7 +5,10 @@ import { WithID } from "../store/types";
 import { db } from "../store";
 import { DBStream } from "../store/stream-table";
 import { DBSession } from "../store/db";
-import { CROSS_USER_ASSETS_CUTOFF_DATE } from "./playback";
+
+const EXPECTED_CROSS_USER_ASSETS_CUTOFF_DATE = Date.parse(
+  "2023-06-06T00:00:00.000Z"
+);
 
 let server: TestServer;
 let ingest: string;
@@ -117,12 +120,12 @@ describe("controllers/playback", () => {
       } as const;
       await db.asset.update(asset.id, {
         playbackRecordingId: "mock_asset_1",
-        createdAt: CROSS_USER_ASSETS_CUTOFF_DATE + 1000,
+        createdAt: EXPECTED_CROSS_USER_ASSETS_CUTOFF_DATE + 1000,
         ...assetPatch,
       });
       await db.asset.update(asset2.id, {
         playbackRecordingId: "mock_asset_2",
-        createdAt: CROSS_USER_ASSETS_CUTOFF_DATE + 2000,
+        createdAt: EXPECTED_CROSS_USER_ASSETS_CUTOFF_DATE + 2000,
         ...assetPatch,
       });
 
@@ -484,10 +487,10 @@ describe("controllers/playback", () => {
     describe("cross-user playback backward compatibility", () => {
       beforeEach(async () => {
         await db.asset.update(asset.id, {
-          createdAt: CROSS_USER_ASSETS_CUTOFF_DATE - 2000,
+          createdAt: EXPECTED_CROSS_USER_ASSETS_CUTOFF_DATE - 2000,
         });
         await db.asset.update(asset2.id, {
-          createdAt: CROSS_USER_ASSETS_CUTOFF_DATE - 1000,
+          createdAt: EXPECTED_CROSS_USER_ASSETS_CUTOFF_DATE - 1000,
         });
       });
 

--- a/packages/api/src/controllers/playback.ts
+++ b/packages/api/src/controllers/playback.ts
@@ -24,9 +24,9 @@ import logger from "../logger";
  * asset playback. Assets created before this date can still be played by other
  * accounts by dStorage ID. Assets created after this date will not have
  * cross-account playback enabled, ensuring users are billed appropriately. This
- * was made for backward compatibiltiy during the Viewership V2 deploy.
+ * was made for backward compatibility during the Viewership V2 deploy.
  */
-export const CROSS_USER_ASSETS_CUTOFF_DATE = new Date(2023, 5, 10).getTime();
+const CROSS_USER_ASSETS_CUTOFF_DATE = 1686009600000; // 2023-06-06T00:00:00.000Z
 
 var embeddablePlayerOrigin = /^https:\/\/(.+\.)?lvpr.tv$/;
 


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Fixes the threshold used to allow assets to be queried by users other than their owner.

Turns out that months are 0-indexed on node Date libs.

**Specific updates (required)**
 - Fix the constant to tonight instead of this weekend
 - Make it a fixed number to avoid any other timestamp or timezone issues
 - Stop using the code constant in the tests, which made this not be detected during development


**How did you test each of these updates (required)**
`yarn test`

**Does this pull request close any open issues?**
https://discord.com/channels/423160867534929930/1101595605878448259/1114635371863609434

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
