### PR TITLE
Revert removing recording fields from webhook

### DIFF
--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -264,6 +264,12 @@ export class TaskScheduler {
       const asset = await db.asset.get(task.outputAssetId);
       if (asset && asset.source.type == "recording" && asset.source.sessionId) {
         const session = await db.session.get(asset.source.sessionId);
+        const externalSession = await toExternalSession(
+          this.config,
+          session,
+          null,
+          true
+        );
         if (session) {
           await this.queue.publishWebhook("events.recording.ready", {
             type: "webhook_event",
@@ -274,8 +280,10 @@ export class TaskScheduler {
             userId: session.userId,
             sessionId: session.id,
             payload: {
+              recordingUrl: externalSession?.recordingUrl,
+              mp4Url: externalSession?.mp4Url,
               session: {
-                ...(await toExternalSession(this.config, session, null, true)),
+                ...externalSession,
                 recordingStatus: "ready",
                 assetId: session.id,
               },

--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -264,13 +264,13 @@ export class TaskScheduler {
       const asset = await db.asset.get(task.outputAssetId);
       if (asset && asset.source.type == "recording" && asset.source.sessionId) {
         const session = await db.session.get(asset.source.sessionId);
-        const externalSession = await toExternalSession(
-          this.config,
-          session,
-          null,
-          true
-        );
         if (session) {
+          const externalSession = await toExternalSession(
+            this.config,
+            session,
+            null,
+            true
+          );
           await this.queue.publishWebhook("events.recording.ready", {
             type: "webhook_event",
             id: uuid(),


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

During the Recording V2 work we removed two fields from the webhook payload:
- `recordingUrl`
- `mp4Url`

This PR adds them back for the sake of backwards-compatibility.

<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional)**

<!-- Drag some screenshots here, if applicable -->

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] ~~My change requires a change to the documentation.~~
- [ ] ~~I have updated the documentation accordingly.~~
- [ ] ~~I have added tests to cover my changes.~~
