### PR TITLE
Allow modifying profiles of a suspended stream

### DIFF
--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1362,7 +1362,7 @@ app.patch(
         errors: ["cannot change 'record' field while stream is active"],
       });
     }
-    if (profiles != undefined && stream.isActive) {
+    if (profiles != undefined && stream.isActive && !stream.suspended) {
       res.status(400);
       return res.json({
         errors: ["cannot change 'profiles' field while stream is active"],


### PR DESCRIPTION
fix https://linear.app/livepeer/issue/PS-117/multitream-targets-not-updating-to-only-have-source-rendition