### PR TITLE
api: Add support for trusted IPFS gateway inputs

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -32,7 +32,7 @@
     "go-livepeer": "run-p \"go-livepeer:**\" --",
     "go-livepeer:broadcaster": "bin/livepeer -broadcaster -datadir ./bin/broadcaster -orchAddr 127.0.0.1:3086 -rtmpAddr 0.0.0.0:3035 -httpAddr :3085 -cliAddr :3075 -v 6 -authWebhookUrl http://127.0.0.1:3004/api/stream/hook -orchWebhookUrl http://127.0.0.1:3004/api/orchestrator",
     "go-livepeer:orchestrator": "bin/livepeer -orchestrator -datadir ./bin/orchestrator -transcoder -serviceAddr 127.0.0.1:3086 -cliAddr :3076 -v 6",
-    "test": "jest \"${PWD}/src\" -i --silent --clear-cache",
+    "test": "jest \"${PWD}/src\" -i --silent",
     "test:dev": "jest \"${PWD}/src\" -i --silent --watch",
     "test:build": "parcel build --no-autoinstall --no-minify --bundle-node-modules -t browser --out-dir ../dist-worker ../src/worker.js",
     "coverage": "yarn run test --coverage",

--- a/packages/api/src/controllers/asset.test.ts
+++ b/packages/api/src/controllers/asset.test.ts
@@ -170,6 +170,42 @@ describe("controllers/asset", () => {
     });
   });
 
+  describe("dstorage URLs transformation", () => {
+    const testCases = [
+      { url: "https://arweave.net/faketxid", expected: "ar://faketxid" },
+      {
+        url: "https://ipfs.example.com/ipfs/fakecid",
+        expected: "ipfs://fakecid",
+      },
+      {
+        url: "https://my-gateway.ipfs-provider.io/ipfs/fakecid2",
+        expected: "ipfs://fakecid2",
+      },
+      {
+        url: "https://untrusted-ipfs.example.com/ipfs/fakecid3",
+        expected: null,
+      },
+    ];
+
+    for (const { url, expected } of testCases) {
+      it(`should transform ${url} to ${expected}`, async () => {
+        const spec = { name: "test", url };
+        let res = await client.post(`/asset/upload/url`, spec);
+
+        expect(res.status).toBe(201);
+        let {
+          asset: { source },
+        } = await res.json();
+
+        expect(source).toMatchObject({
+          type: "url",
+          url: expected ?? url,
+          gatewayUrl: expected ? url : undefined,
+        });
+      });
+    }
+  });
+
   it("should store the creator ID as an object", async () => {
     const spec = {
       name: "test",

--- a/packages/api/src/controllers/helpers.test.ts
+++ b/packages/api/src/controllers/helpers.test.ts
@@ -85,7 +85,7 @@ describe("controllers/helpers", () => {
         },
       };
       expect(toObjectStoreUrl(storageObj)).toBe(
-        "s3+https://AKIAIOSFODNN7EXAMPLE:wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY@gateway.storjshare.io/testbucket"
+        "s3+https://AKIAIOSFODNN7EXAMPLE:wJalrXUtnFEMI%2FK7MDENG%2FbPxRfiCYEXAMPLEKEY@gateway.storjshare.io/testbucket"
       );
     });
 

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -33,7 +33,7 @@ function coerceJsonStrArr(arg: string): string[] {
   return arr;
 }
 
-function coerceCorsList(flagName: string) {
+function coerceRegexList(flagName: string) {
   return (arg: string): (string | RegExp)[] => {
     try {
       const arr = coerceJsonStrArr(arg);
@@ -148,6 +148,13 @@ export default function parseCli(argv?: string | readonly string[]) {
         type: "string",
         default: "https://ipfs.livepeer.studio/ipfs/",
       },
+      "trusted-ipfs-gateways": {
+        describe:
+          "comma-separated list of regexes for trusted IPFS gateways to automatically convert to IPFS URLs",
+        type: "string",
+        default: undefined,
+        coerce: coerceRegexList("trusted-ipfs-gateways"),
+      },
       "return-region-in-orchestrator": {
         describe: "return /api/region result also in /api/orchestrator",
         type: "boolean",
@@ -182,7 +189,7 @@ export default function parseCli(argv?: string | readonly string[]) {
           "add a / prefix and suffix to an element to have it parsed as a regex",
         type: "string",
         default: undefined,
-        coerce: coerceCorsList("cors-jwt-allowlist"),
+        coerce: coerceRegexList("cors-jwt-allowlist"),
       },
       broadcasters: {
         describe:

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -727,6 +727,11 @@ components:
                 url:
                   type: string
                   description: URL from which the asset was uploaded
+                gatewayUrl:
+                  type: string
+                  description:
+                    Gateway URL from asset if parsed from provided URL on
+                    upload.
                 encryption:
                   $ref: "#/components/schemas/new-asset-payload/properties/encryption"
             - additionalProperties: false

--- a/packages/api/src/test-server.ts
+++ b/packages/api/src/test-server.ts
@@ -40,6 +40,10 @@ params.sendgridApiKey = sendgridApiKey;
 params.postgresUrl = `postgresql://postgres@127.0.0.1/${testId}`;
 params.recordObjectStoreId = "mock_store";
 params.vodObjectStoreId = "mock_vod_store";
+params.trustedIpfsGateways = [
+  "https://ipfs.example.com/ipfs/",
+  /https:\/\/.+\.ipfs-provider.io\/ipfs\//,
+];
 params.ingest = [
   {
     ingest: "rtmp://test/live",


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This is to support users to provide gateway URLs as input and we parse the corresponding
dStorage protocol URL in case the gateway belongs to a trusted list.

Will fix the use case of Lens which is using their own gateway as input.

**Specific updates (required)**
 - Add a logic to translate gateway URLs into dStorage URLs on upload
 - Add API to migrate existing assets
 - Some tests I can't run locally

**How did you test each of these updates (required)**
`yarn test`

**Does this pull request close any open issues?**
Ad-hoc

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
