### PR TITLE
access-control: increase webhook-timeout and follow redirects

### DIFF
--- a/packages/api/src/controllers/access-control.ts
+++ b/packages/api/src/controllers/access-control.ts
@@ -16,10 +16,10 @@ import { DBWebhook } from "../store/webhook-table";
 import { PlaybackPolicy } from "../schema/types";
 import { signatureHeaders, storeTriggerStatus } from "../webhooks/cannon";
 import { Response } from "node-fetch";
-import { fetchWithTimeout } from "../util";
+import { fetchWithTimeoutAndRedirects } from "../util";
 import fetch from "node-fetch";
 
-const WEBHOOK_TIMEOUT = 5 * 1000;
+const WEBHOOK_TIMEOUT = 30 * 1000;
 const app = Router();
 
 async function fireGateWebhook(
@@ -55,8 +55,7 @@ async function fireGateWebhook(
   let statusCode: number;
 
   try {
-    resp = await fetchWithTimeout(webhook.url, params);
-    // TODO: remember to handle redirects
+    resp = await fetchWithTimeoutAndRedirects(webhook.url, params);
     statusCode = resp.status;
 
     if (resp.status < 200 || resp.status >= 300) {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

- Increased webhook timeout to 30 seconds - 5 seconds is not enough. The time to do an RPC call to infura to check if you have an NFT, and it's gone. Especially if you have multiple conditions in your webhook logic

Also, address redirects

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional)**

<!-- Drag some screenshots here, if applicable -->

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
