### PR TITLE
Return targetId while creating a multistream target

### DIFF
--- a/packages/api/src/controllers/stream.test.ts
+++ b/packages/api/src/controllers/stream.test.ts
@@ -523,7 +523,7 @@ describe("controllers/stream", () => {
           spec: { name: "target-name", url: "rtmp://test/test" },
         }
       );
-      expect(res2.status).toBe(204);
+      expect(res2.status).toBe(200);
     });
 
     describe("set active and heartbeat", () => {

--- a/packages/api/src/controllers/stream.test.ts
+++ b/packages/api/src/controllers/stream.test.ts
@@ -524,6 +524,8 @@ describe("controllers/stream", () => {
         }
       );
       expect(res2.status).toBe(200);
+      const body = await res2.json();
+      expect(body.id).toBeDefined();
     });
 
     describe("set active and heartbeat", () => {

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -115,11 +115,7 @@ async function validateMultistreamTarget(
   return { ...specless, id: created.id };
 }
 
-async function validateMultistreamOpts(
-  userId: string,
-  profiles: Profile[],
-  multistream: MultistreamOptions
-): Promise<MultistreamOptions> {
+function toProfileNames(profiles: Profile[]): Set<string> {
   const profileNames = new Set<string>();
   for (const { name } of profiles) {
     if (!name) {
@@ -132,7 +128,15 @@ async function validateMultistreamOpts(
     profileNames.add(name);
   }
   profileNames.add("source");
+  return profileNames;
+}
 
+async function validateMultistreamOpts(
+  userId: string,
+  profiles: Profile[],
+  multistream: MultistreamOptions
+): Promise<MultistreamOptions> {
+  const profileNames = toProfileNames(profiles);
   if (!multistream?.targets) {
     return { targets: [] };
   }
@@ -1346,8 +1350,14 @@ app.post(
       return res.json({ errors: ["stream not found"] });
     }
 
+    const newTarget = await validateMultistreamTarget(
+      req.user.id,
+      toProfileNames(stream.profiles),
+      payload
+    );
+
     let multistream: DBStream["multistream"] = {
-      targets: [...(stream.multistream?.targets ?? []), payload],
+      targets: [...(stream.multistream?.targets ?? []), newTarget],
     };
 
     multistream = await validateMultistreamOpts(
@@ -1364,8 +1374,8 @@ app.post(
 
     await triggerCatalystStreamUpdated(req, stream.playbackId);
 
-    res.status(204);
-    res.end();
+    res.status(200);
+    res.json(newTarget);
   }
 );
 

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1371,11 +1371,11 @@ app.post(
     };
 
     await db.stream.update(stream.id, patch);
-
+    const updatedTarget = await db.multistreamTarget.get(newTarget.id);
     await triggerCatalystStreamUpdated(req, stream.playbackId);
 
     res.status(200);
-    res.json(newTarget);
+    res.json(db.multistreamTarget.cleanWriteOnlyResponse(updatedTarget));
   }
 );
 


### PR DESCRIPTION
Linear: https://linear.app/livepeer/issue/PS-196/adding-target-id-to-response-of-atomic-creation