### PR TITLE
www: bump Docker to node 18

### DIFF
--- a/packages/www/Dockerfile
+++ b/packages/www/Dockerfile
@@ -1,4 +1,4 @@
-FROM	node:14
+FROM	node:18
 
 WORKDIR	/app
 


### PR DESCRIPTION
Breaking on 14.

We also don't super-duper need this Docker image anymore, we could drop it.