### PR TITLE
Hide sourcePlaybackReady field from responses

### DIFF
--- a/packages/api/src/schema/db-schema.yaml
+++ b/packages/api/src/schema/db-schema.yaml
@@ -868,6 +868,7 @@ components:
         sourcePlaybackReady:
           type: boolean
           description: Whether source playback is ready
+          writeOnly: true
         playbackRecordingId:
           type: string
           writeOnly: true


### PR DESCRIPTION
This is an internal field so should be hidden