### PR TITLE
add tooltip to processing

### DIFF
--- a/packages/www/components/AssetDetails/AssetPlayerBox/ProcessingProgress.tsx
+++ b/packages/www/components/AssetDetails/AssetPlayerBox/ProcessingProgress.tsx
@@ -1,13 +1,29 @@
 import { useMemo } from "react";
 import { Asset } from "livepeer";
 import Progress from "./Progress";
+import { Flex, Box, Tooltip } from "@livepeer/design-system";
+import { QuestionMarkCircledIcon as Help } from "@radix-ui/react-icons";
 
 const ProcessingProgress = ({ asset }: { asset?: Asset }) => {
   const percentage = useMemo(() => {
     const progress = asset?.status?.progress ?? 0;
     return Math.floor(progress * 100);
   }, [asset]);
-  return <Progress text="Processing" percentage={percentage} />;
+  return (
+    <Flex align="center">
+      <Tooltip
+        multiline
+        content={
+          <Box>
+            Your video can now be played. In the background, it is converted
+            into several quality levels so that it can be played smoothly by all
+            viewers.
+          </Box>
+        }>
+        <Help />
+      </Tooltip>
+    </Flex>
+  );
 };
 
 export default ProcessingProgress;

--- a/packages/www/components/AssetDetails/AssetPlayerBox/ProcessingProgress.tsx
+++ b/packages/www/components/AssetDetails/AssetPlayerBox/ProcessingProgress.tsx
@@ -1,29 +1,13 @@
 import { useMemo } from "react";
 import { Asset } from "livepeer";
 import Progress from "./Progress";
-import { Flex, Box, Tooltip } from "@livepeer/design-system";
-import { QuestionMarkCircledIcon as Help } from "@radix-ui/react-icons";
 
 const ProcessingProgress = ({ asset }: { asset?: Asset }) => {
   const percentage = useMemo(() => {
     const progress = asset?.status?.progress ?? 0;
     return Math.floor(progress * 100);
   }, [asset]);
-  return (
-    <Flex align="center">
-      <Tooltip
-        multiline
-        content={
-          <Box>
-            Your video can now be played. In the background, it is converted
-            into several quality levels so that it can be played smoothly by all
-            viewers.
-          </Box>
-        }>
-        <Help />
-      </Tooltip>
-    </Flex>
-  );
+  return <Progress text="Processing" percentage={percentage} />;
 };
 
 export default ProcessingProgress;

--- a/packages/www/components/Table/cells/createdAt.tsx
+++ b/packages/www/components/Table/cells/createdAt.tsx
@@ -1,12 +1,13 @@
 import { fileUploadProgressForAsset } from "components/AssetsTable/helpers";
 import { Asset } from "livepeer";
-import { Badge, Flex } from "@livepeer/design-system";
+import { Badge, Box, Flex, Tooltip } from "@livepeer/design-system";
 import { UploadIcon } from "@radix-ui/react-icons";
 import { format } from "date-fns";
 import { useApi } from "hooks";
 import { useEffect, useState } from "react";
 import ReactTooltip from "react-tooltip";
 import { CellComponentProps, TableData } from "../types";
+import { QuestionMarkCircledIcon as Help } from "@radix-ui/react-icons";
 
 const CreatedAt = ({ date, fallback }) => {
   try {
@@ -52,6 +53,17 @@ const FileUploading = ({ progress }) => (
 const ProcessingProgress = ({ progress }) => (
   <Flex gap={1}>
     <UploadIcon /> Processing {Math.floor(progress * 100)}%
+    <Tooltip
+      multiline
+      content={
+        <Box>
+          Your video can now be played. In the background, it is converted into
+          several quality levels so that it can be played smoothly by all
+          viewers.
+        </Box>
+      }>
+      <Help />
+    </Tooltip>
   </Flex>
 );
 


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This adds a tooltip informing the builder what is happening while their asset is processing. Specifically, it lets them know that source playback is available.

**Specific updates (required)**

**How did you test each of these updates (required)**
- upload asset
- wait for upload to complete
- observe asset in list
