### PR TITLE
api: use port 80 in docker

### DIFF
--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -15,5 +15,6 @@ ARG	VERSION
 ENV	VERSION ${VERSION}
 ARG	GITHUB_SHA
 ENV	GITHUB_SHA ${GITHUB_SHA}
+ENV	LP_API_PORT 80
 RUN /usr/local/bin/livepeer-api --help
 ENTRYPOINT ["/usr/local/bin/livepeer-api"]


### PR DESCRIPTION
Missed this line when I changed the Dockerfile around. https://github.com/livepeer/studio/pull/1801/files#diff-58faa9005c5e527f6cd6abf95f0f665c7ed18339e974ec0ea6fe78b91d817676L29