### PR TITLE
api/stream: Do not trigger recording if asset exists

### DIFF
--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1144,6 +1144,13 @@ async function triggerSessionRecordingHooks(
 
   for (const childStream of childStreams) {
     const sessionId = childStream.sessionId ?? childStream.id;
+    const asset = await db.asset.get(sessionId);
+    if (asset) {
+      // if we have an asset, then the recording has already been processed and
+      // we don't need to send a recording.waiting hook.
+      continue;
+    }
+
     const session = await db.session.get(sessionId);
     await publishSingleRecordingWaitingHook(
       config,


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Stops sending events for sessions that have already been processed.

**Specific updates (required)**

Fetch asset before sending delayed recording.waiting hook.

**How did you test each of these updates (required)**

Test in prod, fixing a crisis

**Does this pull request close any open issues?**

War room.

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
