### PR TITLE
api: allow overriding default stream profiles

### DIFF
--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1785,12 +1785,20 @@ app.post("/hook", authorizer({ anyAdmin: true }), async (req, res) => {
     )}`
   );
 
+  // Inject H264ConstrainedHigh profile for no B-Frames in livestreams unless the user has set it manually
+  const constrainedProfiles = stream.profiles.map((profile) => {
+    return {
+      ...profile,
+      profile: profile.profile ?? "H264ConstrainedHigh",
+    };
+  });
+
   res.json({
     manifestID,
     streamID: stream.parentId ?? streamId,
     sessionID: streamId,
     presets: stream.presets,
-    profiles: stream.profiles,
+    profiles: constrainedProfiles,
     objectStore,
     recordObjectStore,
     recordObjectStoreUrl,

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -59,15 +59,6 @@ export const USER_SESSION_TIMEOUT = 60 * 1000; // 1 min
 const ACTIVE_TIMEOUT = 90 * 1000; // 90 sec
 const STALE_SESSION_TIMEOUT = 3 * 60 * 60 * 1000; // 3 hours
 
-const DEFAULT_STREAM_FIELDS: Partial<DBStream> = {
-  profiles: [
-    { name: "240p0", fps: 0, bitrate: 250000, width: 426, height: 240 },
-    { name: "360p0", fps: 0, bitrate: 800000, width: 640, height: 360 },
-    { name: "480p0", fps: 0, bitrate: 1600000, width: 854, height: 480 },
-    { name: "720p0", fps: 0, bitrate: 3000000, width: 1280, height: 720 },
-  ],
-};
-
 const app = Router();
 const hackMistSettings = (req: Request, profiles: Profile[]): Profile[] => {
   if (
@@ -973,7 +964,7 @@ app.post(
     }
 
     let doc: DBStream = {
-      ...DEFAULT_STREAM_FIELDS,
+      profiles: req.config.defaultStreamProfiles,
       ...payload,
       kind: "stream",
       userId: req.user.id,

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -8,6 +8,9 @@ import {
   Price,
 } from "./types/common";
 import { defaultTaskExchange } from "./store/queue";
+import { FfmpegProfile } from "./schema/types";
+import profileValidator from "./schema/validators/ffmpeg-profile";
+import { ValidateFunction, ErrorObject } from "ajv";
 
 const DEFAULT_ARWEAVE_GATEWAY_PREFIXES = [
   "https://arweave.net/",
@@ -452,6 +455,73 @@ export default function parseCli(argv?: string | readonly string[]) {
           "stream-info-service: broadcaster host:port to fetch info from",
         type: "string",
         default: "127.0.0.1:7935",
+      },
+      "default-stream-profiles": {
+        describe: "default stream transcoding profiles if none are provided",
+        type: "string",
+        default: JSON.stringify([
+          {
+            name: "240p0",
+            fps: 0,
+            bitrate: 250000,
+            width: 426,
+            height: 240,
+            profile: "H264ConstrainedHigh",
+          },
+          {
+            name: "360p0",
+            fps: 0,
+            bitrate: 800000,
+            width: 640,
+            height: 360,
+            profile: "H264ConstrainedHigh",
+          },
+          {
+            name: "480p0",
+            fps: 0,
+            bitrate: 1600000,
+            width: 854,
+            height: 480,
+            profile: "H264ConstrainedHigh",
+          },
+          {
+            name: "720p0",
+            fps: 0,
+            bitrate: 3000000,
+            width: 1280,
+            height: 720,
+            profile: "H264ConstrainedHigh",
+          },
+        ] as FfmpegProfile[]),
+        coerce: (str: string): FfmpegProfile[] => {
+          let profiles;
+          const validator = profileValidator as ValidateFunction;
+          try {
+            profiles = JSON.parse(str);
+          } catch (e) {
+            throw new Error(
+              `default-stream-profiles JSON parsing error: ${e.message}`
+            );
+          }
+          if (!Array.isArray(profiles)) {
+            throw new Error("default-stream-profiles must be a JSON array");
+          }
+          const errors: ErrorObject[] = [];
+          for (const profile of profiles) {
+            const valid = validator(profile);
+            if (!valid) {
+              errors.push(...validator.errors);
+            }
+          }
+          if (errors.length > 0) {
+            throw new Error(
+              `default-stream-profiles validation error: ${JSON.stringify(
+                errors
+              )}`
+            );
+          }
+          return profiles;
+        },
       },
     })
     .usage(


### PR DESCRIPTION
Two changes here:

1. Add `--default-stream-profiles` allowing the default profiles for a stream object to be provided at runtime (the profiles that are chosen if there aren't any provided for a stream)
2. Changes those default profiles to use `profile: "H264ConstrainedHigh"` by default. We want this in almost all cases for livestreaming because it's necessary to support WebRTC.