### PR TITLE
www/use-analyzer: allow analyzer to run in more contexts

### DIFF
--- a/packages/api/src/app-router.ts
+++ b/packages/api/src/app-router.ts
@@ -27,6 +27,7 @@ import { taskScheduler } from "./task/scheduler";
 import { setupTus, setupTestTus } from "./controllers/asset";
 import * as fcl from "@onflow/fcl";
 import createFrontend from "@livepeer.studio/www";
+import { NotFoundError } from "./store/errors";
 
 enum OrchestratorSource {
   hardcoded = "hardcoded",
@@ -248,6 +249,9 @@ export default async function makeApp(params: CliArgs) {
       prefixRouter.use(`/${name}`, controller);
     }
   }
+  prefixRouter.use((req, res, next) => {
+    throw new NotFoundError("not found");
+  });
   prefixRouter.use(errorHandler());
   app.use(httpPrefix, prefixRouter);
   // Special case: handle /stream proxies off that endpoint

--- a/packages/www/hooks/use-analyzer.tsx
+++ b/packages/www/hooks/use-analyzer.tsx
@@ -2,6 +2,7 @@ import EventSource from "eventsource";
 import { useApi } from "hooks";
 import { useContext, useMemo, createContext, ReactNode } from "react";
 import { isStaging, isDevelopment, HttpError } from "../lib/utils";
+import { getEndpoint } from "./use-api";
 
 const useLocalAnalyzer = false;
 const defaultRegion = "nyc";
@@ -140,11 +141,7 @@ export namespace events {
 }
 
 const makeUrl = (region: string, path: string) => {
-  if (isDevelopment() && useLocalAnalyzer) {
-    return `http://localhost:8080/data${path}`;
-  }
-  const tld = isStaging() || isDevelopment() ? "monster" : "com";
-  return `https://${region || defaultRegion}.livepeer.${tld}/data${path}`;
+  return `${getEndpoint()}/data${path}`;
 };
 
 class AnalyzerClient {


### PR DESCRIPTION
@victorges, is there any problem these days with disregarding the `region` parameter and just going right to `https://livepeer.studio/data`?