### PR TITLE
www: billing: remove upcoming invoice total on dashboard home page

### DIFF
--- a/packages/www/components/UsageSummary/index.tsx
+++ b/packages/www/components/UsageSummary/index.tsx
@@ -296,13 +296,6 @@ const UsageSummary = () => {
         justify="between"
         align="center"
         css={{ fontSize: "$3", color: "$hiContrast" }}>
-        <Text variant="neutral" css={{ display: "flex", ai: "center" }}>
-          <StyledUpcomingIcon />
-          Upcoming invoice:{" "}
-          <Box css={{ ml: "$1", fontWeight: 600 }}>
-            {usage && `$${upcomingInvoiceTotal}`}
-          </Box>
-        </Text>
         <Link href="/dashboard/billing" passHref legacyBehavior>
           <A variant="primary" css={{ display: "flex", alignItems: "center" }}>
             View billing <ArrowRightIcon />


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Removes the upcoming invoice text in the home page, as the new upcoming invoice calculation is inside the billing page

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional)**

<!-- Drag some screenshots here, if applicable -->

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
