### PR TITLE
add z-index to error dialog

### DIFF
--- a/packages/www/components/ErrorDialog/index.tsx
+++ b/packages/www/components/ErrorDialog/index.tsx
@@ -21,7 +21,7 @@ const ErrorDialog = ({
 }) => {
   return (
     <AlertDialog open={isOpen} onOpenChange={onOpenChange}>
-      <AlertDialogContent css={{ maxWidth: 450, px: "$5", pt: "$4", pb: "$4" }}>
+      <AlertDialogContent css={{ maxWidth: 450, px: "$5", pt: "$4", pb: "$4", zIndex: 1 }}>
         <AlertDialogTitle asChild>
           <Heading size="1">Error</Heading>
         </AlertDialogTitle>


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Added z-index to error dialog

before:
<img width="1487" alt="image" src="https://github.com/livepeer/studio/assets/56798748/eee74783-d53f-4598-9015-20ba22fd02c3">

after:
<img width="1487" alt="image" src="https://github.com/livepeer/studio/assets/56798748/d043548a-7d89-4e1b-b450-cacb7fd0a785">

**How did you test each of these updates (required)**

- visually? 
- yarn test

**Does this pull request close any open issues?**
Nope


**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
