### PR TITLE
Fix upgrade / downgrade language when changing plans

### DIFF
--- a/packages/www/components/PlanForm/index.tsx
+++ b/packages/www/components/PlanForm/index.tsx
@@ -216,7 +216,13 @@ const PlanForm = ({
         </Flex>
 
         <AlertDialogContent
-          css={{ maxWidth: 450, px: "$5", pt: "$4", pb: "$4" }}>
+          css={{
+            maxWidth: 450,
+            px: "$5",
+            pt: "$4",
+            pb: "$4",
+            textAlign: "left",
+          }}>
           <Box
             as="form"
             onSubmit={handleSubmit(onSubmit)}
@@ -434,8 +440,8 @@ const PlanForm = ({
                     {products[stripeProductId].order <
                       products[user.newStripeProductId]?.order ||
                     products[stripeProductId]?.order
-                      ? "downgrade"
-                      : "upgrade"}{" "}
+                      ? "upgrade"
+                      : "downgrade"}{" "}
                     to the {products[stripeProductId].name} plan?
                   </Text>
                 </Box>


### PR DESCRIPTION
When upgrading from Hacker plan, the language in the dialog incorrectly asks if you would like to downgrade to the plan instead of upgrade. The dialog text is also center-aligned when it should be left-aligned.

cc: @gioelecerati 

<img width="621" alt="CleanShot 2023-07-18 at 14 29 55@2x" src="https://github.com/livepeer/studio/assets/555740/9686eaff-a512-4660-86f7-5a0021efeb63">
