### PR TITLE
Fix removing Multistream Target from UI

### DIFF
--- a/packages/www/components/StreamDetails/MultistreamTargetsTable/Toolbox.tsx
+++ b/packages/www/components/StreamDetails/MultistreamTargetsTable/Toolbox.tsx
@@ -87,13 +87,13 @@ const DisableDialog = ({
 };
 
 const DeleteDialog = ({
-  target,
+  targetId,
   stream,
   invalidateStream,
   open,
   setOpen,
 }: {
-  target?: MultistreamTarget;
+  targetId?: string;
   stream: Stream;
   invalidateStream: (optm: Stream) => Promise<void>;
   open: boolean;
@@ -132,11 +132,10 @@ const DeleteDialog = ({
                 setSaving(true);
                 try {
                   const targets = stream.multistream.targets.filter(
-                    (t) => t.id !== target.id
+                    (t) => t.id !== targetId
                   );
                   const patch = { multistream: { targets } };
                   await patchStream(stream.id, patch);
-                  await deleteMultistreamTarget(target.id);
                   setOpen(false);
                   await invalidateStream({ ...stream, ...patch });
                 } finally {
@@ -166,10 +165,12 @@ const DeleteDialog = ({
 const Toolbox = ({
   target,
   stream,
+  targetId,
   invalidateTargetId,
   invalidateStream,
 }: {
   target?: MultistreamTarget;
+  targetId?: string;
   stream: Stream;
   invalidateTargetId: (id: string) => Promise<void>;
   invalidateStream: (optm?: Stream) => Promise<void>;
@@ -241,7 +242,6 @@ const Toolbox = ({
               Edit
             </DropdownMenuItem>
             <DropdownMenuItem
-              disabled={!target}
               onSelect={() => setDeleteDialogOpen(true)}
               color="red">
               Delete
@@ -268,7 +268,7 @@ const Toolbox = ({
         invalidate={invalidateAll}
       />
       <DeleteDialog
-        target={target}
+        targetId={targetId}
         stream={stream}
         invalidateStream={invalidateStream}
         open={deleteDialogOpen}

--- a/packages/www/components/StreamDetails/MultistreamTargetsTable/helpers.tsx
+++ b/packages/www/components/StreamDetails/MultistreamTargetsTable/helpers.tsx
@@ -90,6 +90,7 @@ export const makeTableData = (
             children: (
               <Toolbox
                 target={target}
+                targetId={ref.id}
                 stream={stream}
                 invalidateTargetId={invalidateTargetId}
                 invalidateStream={invalidateStream}

--- a/packages/www/components/StreamDetails/MultistreamTargetsTable/index.tsx
+++ b/packages/www/components/StreamDetails/MultistreamTargetsTable/index.tsx
@@ -13,6 +13,7 @@ import { HealthStatus } from "hooks/use-analyzer";
 import SaveTargetDialog, { Action } from "./SaveTargetDialog";
 import { makeColumns, makeTableData, TargetsTableData } from "./helpers";
 import { makeCreateAction } from "components/Table/helpers";
+import { getMultistreamTarget } from "hooks/use-api/endpoints/multistream";
 
 const MultistreamTargetsTable = ({
   title = "Multistream Targets",


### PR DESCRIPTION
Two changes:
- Do not remove multistream target when the "Delete" button is clicked (it may lead to corrupted data if stream was not updated, but multistream target was deleted)
- Allow removing multistream from the stream when the multistream target was removed

Fix https://linear.app/livepeer/issue/PS-90/switchboard-not-able-to-delete-multistream-targets