### PR TITLE
Populate recordingURL when source playback is ready

### DIFF
--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -444,8 +444,12 @@ export async function getRecordingFields(
   );
   return {
     recordingStatus: recordingStatus,
-    recordingUrl: pathJoin(base, "index.m3u8"),
-    mp4Url: pathJoin(base, "source.mp4"),
+    ...(!isReady && !forceUrl
+      ? null
+      : {
+          recordingUrl: pathJoin(base, "index.m3u8"),
+          mp4Url: pathJoin(base, "source.mp4"),
+        }),
   };
 }
 


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

<!-- A clear and concise description of what this pull request does. -->
Populate recordingURL when source playback is ready

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->
- Populate recordingURL as soon as source playback is available
- Refactor the function to simplify and set the recording v2 status based on the recording vod asset
**How did you test each of these updates (required)**
Tested in staging.
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional)**

<!-- Drag some screenshots here, if applicable -->

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
