### PR TITLE
www: Fix initial API client state

### DIFF
--- a/packages/www/hooks/use-api/index.tsx
+++ b/packages/www/hooks/use-api/index.tsx
@@ -3,7 +3,7 @@ import jwt from "jsonwebtoken";
 import { User } from "@livepeer.studio/api";
 import { isStaging, isDevelopment } from "../../lib/utils";
 import { ApiState } from "./types";
-import { clearTokens, getStoredToken } from "./tokenStorage";
+import { clearTokens, getRefreshToken, getStoredToken } from "./tokenStorage";
 import * as accessControlEndpointsFunctions from "./endpoints/accessControl";
 import * as apiTokenEndpointsFunctions from "./endpoints/apiToken";
 import * as assetEndpointsFunctions from "./endpoints/asset";
@@ -125,6 +125,7 @@ export const ApiContext = createContext(makeContext({} as ApiState, () => {}));
 export const ApiProvider = ({ children }) => {
   const [state, setState] = useState<ApiState>({
     token: getStoredToken(),
+    refreshToken: getRefreshToken(),
   });
 
   const context = makeContext(state, setState);


### PR DESCRIPTION

**What does this pull request do? Explain your changes. (required)**
Fixes the JWT refreshing issue when the page reloads. It was missing loading the refresh token from storage on load.

**Specific updates (required)**
Read refresh token from local storage when initializing state.

**How did you test each of these updates (required)**
`yarn dev`

**Does this pull request close any open issues?**
Fixes staging issue on refreshing JWTs that logs out every now and then.

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
