### PR TITLE
api/controllers: Throw errors on bad filters

### DIFF
--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -441,8 +441,10 @@ function parseFiltersRaw(fieldsMap: FieldsMap, val: string): SQLStatement[] {
               case "lte":
                 comparison = "<=";
                 break;
-              default:
+              case "eq":
                 comparison = "=";
+              default:
+                throw new Error(`unknown comparison: "${key}"`);
             }
             q.push(
               sql``

--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -12,6 +12,7 @@ import { S3StoreOptions as TusS3Opts } from "tus-node-server";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import base64url from "base64url";
 import { CreatorId, InputCreatorId, ObjectStore } from "../schema/types";
+import { BadRequestError } from "../store/errors";
 
 const ITERATIONS = 10000;
 
@@ -376,6 +377,14 @@ export function parseFilters(
   fieldsMap: FieldsMap,
   val: string
 ): SQLStatement[] {
+  try {
+    return parseFiltersRaw(fieldsMap, val);
+  } catch (e) {
+    throw new BadRequestError(`error parsing filters: ${e}`);
+  }
+}
+
+function parseFiltersRaw(fieldsMap: FieldsMap, val: string): SQLStatement[] {
   const isObject = function (a) {
     return !!a && a.constructor === Object;
   };
@@ -387,19 +396,18 @@ export function parseFilters(
   if (!fieldsMap || Object.keys(fieldsMap).length === 0) {
     return q;
   }
-  let json;
-  try {
-    json = JSON.parse(decodeURIComponent(val));
-  } catch (e) {
-    console.error("parseFilters: error decoding filters", e);
-    return q;
-  }
+
+  const json = JSON.parse(decodeURIComponent(val));
   if (!Array.isArray(json)) {
-    console.error("parseFilters: filters are not an array");
-    return q;
+    throw new Error(`must be an array`);
   }
+
   for (const filter of json) {
     const fv = fieldsMap[filter.id];
+    if (!filter.value) {
+      throw new Error(`missing filter value for id "${filter.id}"`);
+    }
+
     if (fv) {
       if (typeof fv === "string") {
         q.push(sql``.append(fv).append(sql` = ${filter.value}`));
@@ -448,7 +456,7 @@ export function parseFilters(
         }
       }
     } else {
-      console.error("parseFilters: unknown field: ", filter.id);
+      throw new Error(`unknown field: "${filter.id}"`);
     }
   }
   return q;


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This is to start throwing errors on bad filters specified on the request which improve
API ergonomy. Every time I try to write one myself I end up doing something wrong
and have no feedback that it is wrong.

We've been logging those cases for a while now to make sure no one is using, and
[no one is.](https://eu-metrics-monitoring.livepeer.live/grafana/explore?orgId=1&left=%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22%7Bapp%3D%5C%22prod-livepeer-api%5C%22%7D%20%7C%3D%20%5C%22parseFilters:%5C%22%22,%22queryType%22:%22range%22%7D%5D,%22range%22:%7B%22from%22:%22now-14d%22,%22to%22:%22now-7d%22%7D%7D)

**Specific updates (required)**
 - Wrap `parseFilter` into a function that wraps errors as a 400
 - Change logs into thrown errors
 - Check that `filter.value` is provided as well (not logged before, but feels relatively specific/safe)
 - Check that the specified comparison is valid (not logged before, but feels relatively specific/safe)

**How did you test each of these updates (required)**
call the API with bad filters

**Does this pull request close any open issues?**
Only my own internal ones.

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
