### PR TITLE
Increase final retry delay

### DIFF
--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -428,7 +428,10 @@ export class TaskScheduler {
     };
 
     task = await this.updateTask(task, { status });
-    await sleep(retries * TASK_RETRY_BASE_DELAY);
+    // increase sleep for final retry
+    const sleepDur =
+      (retries == MAX_RETRIES ? retries + 1 : retries) * TASK_RETRY_BASE_DELAY;
+    await sleep(sleepDur);
     await this.scheduleTask(task, retries);
   }
 

--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -37,6 +37,7 @@ function sqlQueryGroup(values: string[]) {
 
 const MAX_RETRIES = 2;
 const TASK_RETRY_BASE_DELAY = 30 * 1000;
+const TASK_FINAL_RETRY_DELAY = 3 * 60 * 1000;
 
 export class TaskScheduler {
   config: CliArgs;
@@ -430,7 +431,9 @@ export class TaskScheduler {
     task = await this.updateTask(task, { status });
     // increase sleep for final retry
     const sleepDur =
-      (retries == MAX_RETRIES ? retries + 1 : retries) * TASK_RETRY_BASE_DELAY;
+      retries == MAX_RETRIES
+        ? TASK_FINAL_RETRY_DELAY
+        : retries * TASK_RETRY_BASE_DELAY;
     await sleep(sleepDur);
     await this.scheduleTask(task, retries);
   }


### PR DESCRIPTION
This is to help out with the situation where a catalyst deploy is happening, use a longer delay for task retries to have a better chance of the app being ready. This has been tested locally e2e.