### PR TITLE
api/stream: Name recording waiting queue explicitly

### DIFF
--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1254,7 +1254,8 @@ async function publishDelayedRecordingWaitingHook(
         },
       },
     },
-    USER_SESSION_TIMEOUT + 10_000
+    USER_SESSION_TIMEOUT + 10_000,
+    "recording_waiting_delayed_events"
   );
 }
 

--- a/packages/api/src/store/queue.ts
+++ b/packages/api/src/store/queue.ts
@@ -38,7 +38,8 @@ export default interface Queue {
   delayedPublishWebhook(
     key: RoutingKey,
     msg: messages.Any,
-    delay: number
+    delay: number,
+    delayedQueueName?: string
   ): Promise<void>;
 
   consume(name: QueueName, func: (msg: ConsumeMessage) => void): Promise<void>;
@@ -235,10 +236,14 @@ export class RabbitQueue implements Queue {
   public delayedPublishWebhook(
     routingKey: RoutingKey,
     msg: messages.Any,
-    delay: number
+    delay: number,
+    delayedQueueName?: string
   ): Promise<void> {
     delay = Math.round(delay);
-    const delayedQueueName = delayedWebhookQueue(delay);
+    if (!delayedQueueName) {
+      delayedQueueName = delayedWebhookQueue(delay);
+    }
+
     // TODO: Find a way to reimplement this without on-demand queues.
     return this._withSetup(
       async (channel: Channel) => {
@@ -260,7 +265,7 @@ export class RabbitQueue implements Queue {
         console.log(
           `emitting delayed message: delay=${
             delay / 1000
-          }s msg=${JSON.stringify(msg)}`
+          }s queue=${delayedQueueName} msg=${JSON.stringify(msg)}`
         );
         return this._channelPublish(delayedQueueName, routingKey, msg, {
           persistent: true,


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This is to give a clearer name to the `recording.waiting` queue.

**Specific updates (required)**

 Support overriding queue names for the delayed webhooks and use it for recording.waiting event.

**How did you test each of these updates (required)**

yarn test

**Does this pull request close any open issues?**
Discussed in 5Ys meeting.


**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
