### PR TITLE
Populate recordingURL when source playback is ready (#1847)

### DIFF
--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -209,37 +209,6 @@ export function getWebRTCPlaybackUrl(ingest: string, stream: DBStream) {
   return pathJoin(ingest, `webrtc`, stream.playbackId);
 }
 
-async function getRecordingUrls(
-  config: CliArgs,
-  ingest: string,
-  session: DBSession
-): Promise<{ recordingUrl: string; mp4Url: string }> {
-  // Recording V2
-  if (session.version === "v2") {
-    const asset = await db.asset.getBySessionId(session.id);
-    if (!asset || ["waiting", "processing"].includes(asset.status?.phase)) {
-      // Recording processing in progress
-      return;
-    }
-    const assetWithPlayback = await withPlaybackUrls(config, ingest, asset);
-    return {
-      recordingUrl: assetWithPlayback.playbackUrl,
-      mp4Url: assetWithPlayback.downloadUrl,
-    };
-  }
-
-  // Backwards-compatibility for Recording V1
-  const base = pathJoin(
-    ingest,
-    `recordings`,
-    session.lastSessionId ?? session.id
-  );
-  return {
-    recordingUrl: pathJoin(base, "index.m3u8"),
-    mp4Url: pathJoin(base, "source.mp4"),
-  };
-}
-
 /**
  * Returns whether the stream is currently tagged as active but hasn't been
  * updated in a long time and thus should be cleaned up.
@@ -442,22 +411,46 @@ export async function getRecordingFields(
     return {};
   }
 
+  // Recording V2
+  if (session.version === "v2") {
+    const asset = await db.asset.getBySessionId(session.id);
+    if (!asset) {
+      return { recordingStatus: "waiting" };
+    }
+    const assetWithPlayback = await withPlaybackUrls(config, ingest, asset);
+    const assetPhase = assetWithPlayback.status?.phase;
+    return {
+      recordingStatus:
+        assetPhase == "ready"
+          ? "ready"
+          : assetPhase == "failed"
+          ? "none"
+          : "waiting",
+      recordingUrl: assetWithPlayback.playbackUrl,
+      mp4Url: assetWithPlayback.downloadUrl,
+    };
+  }
+
+  // Backwards-compatibility for Recording V1
   const readyThreshold = Date.now() - USER_SESSION_TIMEOUT;
   const isReady = session.lastSeen > 0 && session.lastSeen < readyThreshold;
   const isUnused = !session.lastSeen && session.createdAt < readyThreshold;
 
   const recordingStatus = isReady ? "ready" : isUnused ? "none" : "waiting";
-  if (!isReady && !forceUrl) {
-    return { recordingStatus };
-  }
-  const recordingUrls = await getRecordingUrls(config, ingest, session);
-  if (!recordingUrls) {
-    return { recordingStatus: "waiting" };
-  }
-  if (!recordingUrls.recordingUrl) {
-    return { recordingStatus: "none" };
-  }
-  return { recordingStatus, ...recordingUrls };
+  const base = pathJoin(
+    ingest,
+    `recordings`,
+    session.lastSessionId ?? session.id
+  );
+  return {
+    recordingStatus: recordingStatus,
+    ...(!isReady && !forceUrl
+      ? null
+      : {
+          recordingUrl: pathJoin(base, "index.m3u8"),
+          mp4Url: pathJoin(base, "source.mp4"),
+        }),
+  };
 }
 
 export async function withRecordingFields(


### PR DESCRIPTION
This is to re-roll #1847 which was reverted previously in 6336f953b66035f7c280dd428c13544056b87a3e