### PR TITLE
Only display tooltip when playback is ready

### DIFF
--- a/packages/www/components/Table/cells/createdAt.tsx
+++ b/packages/www/components/Table/cells/createdAt.tsx
@@ -50,10 +50,10 @@ const FileUploading = ({ progress }) => (
   </Flex>
 );
 
-const ProcessingProgress = ({ progress, playbackReady }) => (
+const ProcessingProgress = ({ progress, playbackUrl }) => (
   <Flex gap={1}>
     <UploadIcon /> Processing {Math.floor(progress * 100)}%
-    {playbackReady && (
+    {playbackUrl && (
       <Tooltip
         multiline
         content={
@@ -87,6 +87,7 @@ const CreatedAtCell = <D extends TableData>({
   const { id, date, fallback, asset } = cell.value;
   const { phase, errorMessage, progress } = asset.status;
   const isFileUploading = fileUploadProgress !== undefined;
+  const playbackUrl = asset.playbackUrl;
 
   useEffect(() => {
     // Has to fetch the file uploads from this cell, instead of from the table fetcher, to avoid fetching again assets too
@@ -101,12 +102,7 @@ const CreatedAtCell = <D extends TableData>({
     return <FailedProcessing id={id} errorMessage={errorMessage} />;
   }
   if (phase === "processing") {
-    return (
-      <ProcessingProgress
-        progress={progress}
-        playbackReady={asset.playbackUrl !== undefined}
-      />
-    );
+    return <ProcessingProgress progress={progress} playbackUrl={playbackUrl} />;
   }
   if (isFileUploading) {
     return <FileUploading progress={fileUploadProgress} />;

--- a/packages/www/components/Table/cells/createdAt.tsx
+++ b/packages/www/components/Table/cells/createdAt.tsx
@@ -50,20 +50,22 @@ const FileUploading = ({ progress }) => (
   </Flex>
 );
 
-const ProcessingProgress = ({ progress }) => (
+const ProcessingProgress = ({ progress, playbackReady }) => (
   <Flex gap={1}>
     <UploadIcon /> Processing {Math.floor(progress * 100)}%
-    <Tooltip
-      multiline
-      content={
-        <Box>
-          Your video can now be played. In the background, it is converted into
-          several quality levels so that it can be played smoothly by all
-          viewers.
-        </Box>
-      }>
-      <Help />
-    </Tooltip>
+    {playbackReady && (
+      <Tooltip
+        multiline
+        content={
+          <Box>
+            Your video can now be played. In the background, it is converted
+            into several quality levels so that it can be played smoothly by all
+            viewers.
+          </Box>
+        }>
+        <Help />
+      </Tooltip>
+    )}
   </Flex>
 );
 
@@ -99,7 +101,12 @@ const CreatedAtCell = <D extends TableData>({
     return <FailedProcessing id={id} errorMessage={errorMessage} />;
   }
   if (phase === "processing") {
-    return <ProcessingProgress progress={progress} />;
+    return (
+      <ProcessingProgress
+        progress={progress}
+        playbackReady={asset.playbackUrl !== undefined}
+      />
+    );
   }
   if (isFileUploading) {
     return <FileUploading progress={fileUploadProgress} />;


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
Fixes the tooltip logic to only display when a playback url is available.

**How did you test each of these updates (required)**
- upload asset
- wait for upload to complete
- observe asset in list
