### PR TITLE
Handle update task failure

### DIFF
--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -416,16 +416,7 @@ export class TaskScheduler {
           retries,
         },
       });
-    } catch (err) {
-      this.failTask(task, "Failed to update task to waiting").catch((err) =>
-        console.error(
-          `Error failing task after task update error: taskId=${task.id} err=`,
-          err
-        )
-      );
-      throw err;
-    }
-    try {
+
       await this.queue.publish("task", `task.trigger.${task.type}.${task.id}`, {
         type: "task_trigger",
         id: uuid(),


### PR DESCRIPTION
To address this: https://linear.app/livepeer/issue/VID-428/asset-still-uploading-for-almost-a-week

We should mark the task as failed rather than just leaving it in the previous state. Tested this by placing an error throw line into the code, created an upload task and saw it set to failed, with the old code it was left as `pending`.