### PR TITLE
Fix the attestation metadata content stored in IPFS

### DIFF
--- a/packages/api/src/controllers/experiment/attestation.ts
+++ b/packages/api/src/controllers/experiment/attestation.ts
@@ -92,14 +92,14 @@ app.post("/", validatePost("attestation"), async (req, res) => {
   return res.status(201).json(attestationMetadata);
 });
 
-function toContent(attestation: Attestation): string {
-  return JSON.stringify({
+function toContent(attestation: Attestation) {
+  return {
     domain: attestation.domain,
     primaryType: attestation.primaryType,
     message: attestation.message,
     signature: attestation.signature,
     signatureType: attestation.signatureType,
-  });
+  };
 }
 
 async function verifySignature(

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -1303,7 +1303,7 @@ components:
                 - content
               properties:
                 content:
-                  type: string
+                  type: object
                   description: File content to store into IPFS
                 ipfs:
                   $ref: "#/components/schemas/ipfs-export-params"


### PR DESCRIPTION
It was related to one of comments from @victorges in the PR https://github.com/livepeer/studio/pull/1775

Changed the content to JSON in task-runner, but did not in studio, which results in the JSON escape chars stored in IPFS.