### PR TITLE
Return live thumbnail URL for everyone

### DIFF
--- a/packages/api/src/controllers/playback.ts
+++ b/packages/api/src/controllers/playback.ts
@@ -92,7 +92,7 @@ function newPlaybackInfo(
   }
   if (thumbUrl) {
     playbackInfo.meta.source.push({
-      hrn: "Thumbnail",
+      hrn: "Thumbnail (JPEG)",
       type: "image/jpeg",
       url: thumbUrl,
     });
@@ -236,7 +236,11 @@ async function getPlaybackInfo(
   if (stream) {
     let url: string;
     let thumbUrl: string;
-    ({ url, thumbUrl } = await getRunningRecording(stream, req));
+    try {
+      ({ url, thumbUrl } = await getRunningRecording(stream, req));
+    } catch (e) {
+      logger.error("Error while getting recording", e);
+    }
 
     return newPlaybackInfo(
       "live",

--- a/packages/api/src/controllers/playback.ts
+++ b/packages/api/src/controllers/playback.ts
@@ -234,15 +234,9 @@ async function getPlaybackInfo(
   }
 
   if (stream) {
-    const thumbsEnabled = await isExperimentSubject(
-      "live-thumbs",
-      req?.user?.id
-    );
     let url: string;
     let thumbUrl: string;
-    if (withRecordings || thumbsEnabled) {
-      ({ url, thumbUrl } = await getRunningRecording(stream, req));
-    }
+    ({ url, thumbUrl } = await getRunningRecording(stream, req));
 
     return newPlaybackInfo(
       "live",
@@ -253,7 +247,7 @@ async function getPlaybackInfo(
       stream.isActive ? 1 : 0,
       url,
       withRecordings,
-      thumbsEnabled && thumbUrl
+      thumbUrl
     );
   }
 

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -2107,12 +2107,13 @@ components:
                 properties:
                   hrn:
                     type: string
+                    description: Human Readable Name
                     example: MP4
                     enum:
                       - HLS (TS)
                       - MP4
                       - WebRTC (H264)
-                      - Thumbnail
+                      - Thumbnail (JPEG)
                   type:
                     type: string
                     example: html5/video/mp4


### PR DESCRIPTION
@victorges does this playback info response look ok to you, the thumbnail source I mean:

```
{
    "type": "live",
    "meta": {
        "live": 0,
        "source": [
            {
                "hrn": "HLS (TS)",
                "type": "html5/application/vnd.apple.mpegurl",
                "url": "https://livepeercdn.studio/hls/b7caqhzl06ma2iqn/index.m3u8"
            },
            {
                "hrn": "WebRTC (H264)",
                "type": "html5/video/h264",
                "url": "https://livepeercdn.studio/webrtc/b7caqhzl06ma2iqn"
            },
            {
                "hrn": "Thumbnail",
                "type": "image/jpeg",
                "url": "https://storage.lp-playback.studio/raw/juixm77hfsmhyslrxtycnqfmnlfq/catalyst-recordings-com/hls/b7caqhzl06ma2iqn/303c14b0-0b12-4275-8228-dbea616fe82a/source/latest.jpg"
            }
        ]
    }
}
```