### PR TITLE
billing: migration: don't update anchor on hacker subscribe

### DIFF
--- a/packages/api/src/controllers/stripe.ts
+++ b/packages/api/src/controllers/stripe.ts
@@ -490,7 +490,6 @@ app.post("/subscribe-hackers-to-pay-as-you-go", async (req, res) => {
         subscription = await req.stripe.subscriptions.update(
           user.stripeCustomerSubscriptionId,
           {
-            billing_cycle_anchor: "now",
             cancel_at_period_end: false,
             items: [
               ...subscriptionItems.data.map((item) => {
@@ -656,7 +655,6 @@ app.post("/migrate-pro-user", async (req, res) => {
       subscription = await req.stripe.subscriptions.update(
         user.stripeCustomerSubscriptionId,
         {
-          billing_cycle_anchor: "now",
           cancel_at_period_end: false,
           items: [
             ...subscriptionItems.data.map((item) => {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Removing the anchor `now` on hacker subscription to pay as you go plans
This is needed because on hacker migration the billing cycle would get reset to today instead of keeping the original subscription date.

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional)**

<!-- Drag some screenshots here, if applicable -->

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
