### PR TITLE
Fix Stream Idle by using the isActive from webhook, not stream

### DIFF
--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -902,6 +902,7 @@ app.post(
     const patch: Partial<DBSession & DBStream> = {
       isHealthy: payload.is_active ? payload.is_healthy : undefined,
       issues,
+      isActive: payload.is_active,
       // do not clear the `lastSeen` field when the stream is not active
       ...(payload.is_active ? { lastSeen: Date.now() } : null),
     };


### PR DESCRIPTION
One more fix for another scenario in which stream can stay active while it's not active anymore.

Here's what was the issue:
1. We get more two concurrent requests `/health/hook` and `/setactive` and they both change the `stream` object.
2. In `health/hook` we first get the stream data, then patch it, and then replace the whole `stream` object in db
3. So, here is what may happen:
 - `/health/hook` function is called, it gets the current stream with `isActive: true`
 - `/setactive` function is called to change the stream active to `isActive: false`
 - `/setactive` updates DB and the stream in DB is `isActive: false`
 - /health/hook` replaces the stream object with `isActive: true`

In result, we have the stream with `isActive: true`, which is incorrect.