### PR TITLE
api: make www optional for development

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -25,7 +25,7 @@
     "dev-server": "run-s compile-schemas && node dist/cli.js",
     "redoc": "nodemon -w src/schema/schema.yaml -x npm run prepare:redoc",
     "siserver": "nodemon -w dist -x node -r esm dist/stream-info-service.js -e js,yaml",
-    "dev:server": "NODE_ENV=development nodemon --inspect -w dist -x node dist/cli.js -e js,yaml",
+    "dev:server": "NODE_ENV=development LP_API_FRONTEND=false nodemon --inspect -w dist -x node dist/cli.js -e js,yaml",
     "dev:babel": "yarn run prepare:babel --watch",
     "dev:yaml-json": "nodemon -w ./src/schema -e 'yaml' -x 'run-s compile-schemas'",
     "dev": "run-p \"dev:**\"",

--- a/packages/api/src/app-router.ts
+++ b/packages/api/src/app-router.ts
@@ -26,7 +26,7 @@ import { pathJoin } from "./controllers/helpers";
 import { taskScheduler } from "./task/scheduler";
 import { setupTus, setupTestTus } from "./controllers/asset";
 import * as fcl from "@onflow/fcl";
-import wwwHandlerPromise from "@livepeer.studio/www";
+import createFrontend from "@livepeer.studio/www";
 
 enum OrchestratorSource {
   hardcoded = "hardcoded",
@@ -83,6 +83,7 @@ export default async function makeApp(params: CliArgs) {
     amqpTasksExchange,
     returnRegionInOrchestrator,
     halfRegionOrchestratorsUntrusted,
+    frontend,
   } = params;
 
   if (supportAddr || sendgridTemplateId || sendgridApiKey) {
@@ -262,8 +263,10 @@ export default async function makeApp(params: CliArgs) {
   if (fallbackProxy) {
     app.use(proxy({ target: fallbackProxy, changeOrigin: true }));
   }
-  const wwwHandler = await wwwHandlerPromise;
-  app.use(wwwHandler);
+  if (frontend) {
+    const wwwHandler = await createFrontend();
+    app.use(wwwHandler);
+  }
 
   // These parameters are required to use the fcl library, even though we don't use on-chain verification
   await fcl.config({

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -422,6 +422,11 @@ export default function parseCli(argv?: string | readonly string[]) {
         type: "string",
         default: "https://meet.livekit.io/custom",
       },
+      frontend: {
+        describe: "serve the embedded @livepeer/www Next.js frontend",
+        type: "boolean",
+        default: true,
+      },
     })
     .usage(
       `

--- a/packages/www/server.js
+++ b/packages/www/server.js
@@ -21,4 +21,4 @@ const getApp = async () => {
   await app.prepare();
   return app.getRequestHandler();
 };
-module.exports = getApp();
+module.exports = getApp;


### PR DESCRIPTION
This makes the embedded front-end in the API server added in https://github.com/livepeer/studio/pull/1801 optional and disables it in the `yarn run dev` case. The production build and the development builds get in a fight otherwise.