### PR TITLE
Revert "use random port for catalyst mock server (#1860)"

### DIFF
--- a/packages/api/src/test-server.ts
+++ b/packages/api/src/test-server.ts
@@ -60,20 +60,19 @@ params.listen = true;
 params.requireEmailVerification = true;
 params.livekitHost = "livekit";
 params.frontend = false;
+params.catalystBaseUrl = "http://127.0.0.1:7171";
 
 let server: AppServer & { host?: string };
-let catalystServer;
 
 console.log(`test run parameters: ${JSON.stringify(params)}`);
 
 async function setupServer() {
   await rabbitMgmt.createVhost(testId);
 
-  catalystServer = await startAuxTestServer();
+  const catalystServer = await startAuxTestServer(7171);
   catalystServer.app.post("/api/events", (req, res) => {
     res.status(200).end();
   });
-  params.catalystBaseUrl = `http://127.0.0.1:${catalystServer.port}`;
 
   server = await makeApp(params);
 
@@ -98,9 +97,6 @@ afterAll(async () => {
     await server.queue.close();
     await server.close();
     server = null;
-  }
-  if (catalystServer) {
-    await catalystServer.close();
   }
   fs.removeSync(dbPath);
   await rabbitMgmt.deleteVhost(testId);


### PR DESCRIPTION
This reverts commit 275b69576e427a5f094858516142d3082b6e40fa.

Looks maybe like this contributed to CI failures?