### PR TITLE
api: Stop spamming external Object Stores

### DIFF
--- a/packages/api/src/controllers/session.ts
+++ b/packages/api/src/controllers/session.ts
@@ -24,6 +24,7 @@ import {
 } from "./stream";
 import { LVPR_SDK_EMAILS, getClips } from "./clip";
 import { NotFoundError } from "../store/errors";
+import { cache } from "../store/cache";
 
 const app = Router();
 
@@ -229,6 +230,7 @@ export async function getRunningRecording(content: DBStream, req: Request) {
     `);
     return {
       url: null,
+      thumbUrl: null,
       session: null,
       objectStoreId: null,
     };
@@ -246,43 +248,38 @@ export async function buildRecordingUrl(
   recordCatalystObjectStoreId: string,
   secondaryRecordObjectStoreId: string
 ) {
-  const os = await db.objectStore.get(recordCatalystObjectStoreId, {
-    useCache: true,
-  });
-
-  let urlPrefix = pathJoin(os.publicUrl, session.playbackId, session.id);
-  let manifestUrl = pathJoin(urlPrefix, "output.m3u8");
-
-  let params = {
-    method: "HEAD",
-    timeout: 5 * 1000,
-  };
-  let resp = await fetchWithTimeout(manifestUrl, params);
-  if (resp.status == 200) {
-    return {
-      url: manifestUrl,
-      session,
-      objectStoreId: recordCatalystObjectStoreId,
-      thumbUrl: pathJoin(urlPrefix, "source", "latest.jpg"),
-    };
-  }
-
-  const secondaryOs = await db.objectStore.get(secondaryRecordObjectStoreId, {
-    useCache: true,
-  });
-  urlPrefix = pathJoin(secondaryOs.publicUrl, session.playbackId, session.id);
-  manifestUrl = pathJoin(urlPrefix, "output.m3u8");
-
-  const objectStoreId = secondaryRecordObjectStoreId;
-
-  resp = await fetchWithTimeout(manifestUrl, params);
-
-  if (resp.status != 200) {
-    return {
+  return (
+    (await buildSingleRecordingUrl(session, recordCatalystObjectStoreId)) ??
+    (await buildSingleRecordingUrl(session, secondaryRecordObjectStoreId)) ?? {
       url: null,
+      thumbUrl: null,
       session,
-      objectStoreId,
-    };
+      objectStoreId: secondaryRecordObjectStoreId,
+    }
+  );
+}
+
+async function buildSingleRecordingUrl(
+  session: DBSession,
+  objectStoreId: string
+) {
+  const os = await db.objectStore.get(objectStoreId, { useCache: true });
+
+  const urlPrefix = pathJoin(os.publicUrl, session.playbackId, session.id);
+  const manifestUrl = pathJoin(urlPrefix, "output.m3u8");
+
+  const exists = await cache.getOrSet(
+    `manifest-check-${manifestUrl}`,
+    async () => {
+      let resp = await fetchWithTimeout(manifestUrl, {
+        method: "HEAD",
+        timeout: 5 * 1000,
+      });
+      return resp.status === 200;
+    }
+  );
+  if (!exists) {
+    return null;
   }
 
   return {
@@ -292,4 +289,5 @@ export async function buildRecordingUrl(
     thumbUrl: pathJoin(urlPrefix, "source", "latest.jpg"),
   };
 }
+
 export default app;


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
We started seeing external OSes return 429s to us. This might be because we
are calling them every time we get a request for the playback info endpoint.

This might also be why the latency is still so high on this API. This should improve
that as well.

The assumption is that this failure and added latency is cascading to other things rn.

**Specific updates (required)**
- Add cache to the `fetch` call made to the external OS
- Clean up function helper

**How did you test each of these updates (required)**
`yarn test`

**Does this pull request close any open issues?**
incident

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
