### PR TITLE
Webhook get and resend APIs

### DIFF
--- a/packages/api/src/controllers/webhook-log.ts
+++ b/packages/api/src/controllers/webhook-log.ts
@@ -1,0 +1,142 @@
+import { FieldsMap, makeNextHREF, parseFilters, parseOrder } from "./helpers";
+import { authorizer } from "../middleware";
+import { db } from "../store";
+import {
+  BadRequestError,
+  ForbiddenError,
+  NotFoundError,
+} from "../store/errors";
+import { resendWebhook } from "../webhooks/cannon";
+import sql from "sql-template-strings";
+import Router from "express/lib/router";
+import { WebhookResponse } from "../schema/types";
+import { DBWebhook } from "../store/webhook-table";
+
+const app = Router({ mergeParams: true });
+
+const requestsFieldsMap: FieldsMap = {
+  id: `webhook_response.ID`,
+  createdAt: { val: `webhook_response.data->'createdAt'`, type: "int" },
+  userId: `webhook_response.data->>'userId'`,
+  event: `webhook_response.data->>'event'`,
+  statusCode: `webhook_response.data->'response'->>'status'`,
+};
+
+app.put("/:requestId/resend", authorizer({}), async (req, res) => {
+  const webhook = await db.webhook.get(req.params.id);
+  const webhookResponse = await db.webhookResponse.get(req.params.requestId);
+  await checkRequest(req, webhook, webhookResponse);
+
+  await resendWebhook(webhook, webhookResponse);
+  res.status(202).end();
+});
+
+app.get("/:requestId", authorizer({}), async (req, res) => {
+  const webhook = await db.webhook.get(req.params.id);
+  const webhookResponse = await db.webhookResponse.get(req.params.requestId);
+  await checkRequest(req, webhook, webhookResponse);
+
+  res.status(200);
+  return res.json(webhookResponse);
+});
+
+async function checkRequest(
+  req,
+  webhook: DBWebhook,
+  webhookResponse: WebhookResponse
+) {
+  if (
+    !req.user.admin &&
+    (req.user.id !== webhook.userId || req.user.id !== webhookResponse.userId)
+  ) {
+    throw new ForbiddenError(`invalid user`);
+  }
+  if (!webhook || webhook.deleted) {
+    throw new NotFoundError(`webhook not found`);
+  }
+  if (webhookResponse.webhookId !== webhook.id) {
+    throw new BadRequestError(`mismatch between webhook and webhook log`);
+  }
+}
+
+app.get("/", authorizer({}), async (req, res) => {
+  let { limit, cursor, all, allUsers, order, filters, count } = req.query;
+  if (isNaN(parseInt(limit))) {
+    limit = undefined;
+  }
+  if (!order) {
+    order = "createdAt-true";
+  }
+
+  if (req.user.admin && allUsers && allUsers !== "false") {
+    const query = parseFilters(requestsFieldsMap, filters);
+    query.push(sql`webhook_response.data->>'webhookId' = ${req.params.id}`);
+    if (!all || all === "false") {
+      query.push(sql`webhook_response.data->>'deleted' IS NULL`);
+    }
+
+    let fields =
+      " webhook_response.id as id, webhook_response.data as data, users.id as usersId, users.data as usersdata";
+    if (count) {
+      fields = fields + ", count(*) OVER() AS count";
+    }
+    const from = `webhook_response left join users on webhook_response.data->>'userId' = users.id`;
+    const [output, newCursor] = await db.webhookResponse.find(query, {
+      limit,
+      cursor,
+      fields,
+      from,
+      order: parseOrder(requestsFieldsMap, order),
+      process: ({ data, usersdata, count: c }) => {
+        if (count) {
+          res.set("X-Total-Count", c);
+        }
+        return { ...data, user: db.user.cleanWriteOnlyResponse(usersdata) };
+      },
+    });
+
+    res.status(200);
+
+    if (output.length > 0 && newCursor) {
+      res.links({ next: makeNextHREF(req, newCursor) });
+    }
+    return res.json(output);
+  }
+
+  const query = parseFilters(requestsFieldsMap, filters);
+  query.push(sql`webhook_response.data->>'userId' = ${req.user.id}`);
+  query.push(sql`webhook_response.data->>'webhookId' = ${req.params.id}`);
+
+  if (!all || all === "false" || !req.user.admin) {
+    query.push(sql`webhook_response.data->>'deleted' IS NULL`);
+  }
+
+  let fields = " webhook_response.id as id, webhook_response.data as data";
+  if (count) {
+    fields = fields + ", count(*) OVER() AS count";
+  }
+  const from = `webhook_response`;
+  const [output, newCursor] = await db.webhookResponse.find(query, {
+    limit,
+    cursor,
+    fields,
+    from,
+    order: parseOrder(requestsFieldsMap, order),
+    process: ({ data, count: c }) => {
+      if (count) {
+        res.set("X-Total-Count", c);
+      }
+      return { ...data };
+    },
+  });
+
+  res.status(200);
+
+  if (output.length > 0) {
+    res.links({ next: makeNextHREF(req, newCursor) });
+  }
+
+  return res.json(output);
+});
+
+export default app;

--- a/packages/api/src/controllers/webhook-log.ts
+++ b/packages/api/src/controllers/webhook-log.ts
@@ -54,6 +54,9 @@ async function checkRequest(
   if (!webhook || webhook.deleted) {
     throw new NotFoundError(`webhook not found`);
   }
+  if (!webhookResponse || webhookResponse.deleted) {
+    throw new NotFoundError(`webhook log not found`);
+  }
   if (webhookResponse.webhookId !== webhook.id) {
     throw new BadRequestError(`mismatch between webhook and webhook log`);
   }

--- a/packages/api/src/controllers/webhook.test.js
+++ b/packages/api/src/controllers/webhook.test.js
@@ -330,6 +330,7 @@ describe("controllers/webhook", () => {
       expect(webhookRequest.request).toBeDefined();
       expect(webhookRequest.request.body).toBeDefined();
       expect(webhookRequest.request.headers).toBeDefined();
+      expect(webhookRequest.request.headers["Livepeer-Signature"]).not.toBe("");
       expect(webhookRequest.response).toBeDefined();
       expect(webhookRequest.response.body).toBeDefined();
 
@@ -340,10 +341,15 @@ describe("controllers/webhook", () => {
       const getJson = await getRes.json();
       expect(getJson).toEqual(webhookRequest);
 
-      const resendRes = await client.put(
+      const resendRes = await client.post(
         `/webhook/${generatedWebhook.id}/log/${webhookRequest.id}/resend`
       );
-      expect(resendRes.status).toBe(202);
+      expect(resendRes.status).toBe(200);
+      const resent = await resendRes.json();
+      expect(resent.event).toBe(webhookRequest.event);
+      expect(resent.webhookId).toBe(webhookRequest.webhookId);
+      expect(resent.id).not.toBe(webhookRequest.id);
+
       const logRes = await client.get(`/webhook/${generatedWebhook.id}/log`);
       expect(logRes.status).toBe(200);
       logJson = await logRes.json();

--- a/packages/api/src/controllers/webhook.ts
+++ b/packages/api/src/controllers/webhook.ts
@@ -7,15 +7,8 @@ import { v4 as uuid } from "uuid";
 import { makeNextHREF, parseFilters, parseOrder, FieldsMap } from "./helpers";
 import { db } from "../store";
 import sql from "sql-template-strings";
-import {
-  UnprocessableEntityError,
-  NotFoundError,
-  ForbiddenError,
-  BadRequestError,
-} from "../store/errors";
-import { resendWebhook } from "../webhooks/cannon";
-import { DBWebhook } from "../store/webhook-table";
-import { WebhookResponse } from "../schema/types";
+import { UnprocessableEntityError, NotFoundError } from "../store/errors";
+import webhookLog from "./webhook-log";
 
 function validateWebhookPayload(id, userId, createdAt, payload) {
   try {
@@ -45,6 +38,8 @@ function validateWebhookPayload(id, userId, createdAt, payload) {
 }
 
 const app = Router();
+
+app.use("/:id/log", webhookLog);
 
 const fieldsMap: FieldsMap = {
   id: `webhook.ID`,
@@ -285,131 +280,6 @@ app.delete("/", authorizer({}), async (req, res) => {
 
   res.status(204);
   res.end();
-});
-
-const requestsFieldsMap: FieldsMap = {
-  id: `webhook_response.ID`,
-  createdAt: { val: `webhook_response.data->'createdAt'`, type: "int" },
-  userId: `webhook_response.data->>'userId'`,
-  event: `webhook_response.data->>'event'`,
-  statusCode: `webhook_response.data->'response'->>'status'`,
-};
-
-app.put("/:id/log/:requestId/resend", authorizer({}), async (req, res) => {
-  const webhook = await db.webhook.get(req.params.id);
-  const webhookResponse = await db.webhookResponse.get(req.params.requestId);
-  await checkRequest(req, webhook, webhookResponse);
-
-  await resendWebhook(webhook, webhookResponse);
-  res.status(202).end();
-});
-
-app.get("/:id/log/:requestId", authorizer({}), async (req, res) => {
-  const webhook = await db.webhook.get(req.params.id);
-  const webhookResponse = await db.webhookResponse.get(req.params.requestId);
-  await checkRequest(req, webhook, webhookResponse);
-
-  res.status(200);
-  return res.json(webhookResponse);
-});
-
-async function checkRequest(
-  req,
-  webhook: DBWebhook,
-  webhookResponse: WebhookResponse
-) {
-  if (
-    !req.user.admin &&
-    (req.user.id !== webhook.userId || req.user.id !== webhookResponse.userId)
-  ) {
-    throw new ForbiddenError(`invalid user`);
-  }
-  if (!webhook || webhook.deleted) {
-    throw new NotFoundError(`webhook not found`);
-  }
-  if (webhookResponse.webhookId !== webhook.id) {
-    throw new BadRequestError(`mismatch between webhook and webhook log`);
-  }
-}
-
-app.get("/:id/log", authorizer({}), async (req, res) => {
-  let { limit, cursor, all, allUsers, order, filters, count } = req.query;
-  if (isNaN(parseInt(limit))) {
-    limit = undefined;
-  }
-  if (!order) {
-    order = "createdAt-true";
-  }
-
-  if (req.user.admin && allUsers && allUsers !== "false") {
-    const query = parseFilters(requestsFieldsMap, filters);
-    query.push(sql`webhook_response.data->>'webhookId' = ${req.params.id}`);
-    if (!all || all === "false") {
-      query.push(sql`webhook_response.data->>'deleted' IS NULL`);
-    }
-
-    let fields =
-      " webhook_response.id as id, webhook_response.data as data, users.id as usersId, users.data as usersdata";
-    if (count) {
-      fields = fields + ", count(*) OVER() AS count";
-    }
-    const from = `webhook_response left join users on webhook_response.data->>'userId' = users.id`;
-    const [output, newCursor] = await db.webhookResponse.find(query, {
-      limit,
-      cursor,
-      fields,
-      from,
-      order: parseOrder(requestsFieldsMap, order),
-      process: ({ data, usersdata, count: c }) => {
-        if (count) {
-          res.set("X-Total-Count", c);
-        }
-        return { ...data, user: db.user.cleanWriteOnlyResponse(usersdata) };
-      },
-    });
-
-    res.status(200);
-
-    if (output.length > 0 && newCursor) {
-      res.links({ next: makeNextHREF(req, newCursor) });
-    }
-    return res.json(output);
-  }
-
-  const query = parseFilters(requestsFieldsMap, filters);
-  query.push(sql`webhook_response.data->>'userId' = ${req.user.id}`);
-  query.push(sql`webhook_response.data->>'webhookId' = ${req.params.id}`);
-
-  if (!all || all === "false" || !req.user.admin) {
-    query.push(sql`webhook_response.data->>'deleted' IS NULL`);
-  }
-
-  let fields = " webhook_response.id as id, webhook_response.data as data";
-  if (count) {
-    fields = fields + ", count(*) OVER() AS count";
-  }
-  const from = `webhook_response`;
-  const [output, newCursor] = await db.webhookResponse.find(query, {
-    limit,
-    cursor,
-    fields,
-    from,
-    order: parseOrder(requestsFieldsMap, order),
-    process: ({ data, count: c }) => {
-      if (count) {
-        res.set("X-Total-Count", c);
-      }
-      return { ...data };
-    },
-  });
-
-  res.status(200);
-
-  if (output.length > 0) {
-    res.links({ next: makeNextHREF(req, newCursor) });
-  }
-
-  return res.json(output);
 });
 
 export default app;

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -2782,8 +2782,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
   "/webhook/{id}/log/{logId}/resend":
-    put:
+    post:
       summary: Resend a webhook
+      description: |
+        Use this API to resend the same webhook request. This is useful when
+        developing and debugging, allowing you to easily repeat the same webhook
+        to check or fix the behaviour in your handler.
       parameters:
         - name: id
           in: path
@@ -2796,8 +2800,12 @@ paths:
           schema:
             type: string
       responses:
-        "202":
+        "200":
           description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/webhook-response"
         default:
           description: Error
           content:

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -2729,6 +2729,80 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/error"
+  "/webhook/{id}/log":
+    get:
+      summary: Retrieve webhook logs
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/webhook-response"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+  "/webhook/{id}/log/{logId}":
+    get:
+      summary: Retrieve a webhook log
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: logId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/webhook-response"
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+  "/webhook/{id}/log/{logId}/resend":
+    put:
+      summary: Resend a webhook
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: logId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Success
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
   /asset:
     get:
       summary: Retrieve assets

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -218,6 +218,7 @@ components:
     webhook-response:
       type: object
       required:
+        - id
         - webhookId
       additionalProperties: false
       properties:

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -255,6 +255,8 @@ components:
             headers:
               type: object
               description: HTTP request headers
+              additionalProperties:
+                type: string
             body:
               type: string
               description: request body

--- a/packages/api/src/schema/db-schema.yaml
+++ b/packages/api/src/schema/db-schema.yaml
@@ -618,6 +618,9 @@ components:
         deleted:
           type: boolean
           default: false
+        sharedSecret:
+          type: string
+          writeOnly: true
     detection-webhook-payload:
       type: object
       required:

--- a/packages/api/src/schema/db-schema.yaml
+++ b/packages/api/src/schema/db-schema.yaml
@@ -615,6 +615,9 @@ components:
             redirected:
               type: boolean
               writeOnly: true
+        deleted:
+          type: boolean
+          default: false
     detection-webhook-payload:
       type: object
       required:


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
Implements get and resend APIs for webhook logs. So now you can retrieve info for a single webhook log and trigger a resend.
<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**

- I had to move the `storeResponse` function outside of the cannon object so that it could be called by the newly written `resendWebhook` function. 
- I moved the webhook log API handlers to a separate file for better organisation.

**How did you test each of these updates (required)**

Tested locally and wrote a unit test.
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
