### PR TITLE
[SRE-132] build.yaml: Use the new notarization workflow for MacOS binaries

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -151,8 +151,8 @@ jobs:
           app-notarization-email: ${{ secrets.CI_MACOS_NOTARIZATION_USER }}
           app-notarization-password:
             ${{ secrets.CI_MACOS_NOTARIZATION_PASSWORD }}
+          app-notarization-team-id: ${{ secrets.CI_MACOS_NOTARIZATION_TEAM_ID }}
           binary-path: "bin/"
-          app-bundle-id: "org.livepeer.api"
 
       - name: Archive built binaries
         run: |


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Apple deprecated their `altool` base notarization workflow.

**Specific updates (required)**

Uses the now recommended `notarytool`.

**How did you test each of these updates (required)**

https://github.com/livepeer/catalyst-api/pull/755
