### PR TITLE
webhook: b64 encode the response of failing webhooks

### DIFF
--- a/packages/api/src/controllers/webhook.ts
+++ b/packages/api/src/controllers/webhook.ts
@@ -259,6 +259,9 @@ app.post(
     try {
       const triggerTime = response.createdAt ?? Date.now();
       let status: DBWebhook["status"] = { lastTriggeredAt: triggerTime };
+      let responseBody = response.response.body;
+      let encodedResponseBody = Buffer.from(responseBody).toString("base64");
+
       if (
         response.statusCode >= 300 ||
         !response.statusCode ||
@@ -270,7 +273,7 @@ app.post(
             error: errorMessage,
             timestamp: triggerTime,
             statusCode: response.statusCode,
-            response: response.response.body,
+            response: encodedResponseBody,
           },
         };
       }

--- a/packages/api/src/controllers/webhook.ts
+++ b/packages/api/src/controllers/webhook.ts
@@ -259,8 +259,6 @@ app.post(
     try {
       const triggerTime = response.createdAt ?? Date.now();
       let status: DBWebhook["status"] = { lastTriggeredAt: triggerTime };
-      let responseBody = response.response.body;
-      let encodedResponseBody = Buffer.from(responseBody).toString("base64");
 
       if (
         response.statusCode >= 300 ||
@@ -273,7 +271,7 @@ app.post(
             error: errorMessage,
             timestamp: triggerTime,
             statusCode: response.statusCode,
-            response: encodedResponseBody,
+            response: response.response.body,
           },
         };
       }

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -594,6 +594,7 @@ export async function storeTriggerStatus(
 ): Promise<void> {
   try {
     let status: DBWebhook["status"] = { lastTriggeredAt: triggerTime };
+    let encodedResponseBody = Buffer.from(responseBody).toString("base64");
     if (statusCode >= 300 || !statusCode) {
       status = {
         ...status,
@@ -601,7 +602,7 @@ export async function storeTriggerStatus(
           timestamp: triggerTime,
           statusCode,
           error: errorMessage,
-          response: responseBody,
+          response: encodedResponseBody,
         },
       };
     }

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -469,6 +469,8 @@ export default class WebhookCannon {
   ) {
     try {
       const hrDuration = process.hrtime(startTime);
+      let encodedResponseBody = Buffer.from(responseBody).toString("base64");
+
       await this.db.webhookResponse.create({
         id: uuid(),
         webhookId: webhook.id,
@@ -477,7 +479,7 @@ export default class WebhookCannon {
         duration: hrDuration[0] + hrDuration[1] / 1e9,
         statusCode: resp.status,
         response: {
-          body: responseBody,
+          body: encodedResponseBody,
           headers: resp.headers.raw(),
           redirected: resp.redirected,
           status: resp.status,

--- a/packages/www/components/WebhookDetails/DetailsBox.tsx
+++ b/packages/www/components/WebhookDetails/DetailsBox.tsx
@@ -8,6 +8,21 @@ const Cell = styled(Text, {
   fontSize: "$3",
 });
 
+function base64Decode(input: string) {
+  const base64Pattern =
+    /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+  if (base64Pattern.test(input)) {
+    try {
+      if (typeof window !== "undefined" && typeof window.atob === "function") {
+        return window.atob(input);
+      }
+    } catch (e) {
+      console.error("Failed to decode base64 string", e);
+    }
+  }
+  return input; // return the original string if not base64 or if decoding fails
+}
+
 const DetailsBox = ({ data }) => (
   <Box
     css={{
@@ -91,7 +106,7 @@ const DetailsBox = ({ data }) => (
           css={{
             fontFamily: "monospace",
           }}>
-          {data.status.lastFailure.response}
+          {base64Decode(data.status.lastFailure.response)}
         </Cell>
       </>
     ) : (


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Sometimes storing the response of a failing webhook is failing if the response contains a some special characters. Encoding the response before saving it with avoid all these cases. Currently on the dashboard only the status code is displayed, so no need for frontend changes

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional)**

<!-- Drag some screenshots here, if applicable -->

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
