### PR TITLE
api: Improve dStorage URL parsing logic

### DIFF
--- a/packages/api/src/app-router.ts
+++ b/packages/api/src/app-router.ts
@@ -53,10 +53,10 @@ const PROM_BUNDLE_OPTS: promBundle.Opts = {
 
 export default async function makeApp(params: CliArgs) {
   const {
-    httpPrefix = "/api",
+    httpPrefix,
     postgresUrl,
     postgresReplicaUrl,
-    frontendDomain = "livepeer.studio",
+    frontendDomain,
     supportAddr,
     sendgridTemplateId,
     sendgridApiKey,
@@ -75,7 +75,7 @@ export default async function makeApp(params: CliArgs) {
     broadcasters = [],
     ingest = [],
     prices = [],
-    corsJwtAllowlist = [`https://${frontendDomain}`],
+    corsJwtAllowlist,
     insecureTestToken,
     stripeSecretKey,
     amqpUrl,

--- a/packages/api/src/controllers/asset.test.ts
+++ b/packages/api/src/controllers/asset.test.ts
@@ -174,12 +174,20 @@ describe("controllers/asset", () => {
     const testCases = [
       { url: "https://arweave.net/faketxid", expected: "ar://faketxid" },
       {
+        url: "https://arweave.net/faketxid2/myFile.mp4",
+        expected: "ar://faketxid2/myFile.mp4",
+      },
+      {
         url: "https://ipfs.example.com/ipfs/fakecid",
         expected: "ipfs://fakecid",
       },
       {
         url: "https://my-gateway.ipfs-provider.io/ipfs/fakecid2",
         expected: "ipfs://fakecid2",
+      },
+      {
+        url: "https://my-gateway.ipfs-provider.io/ipfs/fakecid3/filename.mp4",
+        expected: "ipfs://fakecid3/filename.mp4",
       },
       {
         url: "https://untrusted-ipfs.example.com/ipfs/fakecid3",

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -48,7 +48,10 @@ import os from "os";
 import { ensureExperimentSubject } from "../store/experiment-table";
 import { CliArgs } from "../parse-cli";
 
-const ARWEAVE_GATEWAY_PREFIX = "https://arweave.net/";
+const ARWEAVE_GATEWAY_PREFIXES = [
+  "https://arweave.net/",
+  "https://gateway.arweave.net/",
+];
 
 const app = Router();
 
@@ -147,7 +150,8 @@ function parseUrlToDStorageUrl(
   }
 
   const isArweave =
-    pathElements.length >= 1 && url.startsWith(ARWEAVE_GATEWAY_PREFIX);
+    pathElements.length >= 1 &&
+    anyMatchesRegexOrPrefix(ARWEAVE_GATEWAY_PREFIXES, url);
   if (isArweave) {
     const txIdPath = pathElements.join("/");
     return `ar://${txIdPath}`;

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -9,6 +9,11 @@ import {
 } from "./types/common";
 import { defaultTaskExchange } from "./store/queue";
 
+const DEFAULT_ARWEAVE_GATEWAY_PREFIXES = [
+  "https://arweave.net/",
+  "https://gateway.arweave.net/",
+];
+
 function coerceArr(arg: any) {
   if (!Array.isArray(arg)) {
     const arr = [];
@@ -154,6 +159,13 @@ export default function parseCli(argv?: string | readonly string[]) {
         type: "string",
         default: "[]",
         coerce: coerceRegexList("trusted-ipfs-gateways"),
+      },
+      "trusted-arweave-gateways": {
+        describe:
+          "comma-separated list of regexes for trusted Arweave gateways to automatically convert to Arweave URLs",
+        type: "string",
+        default: JSON.stringify(DEFAULT_ARWEAVE_GATEWAY_PREFIXES),
+        coerce: coerceRegexList("trusted-arweave-gateways"),
       },
       "return-region-in-orchestrator": {
         describe: "return /api/region result also in /api/orchestrator",

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -121,6 +121,7 @@ export default function parseCli(argv?: string | readonly string[]) {
       "frontend-domain": {
         describe: "the domain used in templating urls, example: livepeer.org",
         type: "string",
+        default: "livepeer.studio",
       },
       "kube-namespace": {
         describe:
@@ -200,7 +201,7 @@ export default function parseCli(argv?: string | readonly string[]) {
           "comma-separated list of domains to allow CORS for requests authenticated with a JWT. " +
           "add a / prefix and suffix to an element to have it parsed as a regex",
         type: "string",
-        default: "[]",
+        default: `["https://livepeer.studio"]`,
         coerce: coerceRegexList("cors-jwt-allowlist"),
       },
       broadcasters: {

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -158,7 +158,7 @@ export default function parseCli(argv?: string | readonly string[]) {
         describe:
           "comma-separated list of regexes for trusted IPFS gateways to automatically convert to IPFS URLs",
         type: "string",
-        default: "[]",
+        default: `["https://ipfs.livepeer.studio/ipfs/"]`,
         coerce: coerceRegexList("trusted-ipfs-gateways"),
       },
       "trusted-arweave-gateways": {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This is to make a couple improvements on the v0 deployed yesterday to update
dStorage gateway URLs. This is paired with https://github.com/livepeer/livepeer-infra/pull/1454 improving 
the list of trusted IPFS gateways.

**Specific updates (required)**
 - Allow dStorage gateway URLs to include file paths
 - Support some additional Arweave gateway URLs
 - Maybe: Make the above configurable as well

**How did you test each of these updates (required)**
`yarn test`

**Does this pull request close any open issues?**
Overall CID-upload API stability, not tracked anywhere

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
