### PR TITLE
www: fix active right now status

### DIFF
--- a/packages/www/components/ActiveStreamsBadge/index.tsx
+++ b/packages/www/components/ActiveStreamsBadge/index.tsx
@@ -6,7 +6,7 @@ import { useCallback } from "react";
 const ActiveStreamsBadge = () => {
   const { user, getStreams } = useApi();
   const fetcher = useCallback(async () => {
-    const [streams] = await getStreams(user.id, {
+    const [streams, nextCursor, count] = await getStreams(user.id, {
       count: true,
       active: true,
     });

--- a/packages/www/components/ActiveStreamsBadge/index.tsx
+++ b/packages/www/components/ActiveStreamsBadge/index.tsx
@@ -6,20 +6,20 @@ import { useCallback } from "react";
 const ActiveStreamsBadge = () => {
   const { user, getStreams } = useApi();
   const fetcher = useCallback(async () => {
-    const [, , count] = await getStreams(user.id, {
+    const [streams] = await getStreams(user.id, {
       count: true,
       active: true,
     });
-    return { count };
+    return { streams };
   }, [user.id]);
 
   const { isLoading, data } = useQuery("activeStreams", () => fetcher());
-  if (isLoading || !data?.count) {
+  if (isLoading || !(data?.streams?.length > 0)) {
     return null;
   }
   return (
     <Badge size="1" variant="primary" css={{ letterSpacing: 0, mt: "7px" }}>
-      {data?.count} active right now
+      {data?.streams?.length} active right now
     </Badge>
   );
 };


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Apparently, the X-Total-Count header result is getting somehow cached by the `getStreams` function, which is displaying `X active right now` streams until the cache of the browser is cleared. This change stops using the header and uses the body length response instead

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional)**

<!-- Drag some screenshots here, if applicable -->

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
