### PR TITLE
api: Create PUT /stream/pull API for idempotent pull stream

### DIFF
--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -609,6 +609,7 @@ const fieldsMap = {
   createdAt: { val: `asset.data->'createdAt'`, type: "int" },
   updatedAt: { val: `asset.data->'status'->'updatedAt'`, type: "int" },
   userId: `asset.data->>'userId'`,
+  creatorId: `stream.data->'creatorId'->>'value'`,
   playbackId: `asset.data->>'playbackId'`,
   playbackRecordingId: `asset.data->>'playbackRecordingId'`,
   phase: `asset.data->'status'->>'phase'`,

--- a/packages/api/src/controllers/stream.test.ts
+++ b/packages/api/src/controllers/stream.test.ts
@@ -542,9 +542,7 @@ describe("controllers/stream", () => {
         expect(updatedStream.profiles).toEqual([]);
 
         const document = await db.stream.get(stream.id);
-        expect(server.db.stream.addDefaultFields(document)).toEqual(
-          updatedStream
-        );
+        expect(db.stream.addDefaultFields(document)).toEqual(updatedStream);
       });
 
       it("should fail to dedup streams by a random key", async () => {
@@ -592,9 +590,7 @@ describe("controllers/stream", () => {
         expect(updatedStream.profiles).toEqual([]);
 
         const document = await db.stream.get(stream.id);
-        expect(server.db.stream.addDefaultFields(document)).toEqual(
-          updatedStream
-        );
+        expect(db.stream.addDefaultFields(document)).toEqual(updatedStream);
       });
 
       it("should wait for stream to become active if requested", async () => {
@@ -610,7 +606,7 @@ describe("controllers/stream", () => {
 
         const [streams] = await db.stream.find();
         expect(streams).toHaveLength(1);
-        expect(streams[0].isActive).toBeFalsy();
+        expect(streams[0].isActive).toBe(false);
 
         // stream not active yet
         expect(responded).toBe(false);

--- a/packages/api/src/controllers/stream.test.ts
+++ b/packages/api/src/controllers/stream.test.ts
@@ -33,6 +33,7 @@ let mockUser: User;
 let mockAdminUser: User;
 let mockNonAdminUser: User;
 let postMockStream: Stream;
+let postMockPullStream: Stream;
 // jest.setTimeout(70000)
 
 beforeAll(async () => {
@@ -59,6 +60,12 @@ beforeAll(async () => {
       renditions: ["random_prefix_bbb_160p"],
     },
   ];
+  postMockPullStream = {
+    ...postMockStream,
+    pull: {
+      source: "https://playback.space/video+7bbb3wee.flv",
+    },
+  };
 
   mockUser = {
     email: `mock_user@gmail.com`,
@@ -475,6 +482,148 @@ describe("controllers/stream", () => {
         const saved = await server.db.multistreamTarget.get(resultMst.id);
         expect(saved).toBeDefined();
         expect(saved.userId).toEqual(adminUser.id);
+      });
+    });
+
+    describe("pull stream idempotent creation", () => {
+      beforeEach(async () => {
+        // TODO: Remove this once experiment is done
+        await client.post("/experiment", {
+          name: "stream-pull-source",
+          audienceUserIds: [adminUser.id],
+        });
+      });
+
+      it("should require a pull configuration", async () => {
+        let res = await client.put("/stream/pull", postMockStream);
+        expect(res.status).toBe(400);
+        const errors = await res.json();
+        expect(errors).toMatchObject({
+          errors: [
+            expect.stringContaining("stream pull configuration is required"),
+          ],
+        });
+
+        res = await client.put("/stream/pull", {
+          ...postMockStream,
+          pull: {}, // an empty object is missing the 'source' field
+        });
+        expect(res.status).toBe(422);
+      });
+
+      it("should create a stream if a pull config is present", async () => {
+        const now = Date.now();
+        const res = await client.put("/stream/pull", postMockPullStream);
+        expect(res.status).toBe(201);
+        const stream = await res.json();
+        expect(stream.id).toBeDefined();
+        expect(stream.kind).toBe("stream");
+        expect(stream.name).toBe("test_stream");
+        expect(stream.createdAt).toBeGreaterThanOrEqual(now);
+        const document = await db.stream.get(stream.id);
+        expect(server.db.stream.addDefaultFields(document)).toEqual(stream);
+      });
+
+      it("should update a stream if it has the same pull source", async () => {
+        let res = await client.put("/stream/pull", postMockPullStream);
+        expect(res.status).toBe(201);
+        const stream = await res.json();
+
+        const now = Date.now();
+        res = await client.put("/stream/pull", {
+          ...postMockPullStream,
+          name: "updated_stream",
+          profiles: [],
+        });
+        expect(res.status).toBe(200);
+        const updatedStream = await res.json();
+        expect(updatedStream.id).toBe(stream.id);
+        expect(updatedStream.name).toBe("updated_stream");
+        expect(updatedStream.profiles).toEqual([]);
+
+        const document = await db.stream.get(stream.id);
+        expect(server.db.stream.addDefaultFields(document)).toEqual(
+          updatedStream
+        );
+      });
+
+      it("should fail to dedup streams by a random key", async () => {
+        let res = await client.put(
+          "/stream/pull?key=invalid",
+          postMockPullStream
+        );
+        expect(res.status).toBe(400);
+        const errors = await res.json();
+        expect(errors).toMatchObject({
+          errors: [expect.stringContaining("key must be one of")],
+        });
+      });
+
+      it("should fail to dedup streams by creatorId if not provided", async () => {
+        let res = await client.put(
+          "/stream/pull?key=creatorId",
+          postMockPullStream
+        );
+        expect(res.status).toBe(400);
+        const errors = await res.json();
+        expect(errors).toMatchObject({
+          errors: [expect.stringContaining("must be present in the payload")],
+        });
+      });
+
+      it("should dedup streams by creatorId if requested", async () => {
+        let res = await client.put("/stream/pull?key=creatorId", {
+          ...postMockPullStream,
+          creatorId: "0xjest",
+        });
+        expect(res.status).toBe(201);
+        const stream = await res.json();
+
+        res = await client.put("/stream/pull", {
+          ...postMockPullStream,
+          creatorId: "0xjest",
+          name: "updated_stream",
+          profiles: [],
+        });
+        expect(res.status).toBe(200);
+        const updatedStream = await res.json();
+        expect(updatedStream.id).toBe(stream.id);
+        expect(updatedStream.name).toBe("updated_stream");
+        expect(updatedStream.profiles).toEqual([]);
+
+        const document = await db.stream.get(stream.id);
+        expect(server.db.stream.addDefaultFields(document)).toEqual(
+          updatedStream
+        );
+      });
+
+      it("should wait for stream to become active if requested", async () => {
+        let responded = false;
+        const resProm = client.put(
+          "/stream/pull?waitActive=true",
+          postMockPullStream
+        );
+        resProm.then(() => (responded = true));
+
+        // give some time for API to create object in DB
+        await sleep(100);
+
+        const [streams] = await db.stream.find();
+        expect(streams).toHaveLength(1);
+        expect(streams[0].isActive).toBeFalsy();
+
+        // stream not active yet
+        expect(responded).toBe(false);
+
+        // set stream active
+        await db.stream.update(streams[0].id, { isActive: true });
+
+        const res = await resProm;
+        expect(responded).toBe(true); // make sure this works
+        expect(res.status).toBe(201);
+        const stream = await res.json();
+        expect(stream.id).toBe(streams[0].id);
+        expect(stream.isActive).toBe(true);
       });
     });
 

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1037,9 +1037,10 @@ app.put(
         ],
       });
     }
+    const streamExisted = streams.length === 1;
 
     let stream: DBStream;
-    if (!streams.length) {
+    if (!streamExisted) {
       stream = await handleCreateStream(req);
     } else {
       stream = {
@@ -1058,7 +1059,7 @@ app.put(
       await pollWaitStreamActive(req, stream.id);
     }
 
-    res.status(201);
+    res.status(streamExisted ? 200 : 201);
     res.json(
       db.stream.addDefaultFields(
         db.stream.removePrivateFields(stream, req.user.admin)

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -351,6 +351,8 @@ const fieldsMap: FieldsMap = {
   lastSeen: { val: `stream.data->'lastSeen'`, type: "int" },
   createdAt: { val: `stream.data->'createdAt'`, type: "int" },
   userId: `stream.data->>'userId'`,
+  creatorId: `stream.data->'creatorId'->>'value'`,
+  "pull.source": `stream.data->'pull'->>'source'`,
   isActive: { val: `stream.data->'isActive'`, type: "boolean" },
   "user.email": { val: `users.data->>'email'`, type: "full-text" },
   parentId: `stream.data->>'parentId'`,

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1010,7 +1010,6 @@ app.post(
 );
 
 const pullStreamKeyAccessors: Record<string, string[]> = {
-  name: ["name"],
   creatorId: ["creatorId", "value"],
   "pull.source": ["pull", "source"],
 };

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -68,7 +68,7 @@ const MAX_WAIT_STREAM_ACTIVE = 2 * 60 * 1000; // 2 min
 // from the stream that are not specified in the PUT payload.
 const EMPTY_NEW_STREAM_PAYLOAD: Required<
   Omit<
-    NewStreamPayload,
+    NewStreamPayload & { creatorId: undefined },
     // omit all the db-schema fields
     | "wowza"
     | "presets"
@@ -1076,11 +1076,11 @@ app.put(
       stream = {
         ...streams[0],
         ...EMPTY_NEW_STREAM_PAYLOAD, // clear all fields that should be set from the payload
-        profiles: req.config.defaultStreamProfiles, // fallback to default profiles if not specified in payload
         ...payload,
-        creatorId: mapInputCreatorId(payload.creatorId),
       };
       await db.stream.replace(stream);
+      // read from DB again to keep exactly what got saved
+      stream = await db.stream.get(stream.id, { useReplica: false });
     }
 
     await TODOtriggerCatalystPullStart(stream);

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -966,7 +966,11 @@ app.put(
     }
 
     const [streams] = await db.stream.find(
-      [sql`data->'pull'->>'source' = ${payload.pull.source}`],
+      [
+        sql`data->>'userId' = ${req.user.id}`,
+        sql`data->>'deleted' IS NULL`,
+        sql`data->'pull'->>'source' = ${payload.pull.source}`,
+      ],
       { useReplica: false }
     );
     if (streams.length > 1) {
@@ -1012,7 +1016,11 @@ app.post(
       }
 
       const [streams] = await db.stream.find(
-        [sql`data->'pull'->>'source' = ${payload.pull.source}`],
+        [
+          sql`data->>'userId' = ${req.user.id}`,
+          sql`data->>'deleted' IS NULL`,
+          sql`data->'pull'->>'source' = ${payload.pull.source}`,
+        ],
         { useReplica: false }
       );
 

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -253,7 +253,7 @@ async function pollWaitStreamActive(req: Request, id: string) {
       throw new NotFoundError("stream not found");
     }
     if (stream.isActive) {
-      return;
+      return stream;
     }
 
     await sleep(sleepDelay);
@@ -1086,7 +1086,7 @@ app.put(
     await TODOtriggerCatalystPullStart(stream);
 
     if (waitActive === "true") {
-      await pollWaitStreamActive(req, stream.id);
+      stream = await pollWaitStreamActive(req, stream.id);
     }
 
     res.status(streamExisted ? 200 : 201);

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -1806,6 +1806,7 @@ components:
                 - unverified
             value:
               type: string
+              index: true
               description:
                 Developer-managed ID of the user who created the resource.
     export-task-params:

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -1816,7 +1816,6 @@ components:
                 - unverified
             value:
               type: string
-              index: true
               description:
                 Developer-managed ID of the user who created the resource.
     export-task-params:

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -436,6 +436,9 @@ components:
                 Approximate location of the pull source. The location is used to
                 determine the closest Livepeer region to pull the stream from.
               additionalProperties: false
+              required:
+                - lat
+                - lon
               properties:
                 lat:
                   type: number

--- a/packages/api/src/schema/db-schema.yaml
+++ b/packages/api/src/schema/db-schema.yaml
@@ -798,6 +798,11 @@ components:
           $ref: "#/components/schemas/stream/properties/objectStoreId"
         detection:
           $ref: "#/components/schemas/stream/properties/detection"
+    creator-id:
+      oneOf:
+        - properties:
+            value:
+              index: true
     playback-policy:
       properties:
         type:

--- a/packages/api/src/store/asset-table.test.ts
+++ b/packages/api/src/store/asset-table.test.ts
@@ -12,6 +12,7 @@ describe("assets table", () => {
     );
     const indexes = res.rows?.map((r: any) => r.indexname).sort();
     expect(indexes).toEqual([
+      "asset_creatorId_value",
       "asset_id",
       "asset_playbackId",
       "asset_playbackRecordingId",


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This creates a separate `PUT /stream/pull` API to replace the `autoStartPull` query-string
that had been created on the regular creation API initially.

This is because the semantics expected from this pull API are now becoming very different
from the regular POST-based Create Stream API that we have today. Specifically, the 2 new
requirements are:
- It should update the stream object if it already exists
- It should block the request until the stream actually starts on the media server

Since blocking a connection is a non-standard and non-recommended behavior, that part
was still kept under a query-string. So this API has 2 possible idempotence results:
- If `waitActive` is NOT specified: when the API succeeds, the stream is guaranteed to be created and the pull to have been triggered.
- If `waitActive` IS specified: when the API succeeds, the stream is guaranteed to be created, the pull triggered, and the media server already started the stream.

In both cases, if a stream with the same `pull.source` already existed, it will have been updated
and then triggered to start.

One caveat is that we make no checks about the stream _already_ being active when this API is called.
In that case, the media server won't actually update the configuration of the ongoing stream, so it is an
exception to the idempotence aimed by this API. We can think of alternatives, like returning an error when
the stream is already active, similar to the PATCH API, but it depends on what the design partner for this
feature expects from this API.

Also notice that I ended up preferring not to use this: https://github.com/livepeer/livepeer-data/pull/180
Doing a simpler poll on the DB instead for the `stream.isActive` field.

**Specific updates (required)**
- Abstract the "create stream" logic from the existing API into a helper, to be reusable in the new API
- Create separate `PUT /stream/pull` API
- Implement logic to update stream object based on PUT payload
- Implement logic to wait for stream to become active

**How did you test each of these updates (required)**
The pull logic on Catalyst is not implement yet so it's not really possible to test it. Mostly tested calling the API itself.

**Does this pull request close any open issues?**
Implements latest requirements here https://discord.com/channels/423160867534929930/1201860223652859986/1201860228413399040

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
