### PR TITLE
fix: fix broadcasting

### DIFF
--- a/packages/www/hooks/use-api/index.tsx
+++ b/packages/www/hooks/use-api/index.tsx
@@ -1,24 +1,24 @@
-import { User } from "@livepeer.studio/api";
+import { useState, useContext, createContext, useEffect } from "react";
 import jwt from "jsonwebtoken";
-import { createContext, useContext, useEffect, useState } from "react";
-import { isDevelopment, isStaging } from "../../lib/utils";
+import { User } from "@livepeer.studio/api";
+import { isStaging, isDevelopment } from "../../lib/utils";
+import { ApiState } from "./types";
+import { clearTokens, getRefreshToken, getStoredToken } from "./tokenStorage";
 import * as accessControlEndpointsFunctions from "./endpoints/accessControl";
 import * as apiTokenEndpointsFunctions from "./endpoints/apiToken";
 import * as assetEndpointsFunctions from "./endpoints/asset";
 import * as broadcasterEndpointsFunctions from "./endpoints/broadcaster";
-import * as clipEndpointsFunctions from "./endpoints/clip";
 import * as dataEndpointsFunctions from "./endpoints/data";
 import * as ingestEndpointsFunctions from "./endpoints/ingest";
 import * as multistreamEndpointsFunctions from "./endpoints/multistream";
 import * as objectStoreEndpointsFunctions from "./endpoints/objectStore";
 import * as sessionEndpointsFunctions from "./endpoints/session";
+import * as clipEndpointsFunctions from "./endpoints/clip";
 import * as streamEndpointsFunctions from "./endpoints/stream";
 import * as taskEndpointsFunctions from "./endpoints/task";
 import * as userEndpointsFunctions from "./endpoints/user";
 import * as versionEndpointsFunctions from "./endpoints/version";
 import * as webhookEndpointsFunctions from "./endpoints/webhook";
-import { clearTokens, getRefreshToken, getStoredToken } from "./tokenStorage";
-import { ApiState } from "./types";
 
 // Allow for manual overriding of the API server endopint
 export const getEndpoint = () => {
@@ -36,7 +36,7 @@ export const getEndpoint = () => {
   if (isDevelopment()) {
     return "http://localhost:3004";
   }
-  return "https://livepeer.studio";
+  return "";
 };
 
 const endpoint = getEndpoint();

--- a/packages/www/hooks/use-api/index.tsx
+++ b/packages/www/hooks/use-api/index.tsx
@@ -1,24 +1,24 @@
-import { useState, useContext, createContext, useEffect } from "react";
-import jwt from "jsonwebtoken";
 import { User } from "@livepeer.studio/api";
-import { isStaging, isDevelopment } from "../../lib/utils";
-import { ApiState } from "./types";
-import { clearTokens, getRefreshToken, getStoredToken } from "./tokenStorage";
+import jwt from "jsonwebtoken";
+import { createContext, useContext, useEffect, useState } from "react";
+import { isDevelopment, isStaging } from "../../lib/utils";
 import * as accessControlEndpointsFunctions from "./endpoints/accessControl";
 import * as apiTokenEndpointsFunctions from "./endpoints/apiToken";
 import * as assetEndpointsFunctions from "./endpoints/asset";
 import * as broadcasterEndpointsFunctions from "./endpoints/broadcaster";
+import * as clipEndpointsFunctions from "./endpoints/clip";
 import * as dataEndpointsFunctions from "./endpoints/data";
 import * as ingestEndpointsFunctions from "./endpoints/ingest";
 import * as multistreamEndpointsFunctions from "./endpoints/multistream";
 import * as objectStoreEndpointsFunctions from "./endpoints/objectStore";
 import * as sessionEndpointsFunctions from "./endpoints/session";
-import * as clipEndpointsFunctions from "./endpoints/clip";
 import * as streamEndpointsFunctions from "./endpoints/stream";
 import * as taskEndpointsFunctions from "./endpoints/task";
 import * as userEndpointsFunctions from "./endpoints/user";
 import * as versionEndpointsFunctions from "./endpoints/version";
 import * as webhookEndpointsFunctions from "./endpoints/webhook";
+import { clearTokens, getRefreshToken, getStoredToken } from "./tokenStorage";
+import { ApiState } from "./types";
 
 // Allow for manual overriding of the API server endopint
 export const getEndpoint = () => {
@@ -36,7 +36,7 @@ export const getEndpoint = () => {
   if (isDevelopment()) {
     return "http://localhost:3004";
   }
-  return "";
+  return "https://livepeer.studio";
 };
 
 const endpoint = getEndpoint();

--- a/packages/www/pages/_app.tsx
+++ b/packages/www/pages/_app.tsx
@@ -1,31 +1,29 @@
-import Head from "next/head";
-import { DefaultSeo } from "next-seo";
-import SEO from "../next-seo.config";
-import { ApiProvider } from "hooks/use-api";
-import { AnalyzerProvider } from "hooks/use-analyzer";
-import { QueryClient, QueryClientProvider } from "react-query";
-import { MetaMaskProvider } from "metamask-react";
-import "../css/recaptcha.css";
-import "../css/markdown.css";
-import React from "react";
 import {
-  globalCss,
-  getThemes,
-  SnackbarProvider,
   DesignSystemProvider,
+  SnackbarProvider,
+  getThemes,
+  globalCss,
 } from "@livepeer/design-system";
-import { ThemeProvider } from "next-themes";
-import { DEFAULT_THEME } from "../lib/theme";
 import {
-  createReactClient,
   LivepeerConfig,
-  studioProvider,
   ThemeConfig,
+  createReactClient,
+  studioProvider,
 } from "@livepeer/react";
-import "../css/hubspot.scss";
-import { isStaging } from "lib/utils";
-import { getEndpoint } from "../hooks/use-api";
+import { AnalyzerProvider } from "hooks/use-analyzer";
+import { ApiProvider } from "hooks/use-api";
+import { isDevelopment, isStaging } from "lib/utils";
+import { MetaMaskProvider } from "metamask-react";
+import { DefaultSeo } from "next-seo";
+import { ThemeProvider } from "next-themes";
+import Head from "next/head";
 import Script from "next/script";
+import { QueryClient, QueryClientProvider } from "react-query";
+import "../css/hubspot.scss";
+import "../css/markdown.css";
+import "../css/recaptcha.css";
+import { DEFAULT_THEME } from "../lib/theme";
+import SEO from "../next-seo.config";
 
 const queryClient = new QueryClient();
 
@@ -66,6 +64,25 @@ const themeMap = {};
 Object.keys(themes).map(
   (key, _index) => (themeMap[themes[key].className] = themes[key].className)
 );
+
+// Allow for manual overriding of the API server endopint
+const getEndpoint = () => {
+  try {
+    const override = localStorage.getItem("LP_API_SERVER_OVERRIDE");
+    if (typeof override === "string") {
+      return override;
+    }
+  } catch (e) {
+    // not found, no problem
+  }
+  if (process.env.NEXT_PUBLIC_USE_STAGING_ENDPOINT === "true" || isStaging()) {
+    return "https://livepeer.monster";
+  }
+  if (isDevelopment()) {
+    return "http://localhost:3004";
+  }
+  return "https://livepeer.studio";
+};
 
 const livepeerClient = createReactClient({
   provider: studioProvider({


### PR DESCRIPTION
This fixes broadcasting by changing the endpoint for WebRTC to be a full URL, as opposed to a relative path.

This commit broke Studio's broadcasting config, and it now expects a full URL and is failing on that: https://github.com/livepeer/livepeer-react/blame/04c040398b917e8d528b00c98c7b350aa0ab6ace/packages/core-web/src/media/browser/webrtc/shared.ts#L267