### PR TITLE
www: Implement JWT refreshing logic

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -32,7 +32,7 @@
     "go-livepeer": "run-p \"go-livepeer:**\" --",
     "go-livepeer:broadcaster": "bin/livepeer -broadcaster -datadir ./bin/broadcaster -orchAddr 127.0.0.1:3086 -rtmpAddr 0.0.0.0:3035 -httpAddr :3085 -cliAddr :3075 -v 6 -authWebhookUrl http://127.0.0.1:3004/api/stream/hook -orchWebhookUrl http://127.0.0.1:3004/api/orchestrator",
     "go-livepeer:orchestrator": "bin/livepeer -orchestrator -datadir ./bin/orchestrator -transcoder -serviceAddr 127.0.0.1:3086 -cliAddr :3076 -v 6",
-    "test": "POSTGRES_CONNECT_TIMEOUT=120000 jest -i --silent \"${PWD}/src.+user.test.ts\"",
+    "test": "POSTGRES_CONNECT_TIMEOUT=120000 jest -i --silent \"${PWD}/src\"",
     "test:dev": "jest \"${PWD}/src\" -i --silent --watch",
     "test:build": "parcel build --no-autoinstall --no-minify --bundle-node-modules -t browser --out-dir ../dist-worker ../src/worker.js",
     "coverage": "yarn run test --coverage",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -32,7 +32,7 @@
     "go-livepeer": "run-p \"go-livepeer:**\" --",
     "go-livepeer:broadcaster": "bin/livepeer -broadcaster -datadir ./bin/broadcaster -orchAddr 127.0.0.1:3086 -rtmpAddr 0.0.0.0:3035 -httpAddr :3085 -cliAddr :3075 -v 6 -authWebhookUrl http://127.0.0.1:3004/api/stream/hook -orchWebhookUrl http://127.0.0.1:3004/api/orchestrator",
     "go-livepeer:orchestrator": "bin/livepeer -orchestrator -datadir ./bin/orchestrator -transcoder -serviceAddr 127.0.0.1:3086 -cliAddr :3076 -v 6",
-    "test": "POSTGRES_CONNECT_TIMEOUT=120000 jest -i --silent \"${PWD}/src\"",
+    "test": "POSTGRES_CONNECT_TIMEOUT=120000 jest -i --silent \"${PWD}/src.+user.test.ts\"",
     "test:dev": "jest \"${PWD}/src\" -i --silent --watch",
     "test:build": "parcel build --no-autoinstall --no-minify --bundle-node-modules -t browser --out-dir ../dist-worker ../src/worker.js",
     "coverage": "yarn run test --coverage",

--- a/packages/api/src/controllers/user.test.ts
+++ b/packages/api/src/controllers/user.test.ts
@@ -396,7 +396,7 @@ describe("controllers/user", () => {
     });
   });
 
-  describe.only("JWT token refresh", () => {
+  describe("JWT token refresh", () => {
     let client: TestClient;
     let ACCESS_TOKEN_TTL: number;
     let REFRESH_TOKEN_TTL: number;

--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -614,6 +614,7 @@ app.post("/token", validatePost("user"), async (req, res) => {
     req.config.jwtSecret,
     {
       algorithm: "HS256",
+      expiresIn: req.config.jwtAccessTokenTtl,
     }
   );
   const refreshToken = await db.jwtRefreshToken.create({
@@ -673,6 +674,7 @@ app.post(
       req.config.jwtSecret,
       {
         algorithm: "HS256",
+        expiresIn: req.config.jwtAccessTokenTtl,
       }
     );
 

--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -623,8 +623,10 @@ app.post("/token", validatePost("user"), async (req, res) => {
   }
 
   const token = signUserJwt(user.id, req.config);
-  const refreshToken = await db.jwtRefreshToken.create({
-    id: uuid(),
+  const refreshToken = uuid();
+
+  await db.jwtRefreshToken.create({
+    id: refreshToken,
     userId: user.id,
     createdAt: Date.now(),
     expiresAt: Date.now() + req.config.jwtRefreshTokenTtl * 1000,
@@ -701,12 +703,14 @@ app.post(
         lastSeen: now,
         revoked: true,
       });
-      ({ id: newRefreshToken } = await db.jwtRefreshToken.create({
-        id: uuid(),
+
+      newRefreshToken = uuid();
+      await db.jwtRefreshToken.create({
+        id: newRefreshToken,
         userId: user.id,
         createdAt: now,
         expiresAt: now + req.config.jwtRefreshTokenTtl * 1000,
-      }));
+      });
     } else {
       // otherwise just update the lastSeen
       await db.jwtRefreshToken.update(refreshToken, {

--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -730,7 +730,12 @@ app.post(
   "/token/migrate",
   authorizer({ noApiToken: true }),
   async (req, res) => {
-    // this API is authorized so we don't need to check anything here
+    if (!req.isNeverExpiringJWT) {
+      return res.status(400).json({
+        errors: ["can only migrate from never-expiring JWTs"],
+      });
+    }
+
     const token = signUserJwt(req.user.id, req.config);
 
     const now = Date.now();

--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -188,6 +188,7 @@ function signUserJwt(
 ) {
   return jwt.sign({ sub: userId, aud: jwtAudience }, jwtSecret, {
     algorithm: "HS256",
+    jwtid: uuid(),
     expiresIn: jwtAccessTokenTtl,
   });
 }

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -26,7 +26,7 @@ export const EMAIL_VERIFICATION_CUTOFF_DATE = 1695765600000; // 2023-09-26T22:00
  * are set to expire after a short time and the client manages using a refresh
  * token for keeping the user logged in.
  */
-export const NEVER_EXPIRING_JWT_CUTOFF_DATE = 1706745600000; // 2024-02-01T00:00:00.000Z
+export const NEVER_EXPIRING_JWT_CUTOFF_DATE = 1709251200000; // 2024-03-01T00:00:00.000Z
 
 function parseAuthHeader(authHeader: string) {
   const match = authHeader?.match(/^\s*(\w+)\s+(.+)$/);

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -113,9 +113,13 @@ function authenticator(): RequestHandler {
 
         // jwt lib will already validate the exp in case its present, so we just
         // need to check for the never-expiring JWTs.
-        if (!verified.exp && Date.now() > EMAIL_VERIFICATION_CUTOFF_DATE) {
+        req.isNeverExpiringJWT = !verified.exp;
+        if (
+          req.isNeverExpiringJWT &&
+          Date.now() > NEVER_EXPIRING_JWT_CUTOFF_DATE
+        ) {
           throw new UnauthorizedError(
-            `legacy access token detected. please log in again`
+            "legacy access token detected. please log in again"
           );
         }
         tracking.recordUser(userId);

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -2,7 +2,7 @@ import { URL } from "url";
 import basicAuth from "basic-auth";
 import corsLib, { CorsOptions } from "cors";
 import { Request, RequestHandler, Response } from "express";
-import jwt, { JwtPayload } from "jsonwebtoken";
+import jwt, { JwtPayload, TokenExpiredError } from "jsonwebtoken";
 
 import { pathJoin2, trimPathPrefix } from "../controllers/helpers";
 import { ApiToken, User } from "../schema/types";
@@ -100,6 +100,9 @@ function authenticator(): RequestHandler {
         userId = verified.sub;
         tracking.recordUser(userId);
       } catch (err) {
+        if (err instanceof TokenExpiredError) {
+          throw new UnauthorizedError(`access token expired`);
+        }
         throw new UnauthorizedError(err.message);
       }
     } else {

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -14,7 +14,19 @@ import tracking from "./tracking";
 
 type AuthScheme = "jwt" | "bearer" | "basic";
 
-export const EMAIL_VERIFICATION_CUTOFF_DATE = 1695765600000;
+/**
+ * EMAIL_VERIFICATION_CUTOFF_DATE is the date when we started requiring email
+ * verification for new users.
+ */
+export const EMAIL_VERIFICATION_CUTOFF_DATE = 1695765600000; // 2023-09-26T22:00:00.000Z
+
+/**
+ * NEVER_EXPIRING_JWT_CUTOFF_DATE is the date when we stop accepting JWTs
+ * without an expiration date (we used to generate them like that). The new JWTs
+ * are set to expire after a short time and the client manages using a refresh
+ * token for keeping the user logged in.
+ */
+export const NEVER_EXPIRING_JWT_CUTOFF_DATE = 1706745600000; // 2024-02-01T00:00:00.000Z
 
 function parseAuthHeader(authHeader: string) {
   const match = authHeader?.match(/^\s*(\w+)\s+(.+)$/);
@@ -98,6 +110,14 @@ function authenticator(): RequestHandler {
           audience: req.config.jwtAudience,
         }) as JwtPayload;
         userId = verified.sub;
+
+        // jwt lib will already validate the exp in case its present, so we just
+        // need to check for the never-expiring JWTs.
+        if (!verified.exp && Date.now() > EMAIL_VERIFICATION_CUTOFF_DATE) {
+          throw new UnauthorizedError(
+            `legacy access token detected. please log in again`
+          );
+        }
         tracking.recordUser(userId);
       } catch (err) {
         if (err instanceof TokenExpiredError) {

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -247,6 +247,11 @@ export default function parseCli(argv?: string | readonly string[]) {
         default: `["https://livepeer.studio"]`,
         coerce: coerceRegexList("cors-jwt-allowlist"),
       },
+      "jwt-access-token-ttl": {
+        describe: "time to live for JWT access tokens, in seconds",
+        type: "number",
+        default: 60 * 60 * 24, // 1 day
+      },
       "jwt-refresh-token-ttl": {
         describe: "time to live for refresh tokens, in seconds",
         type: "number",

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -247,6 +247,11 @@ export default function parseCli(argv?: string | readonly string[]) {
         default: `["https://livepeer.studio"]`,
         coerce: coerceRegexList("cors-jwt-allowlist"),
       },
+      "jwt-refresh-token-ttl": {
+        describe: "time to live for refresh tokens, in seconds",
+        type: "number",
+        default: 60 * 60 * 24 * 30, // 30 days
+      },
       broadcasters: {
         describe:
           "hardcoded list of broadcasters to return from /api/broadcaster.",

--- a/packages/api/src/schema/db-schema.yaml
+++ b/packages/api/src/schema/db-schema.yaml
@@ -464,6 +464,45 @@ components:
           description:
             Timestamp (in milliseconds) at which token object was created
           example: 1587667174725
+    jwt-refresh-token:
+      type: object
+      table: jwt_refresh_token
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          example: 09F8B46C-61A0-4254-9875-F71F4C605BC7
+        userId:
+          type: string
+          index: true
+          example: 66E2161C-7670-4D05-B71D-DA2D6979556F
+        lastSeen:
+          type: number
+          example: 1587667174725
+        createdAt:
+          type: number
+          readOnly: true
+          description:
+            Timestamp (in milliseconds) at which token object was created
+          example: 1587667174725
+        expiresAt:
+          type: number
+          readOnly: true
+          description: Timestamp (in milliseconds) at which token will expire
+          example: 1587667174725
+        revoked:
+          type: boolean
+          description: Whether the refresh token has been revoked
+          default: false
+    refresh-token-payload:
+      type: object
+      additionalProperties: false
+      required:
+        - refreshToken
+      properties:
+        refreshToken:
+          type: string
+          description: Refresh token to be used to generate a new JWT
     transcode-asset-payload:
       additionalProperties: false
       required:

--- a/packages/api/src/store/db.ts
+++ b/packages/api/src/store/db.ts
@@ -17,6 +17,7 @@ import {
   SigningKey,
   Room,
   Attestation,
+  JwtRefreshToken,
 } from "../schema/types";
 import BaseTable, { TableOptions } from "./table";
 import StreamTable from "./stream-table";
@@ -66,6 +67,7 @@ export class DB {
   task: TaskTable;
   signingKey: Table<SigningKey>;
   apiToken: Table<ApiToken>;
+  jwtRefreshToken: Table<JwtRefreshToken>;
   user: Table<User>;
   experiment: ExperimentTable;
   attestation: AttestationTable;
@@ -146,6 +148,10 @@ export class DB {
     this.apiToken = makeTable<ApiToken>({
       db: this,
       schema: schemas["api-token"],
+    });
+    this.jwtRefreshToken = makeTable<JwtRefreshToken>({
+      db: this,
+      schema: schemas["jwt-refresh-token"],
     });
     this.asset = new AssetTable({
       db: this,

--- a/packages/api/src/types/common.d.ts
+++ b/packages/api/src/types/common.d.ts
@@ -43,6 +43,7 @@ declare global {
       catalystBaseUrl: string;
       user?: User;
       isUIAdmin?: boolean;
+      isNeverExpiringJWT?: boolean;
       token?: WithID<ApiToken>;
 
       getBroadcasters?: () => Promise<NodeAddress[]>;

--- a/packages/www/hooks/use-api/endpoints/user.ts
+++ b/packages/www/hooks/use-api/endpoints/user.ts
@@ -57,15 +57,27 @@ export const login = async (email, password) => {
 
 export const refreshAccessToken = async (
   email: string,
-  refreshToken: string
+  refreshToken: string,
+  legacyJwt?: string
 ) => {
-  const res = await fetch("/user/token/refresh", {
-    method: "POST",
-    body: JSON.stringify({ refreshToken }),
-    headers: {
-      "content-type": "application/json",
-    },
-  });
+  let res: Response;
+  if (!refreshToken && legacyJwt) {
+    // TODO: Remove this logic after the never-expiring JWTs cut-off date
+    res = await fetch("/user/token/migrate", {
+      method: "POST",
+      headers: {
+        authorization: `JWT ${legacyJwt}`,
+      },
+    });
+  } else {
+    res = await fetch("/user/token/refresh", {
+      method: "POST",
+      body: JSON.stringify({ refreshToken }),
+      headers: {
+        "content-type": "application/json",
+      },
+    });
+  }
   if (res.status !== 201) {
     return false;
   }

--- a/packages/www/hooks/use-api/endpoints/user.ts
+++ b/packages/www/hooks/use-api/endpoints/user.ts
@@ -57,17 +57,21 @@ export const login = async (email, password) => {
 
 const inFlight: Record<string, Promise<any>> = {};
 
+// This makes sure a given function is only executed a single time concurrently.
+// It is used to prevent multiple concurrent executions of the
+// refreshAccessToken function. The result of the function gets re-used for
+// every caller, since the same promise is returned.
 const singleFlight = <T>(key: string, fn: () => Promise<T>) => {
   const cached = inFlight[key];
   if (cached) {
     return cached as Promise<T>;
   }
 
-  const promise = fn();
-  inFlight[key] = promise;
-  return promise.finally(() => {
+  const promise = fn().finally(() => {
     delete inFlight[key];
   });
+  inFlight[key] = promise;
+  return promise;
 };
 
 export const refreshAccessToken = () =>

--- a/packages/www/hooks/use-api/endpoints/user.ts
+++ b/packages/www/hooks/use-api/endpoints/user.ts
@@ -80,17 +80,19 @@ export const refreshAccessToken = () =>
     } = context;
 
     let res: Response;
-    let baseUrl = `${endpoint}/api`;
+    let baseUrl = `${endpoint}/api/user/token`;
+    // any access token stored without a corresponding refresh token is
+    // considered legacy. i.e. has no expiration and should be migrated.
+    // TODO: Remove this logic after the never-expiring JWTs cut-off date
     if (!refreshToken && legacyJwt) {
-      // TODO: Remove this logic after the never-expiring JWTs cut-off date
-      res = await fetch(`${baseUrl}/user/token/migrate`, {
+      res = await fetch(`${baseUrl}/migrate`, {
         method: "POST",
         headers: {
           authorization: `JWT ${legacyJwt}`,
         },
       });
     } else {
-      res = await fetch(`${baseUrl}/user/token/refresh`, {
+      res = await fetch(`${baseUrl}/refresh`, {
         method: "POST",
         body: JSON.stringify({ refreshToken }),
         headers: {

--- a/packages/www/hooks/use-api/endpoints/user.ts
+++ b/packages/www/hooks/use-api/endpoints/user.ts
@@ -59,7 +59,7 @@ export const refreshAccessToken = async (
   email: string,
   refreshToken: string
 ) => {
-  const [res, body] = await context.fetch("/user/token/refresh", {
+  const res = await fetch("/user/token/refresh", {
     method: "POST",
     body: JSON.stringify({ refreshToken }),
     headers: {
@@ -69,7 +69,7 @@ export const refreshAccessToken = async (
   if (res.status !== 201) {
     return false;
   }
-  const { token, refreshToken: newRefreshToken } = body;
+  const { token, refreshToken: newRefreshToken } = await res.json();
   if (newRefreshToken) {
     // allow the refresh token itself to be refreshed if the server sends a new one
     refreshToken = newRefreshToken;

--- a/packages/www/hooks/use-api/endpoints/user.ts
+++ b/packages/www/hooks/use-api/endpoints/user.ts
@@ -70,14 +70,17 @@ const singleFlight = <T>(key: string, fn: () => Promise<T>) => {
   });
 };
 
-export const refreshAccessToken = (
-  email: string,
-  refreshToken: string,
-  legacyJwt?: string
-) =>
-  singleFlight(`refresh:${email}:${refreshToken}:${legacyJwt}`, async () => {
+export const refreshAccessToken = () =>
+  singleFlight(`refreshAccessToken`, async () => {
+    let {
+      endpoint,
+      token: legacyJwt,
+      refreshToken,
+      user: { email = "" } = {},
+    } = context;
+
     let res: Response;
-    let baseUrl = `${context.endpoint}/api`;
+    let baseUrl = `${endpoint}/api`;
     if (!refreshToken && legacyJwt) {
       // TODO: Remove this logic after the never-expiring JWTs cut-off date
       res = await fetch(`${baseUrl}/user/token/migrate`, {

--- a/packages/www/hooks/use-api/index.tsx
+++ b/packages/www/hooks/use-api/index.tsx
@@ -133,12 +133,16 @@ export const ApiProvider = ({ children }) => {
   useEffect(() => {
     if (state.token) {
       const data = jwt.decode(state.token);
-      context.getUser(data.sub).then(([res, user]) => {
+      context.getUser(data.sub).then(async ([res, user]) => {
         if (res.status !== 200) {
           clearTokens();
           setState((state) => ({ ...state, token: null, refreshToken: null }));
         } else {
           setState((state) => ({ ...state, user: user as User }));
+          // migrate old JWT to refresh-token scheme if needed
+          if (!state.refreshToken) {
+            await userEndpointsFunctions.refreshAccessToken();
+          }
         }
       });
     }

--- a/packages/www/hooks/use-api/index.tsx
+++ b/packages/www/hooks/use-api/index.tsx
@@ -72,11 +72,8 @@ const makeContext = (
 
       const tokenExpired =
         res.status === 401 && body.errors?.[0] === "access token expired";
-      if (tokenExpired && state.refreshToken && !refreshedToken) {
-        const newToken = await userEndpointsFunctions.refreshAccessToken(
-          state.user?.email,
-          state.refreshToken
-        );
+      if (tokenExpired && !refreshedToken) {
+        const newToken = await userEndpointsFunctions.refreshAccessToken();
         if (newToken) {
           return context.fetch(url, opts, newToken);
         }

--- a/packages/www/hooks/use-api/tokenStorage.ts
+++ b/packages/www/hooks/use-api/tokenStorage.ts
@@ -1,5 +1,5 @@
 export const TOKEN_KEY = "PERSISTENT_TOKEN";
-export const REFRESH_TOKEN_KEY = "REFRESH_TOKEN_KEY";
+export const REFRESH_TOKEN_KEY = "REFRESH_TOKEN";
 
 export const storeToken = (token: string, refreshToken: string) => {
   try {

--- a/packages/www/hooks/use-api/tokenStorage.ts
+++ b/packages/www/hooks/use-api/tokenStorage.ts
@@ -1,8 +1,10 @@
 export const TOKEN_KEY = "PERSISTENT_TOKEN";
+export const REFRESH_TOKEN_KEY = "REFRESH_TOKEN_KEY";
 
-export const storeToken = (token) => {
+export const storeToken = (token: string, refreshToken: string) => {
   try {
     localStorage.setItem(TOKEN_KEY, token);
+    localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
   } catch (err) {
     console.error(`
       Error storing persistent token: ${err.message}. Usually this means that you're in a
@@ -11,21 +13,26 @@ export const storeToken = (token) => {
   }
 };
 
-export const getStoredToken = () => {
+export const getStoredToken = () => getStorageItem(TOKEN_KEY);
+
+export const getRefreshToken = () => getStorageItem(REFRESH_TOKEN_KEY);
+
+const getStorageItem = (key: string) => {
   if (!("browser" in process)) {
     return null;
   }
   try {
-    return localStorage.getItem(TOKEN_KEY);
+    return localStorage.getItem(key);
   } catch (err) {
-    console.error(`Error retrieving persistent token: ${err.message}.`);
+    console.error(`Error retrieving ${key} from storage: ${err.message}.`);
     return null;
   }
 };
 
-export const clearToken = () => {
+export const clearTokens = () => {
   try {
     localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(REFRESH_TOKEN_KEY);
   } catch (err) {
     console.error(`Error clearing persistent token: ${err.message}.`);
   }

--- a/packages/www/hooks/use-api/types.ts
+++ b/packages/www/hooks/use-api/types.ts
@@ -15,6 +15,7 @@ export type FileUploadsDictionary = {
 export type ApiState = {
   user?: User;
   token?: string;
+  refreshToken?: string;
   userRefresh?: number;
   noStripe?: boolean;
   currentFileUploads?: FileUploadsDictionary;

--- a/packages/www/hooks/use-logged-in.tsx
+++ b/packages/www/hooks/use-logged-in.tsx
@@ -22,7 +22,7 @@ export default function useLoggedIn(shouldBeLoggedIn = true) {
         router.replace("/verify");
       }
     }
-    console.log(shouldBeLoggedIn, user);
+    // console.log(shouldBeLoggedIn, user);
     // Check for user rather than token so redirects to /dashboard.
     if (shouldBeLoggedIn === false && user) {
       if (emailVerificationMode && user.emailValid === false) {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This is to stop generating JWTs to access the dashboard that have no expiration time. This
causes a security risk if these tokens ever leak, since there's no way to revoke them and they'd
be valid forever.

The new design involves:
- Adding an `exp` to all the JWTs ("access tokens") that we sign, making sure they can only be used temporarily (24h)
- Creating a separate "refresh token" abstraction that is saved on the DB. The client only deals with a vanity ID, just like for API keys. These last for 30 days and can be used to generate new access tokens.
- The refresh tokens themselves are also refreshed when they are close to their expiration (currently 30 days). If a user doesn't accept the dashboard during the refresh token refresh period (20% of ttl, or 6 days), they will need to login again.
- A single refresh token can only be used to generate 1 access token every "half life" (so one every 12h). This is to prevent reuse of this token, which will be immediately revoked if reused.
  - This is a pretty simple security measure. We could create many other restrictions on top of these now that we have them on the DB, like enforcing only the same IP or device to use them.
- There is also some API & logic to migrate from the old never-expiring JWTs to the new scheme.
- Never-expiring JWTs won't be accepted anymore after a cut-off date, date when we should kill the dead migration code.

**Specific updates (required)**

- Create the new refresh and migration APIs
- Create client code to call these APIs to refresh them tokens
- Write some API tests

**How did you test each of these updates (required)**
- `yarn test`
- todo: e2e, maybe in the box, maybe in staging

**Does this pull request close any open issues?**
The never-expiring JWTs.

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
