### PR TITLE
Don't leak IDs from API endpoints

### DIFF
--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -140,7 +140,7 @@ async function createSubscription(
     customer: stripeCustomerId,
   });
   if (existing.data.length > 0) {
-    return new InternalServerError("existing subscription already found");
+    return null;
   }
 
   const prices = await stripe.prices.list({
@@ -314,6 +314,10 @@ app.post("/", validatePost("user"), async (req, res) => {
       defaultProductId,
       customer.id
     );
+    if (!subscription) {
+      res.status(400);
+      res.json({ errors: ["error creating subscription"] });
+    }
     stripeFields = {
       stripeCustomerId: customer.id,
       stripeCustomerSubscriptionId: subscription.id,
@@ -829,6 +833,11 @@ app.post(
       stripeProductId,
       stripeCustomerId
     );
+    if (!subscription) {
+      return res
+        .status(400)
+        .send({ errors: ["could not create subscription"] });
+    }
 
     if (
       stripeProductId !== "prod_0" &&

--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -578,7 +578,7 @@ app.post("/verify-email", validatePost("verify-email"), async (req, res) => {
       });
     }
   }
-  res.status(200);
+  res.status(200).json({});
 });
 
 app.post(

--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -676,7 +676,7 @@ app.post(
     );
     if (newToken) {
       res.status(201);
-      res.json(newToken);
+      res.json({});
     } else {
       res.status(403);
       res.json({ errors: ["error creating password reset token"] });

--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -716,8 +716,10 @@ app.post(
         stripeCustomerId: customer.id,
       });
       res.status(201);
+      res.json(customer);
+    } else {
+      res.status(400);
     }
-    res.json(customer);
   }
 );
 

--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -723,6 +723,7 @@ app.post(
       res.json(customer);
     } else {
       res.status(400);
+      res.json({ errors: ["error creating customer"] });
     }
   }
 );

--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -574,7 +574,7 @@ app.post("/verify-email", validatePost("verify-email"), async (req, res) => {
       });
     }
   }
-  res.status(200).json(cleanUserFields(user));
+  res.status(200);
 });
 
 app.post(

--- a/packages/www/pages/dashboard/index.tsx
+++ b/packages/www/pages/dashboard/index.tsx
@@ -29,7 +29,7 @@ const Dashboard = () => {
       openSnackbar(`Errors: ${res.errors.join(", ")}`);
     } else {
       openSnackbar(
-        `We've sent you a link to verify your email. Please check your inbox at ${res.email}`
+        `We've sent you a link to verify your email. Please check your inbox at ${user.email}`
       );
     }
   };

--- a/packages/www/pages/verify.tsx
+++ b/packages/www/pages/verify.tsx
@@ -77,7 +77,7 @@ const Verify = ({
       openSnackbar(`Errors: ${res.errors.join(", ")}`);
     } else {
       openSnackbar(
-        `We've sent you a link to verify your email. Please check your inbox at ${res.email}`
+        `We've sent you a link to verify your email. Please check your inbox at ${email}`
       );
     }
   };

--- a/packages/www/public/sitemap-0.xml
+++ b/packages/www/public/sitemap-0.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://livepeer.studio</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
-<url><loc>https://livepeer.studio/contact</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/assets</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/billing</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/billing/plans</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/developers/api-keys</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/developers/signing-keys</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/developers/webhooks</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/sessions</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/stream-health</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/streams</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/usage</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
-<url><loc>https://livepeer.studio/forgot-password</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
-<url><loc>https://livepeer.studio/register</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
-<url><loc>https://livepeer.studio/reset-password</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
-<url><loc>https://livepeer.studio/verify</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
+<url><loc>https://livepeer.studio</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
+<url><loc>https://livepeer.studio/contact</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/assets</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/billing</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/billing/plans</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/developers/api-keys</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/developers/signing-keys</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/developers/webhooks</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/sessions</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/stream-health</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/streams</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/usage</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
+<url><loc>https://livepeer.studio/forgot-password</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
+<url><loc>https://livepeer.studio/register</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
+<url><loc>https://livepeer.studio/reset-password</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
+<url><loc>https://livepeer.studio/verify</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
 </urlset>

--- a/packages/www/public/sitemap-0.xml
+++ b/packages/www/public/sitemap-0.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://livepeer.studio</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-05-31T17:49:10.103Z</lastmod></url>
-<url><loc>https://livepeer.studio/contact</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-05-31T17:49:10.103Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-05-31T17:49:10.103Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/assets</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-05-31T17:49:10.103Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/billing</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-05-31T17:49:10.103Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/billing/plans</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-05-31T17:49:10.103Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/usage</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-05-31T17:49:10.103Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/developers/api-keys</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-05-31T17:49:10.103Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/developers/signing-keys</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-05-31T17:49:10.103Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/developers/webhooks</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-05-31T17:49:10.103Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/sessions</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-05-31T17:49:10.103Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/stream-health</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-05-31T17:49:10.103Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/streams</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-05-31T17:49:10.103Z</lastmod></url>
-<url><loc>https://livepeer.studio/forgot-password</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-05-31T17:49:10.103Z</lastmod></url>
-<url><loc>https://livepeer.studio/register</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-05-31T17:49:10.103Z</lastmod></url>
-<url><loc>https://livepeer.studio/reset-password</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-05-31T17:49:10.103Z</lastmod></url>
-<url><loc>https://livepeer.studio/verify</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-05-31T17:49:10.103Z</lastmod></url>
+<url><loc>https://livepeer.studio</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
+<url><loc>https://livepeer.studio/contact</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/assets</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/billing</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/billing/plans</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/developers/api-keys</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/developers/signing-keys</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/developers/webhooks</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/sessions</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/stream-health</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/streams</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/usage</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
+<url><loc>https://livepeer.studio/forgot-password</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
+<url><loc>https://livepeer.studio/register</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
+<url><loc>https://livepeer.studio/reset-password</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
+<url><loc>https://livepeer.studio/verify</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:26:41.931Z</lastmod></url>
 </urlset>

--- a/packages/www/public/sitemap-0.xml
+++ b/packages/www/public/sitemap-0.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://livepeer.studio</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
-<url><loc>https://livepeer.studio/contact</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/assets</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/billing</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/billing/plans</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/developers/api-keys</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/developers/signing-keys</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/developers/webhooks</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/sessions</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/stream-health</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/streams</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
-<url><loc>https://livepeer.studio/dashboard/usage</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
-<url><loc>https://livepeer.studio/forgot-password</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
-<url><loc>https://livepeer.studio/register</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
-<url><loc>https://livepeer.studio/reset-password</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
-<url><loc>https://livepeer.studio/verify</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T10:42:02.664Z</lastmod></url>
+<url><loc>https://livepeer.studio</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T11:09:43.503Z</lastmod></url>
+<url><loc>https://livepeer.studio/contact</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T11:09:43.503Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T11:09:43.503Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/assets</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T11:09:43.503Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/billing</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T11:09:43.503Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/billing/plans</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T11:09:43.503Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/developers/api-keys</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T11:09:43.503Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/developers/signing-keys</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T11:09:43.503Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/developers/webhooks</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T11:09:43.503Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/sessions</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T11:09:43.503Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/stream-health</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T11:09:43.503Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/streams</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T11:09:43.503Z</lastmod></url>
+<url><loc>https://livepeer.studio/dashboard/usage</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T11:09:43.503Z</lastmod></url>
+<url><loc>https://livepeer.studio/forgot-password</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T11:09:43.503Z</lastmod></url>
+<url><loc>https://livepeer.studio/register</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T11:09:43.503Z</lastmod></url>
+<url><loc>https://livepeer.studio/reset-password</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T11:09:43.503Z</lastmod></url>
+<url><loc>https://livepeer.studio/verify</loc><changefreq>daily</changefreq><priority>0.7</priority><lastmod>2023-06-27T11:09:43.503Z</lastmod></url>
 </urlset>


### PR DESCRIPTION
This stops returning information from **write** API endpoints where the return value is unused.