### PR TITLE
fix box www fallback

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -37,7 +37,7 @@
     "test:build": "parcel build --no-autoinstall --no-minify --bundle-node-modules -t browser --out-dir ../dist-worker ../src/worker.js",
     "coverage": "yarn run test --coverage",
     "pkg": "pkg --out-path=bin --no-bytecode --public-packages \"*\" --public . --compress GZip ",
-    "pkg:local": "yarn run prepare && yarn run pkg --targets=$(node -p '`node18-${os.platform()}-${os.arch()}`')",
+    "pkg:local": "yarn run prepare && yarn run pkg --targets=$(node -p '`node18-${process.env.GOOS ?? os.platform()}-${process.env.GOARCH ?? os.arch()}`')",
     "esbuild": "yarn run compile-schemas && node esbuild.mjs"
   },
   "dependencies": {

--- a/packages/api/src/app-router.ts
+++ b/packages/api/src/app-router.ts
@@ -254,12 +254,16 @@ export default async function makeApp(params: CliArgs) {
   }
   const apiErrorHandler = errorHandler();
 
-  app.use((err, _req, res, _next) => {
-    if (frontend && !_req.path.startsWith(httpPrefix)) {
-      wwwHandler(err, _req, res, _next);
-    }
-    apiErrorHandler(err, _req, res, _next);
-  });
+  if (frontend) {
+    app.use((req, res, next) => {
+      if (!req.path.startsWith(httpPrefix)) {
+        return wwwHandler(req, res, next);
+      }
+      next();
+    });
+  }
+
+  app.use(apiErrorHandler);
 
   // These parameters are required to use the fcl library, even though we don't use on-chain verification
   await fcl.config({


### PR DESCRIPTION
4b2fb4cd1 broke the fallback because `wwwHandler` was only registered as a four-argument error handler instead of a regular three-argument handler. I think this fixes while keeping the API handler behavior 