### PR TITLE
URL encode the object store credentials for transcode API

### DIFF
--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -163,7 +163,9 @@ export function toObjectStoreUrl(storage: ObjectStoreStorage): string {
     throw new Error("undefined property 'credentials'");
   }
   const endpointUrl = new URL(storage.endpoint);
-  return `s3+${endpointUrl.protocol}//${storage.credentials.accessKeyId}:${storage.credentials.secretAccessKey}@${endpointUrl.host}/${storage.bucket}`;
+  const accessKey = encodeURIComponent(storage.credentials.accessKeyId);
+  const secretKey = encodeURIComponent(storage.credentials.secretAccessKey);
+  return `s3+${endpointUrl.protocol}//${accessKey}:${secretKey}@${endpointUrl.host}/${storage.bucket}`;
 }
 
 export function deleteCredentials(objectStoreUrl: string): string {

--- a/packages/api/src/controllers/transcode.test.ts
+++ b/packages/api/src/controllers/transcode.test.ts
@@ -116,7 +116,7 @@ describe("controllers/transcode", () => {
           endpoint: "https://inendpoint.com",
           credentials: {
             accessKeyId: "IN_USERNAME",
-            secretAccessKey: "IN_PASSWORD",
+            secretAccessKey: "IN_PASS/WORD",
           },
           bucket: "inbucket",
           path: "/input/video.mp4",
@@ -149,7 +149,7 @@ describe("controllers/transcode", () => {
         params: {
           "transcode-file": {
             input: {
-              url: "s3+https://IN_USERNAME:IN_PASSWORD@inendpoint.com/inbucket/input/video.mp4",
+              url: "s3+https://IN_USERNAME:IN_PASS%2FWORD@inendpoint.com/inbucket/input/video.mp4",
             },
             storage: {
               url: "s3+https://USERNAME:PASSWORD@endpoint.com/mybucket",


### PR DESCRIPTION
We saw an issue reported by a user where special characters were not escaped which caused the download to fail.