### PR TITLE
api: Add createdByTokenName field to assets

### DIFF
--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -81,7 +81,7 @@ function isPrivatePlaybackPolicy(playbackPolicy: PlaybackPolicy) {
 export const primaryStorageExperiment = "primary-vod-storage";
 
 export async function defaultObjectStoreId(
-  { config, body, user }: Request,
+  { config, body, user }: Pick<Request, "config" | "body" | "user">,
   isOldPipeline?: boolean
 ): Promise<string> {
   if (isOldPipeline) {
@@ -182,15 +182,15 @@ function parseUrlToDStorageUrl(
 }
 
 export async function validateAssetPayload(
+  req: Pick<Request, "body" | "user" | "config">,
   id: string,
   playbackId: string,
-  userId: string,
   createdAt: number,
-  defaultObjectStoreId: string,
-  config: CliArgs,
-  payload: NewAssetPayload,
   source: Asset["source"]
 ): Promise<WithID<Asset>> {
+  const userId = req.user.id;
+  const payload = req.body as NewAssetPayload;
+
   if (payload.objectStoreId) {
     const os = await getActiveObjectStore(payload.objectStoreId);
     if (os.userId !== userId) {
@@ -210,7 +210,7 @@ export async function validateAssetPayload(
 
   // Transform IPFS and Arweave gateway URLs into native protocol URLs
   if (source.type === "url") {
-    const dStorageUrl = parseUrlToDStorageUrl(source.url, config);
+    const dStorageUrl = parseUrlToDStorageUrl(source.url, req.config);
 
     if (dStorageUrl) {
       source = {
@@ -235,7 +235,7 @@ export async function validateAssetPayload(
     staticMp4: payload.staticMp4,
     creatorId: mapInputCreatorId(payload.creatorId),
     playbackPolicy,
-    objectStoreId: payload.objectStoreId || defaultObjectStoreId,
+    objectStoreId: payload.objectStoreId || (await defaultObjectStoreId(req)),
     storage: storageInputToState(payload.storage),
   };
 }
@@ -791,16 +791,11 @@ const uploadWithUrlHandler: RequestHandler = async (req, res) => {
 
   const id = uuid();
   const playbackId = await generateUniquePlaybackId(id);
-  const newAsset = await validateAssetPayload(
-    id,
-    playbackId,
-    req.user.id,
-    Date.now(),
-    await defaultObjectStoreId(req),
-    req.config,
-    req.body,
-    { type: "url", url, encryption: assetEncryptionWithoutKey(encryption) }
-  );
+  const newAsset = await validateAssetPayload(req, id, playbackId, Date.now(), {
+    type: "url",
+    url,
+    encryption: assetEncryptionWithoutKey(encryption),
+  });
   const dupAsset = await db.asset.findDuplicateUrlUpload(url, req.user.id);
   if (dupAsset) {
     const [task] = await db.task.find({ outputAssetId: dupAsset.id });
@@ -871,19 +866,10 @@ app.post(
       }
     }
 
-    let asset = await validateAssetPayload(
-      id,
-      playbackId,
-      req.user.id,
-      Date.now(),
-      await defaultObjectStoreId(req),
-      req.config,
-      req.body,
-      {
-        type: "directUpload",
-        encryption: assetEncryptionWithoutKey(encryption),
-      }
-    );
+    let asset = await validateAssetPayload(req, id, playbackId, Date.now(), {
+      type: "directUpload",
+      encryption: assetEncryptionWithoutKey(encryption),
+    });
 
     const { uploadToken, downloadUrl } = await genUploadUrl(
       playbackId,

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -182,7 +182,7 @@ function parseUrlToDStorageUrl(
 }
 
 export async function validateAssetPayload(
-  req: Pick<Request, "body" | "user" | "config">,
+  req: Pick<Request, "body" | "user" | "token" | "config">,
   id: string,
   playbackId: string,
   createdAt: number,
@@ -226,6 +226,7 @@ export async function validateAssetPayload(
     playbackId,
     userId,
     createdAt,
+    createdByTokenName: req.token?.name,
     status: {
       phase: source.type === "directUpload" ? "uploading" : "waiting",
       updatedAt: createdAt,

--- a/packages/api/src/controllers/clip.ts
+++ b/packages/api/src/controllers/clip.ts
@@ -169,15 +169,17 @@ app.post(
     }
 
     let asset = await validateAssetPayload(
+      {
+        // set custom payload and user for the clip
+        body: {
+          name: req.body.name || `clip-${uPlaybackId}`,
+        },
+        user: owner,
+        config: req.config,
+      },
       id,
       uPlaybackId,
-      owner.id,
       Date.now(),
-      await defaultObjectStoreId(req),
-      req.config,
-      {
-        name: req.body.name || `clip-${uPlaybackId}`,
-      },
       {
         type: "clip",
         playbackId,

--- a/packages/api/src/controllers/clip.ts
+++ b/packages/api/src/controllers/clip.ts
@@ -175,6 +175,7 @@ app.post(
           name: req.body.name || `clip-${uPlaybackId}`,
         },
         user: owner,
+        token: req.token,
         config: req.config,
       },
       id,

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1196,7 +1196,6 @@ async function handleCreateStream(req: Request) {
     streamKey,
     playbackId,
     createdByTokenName: req.token?.name,
-    createdByTokenId: req.token?.id,
     isActive: false,
     lastSeen: 0,
   };

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -1010,6 +1010,10 @@ components:
           type: number
           description: Timestamp (in milliseconds) at which asset was created
           example: 1587667174725
+        createdByTokenName:
+          type: string
+          readOnly: true
+          description: Name of the token used to create this object
         size:
           readOnly: true
           type: number


### PR DESCRIPTION
This is needed to do some analytics on how many assets are being created with API keys or from the dashboard.

Additional changes:
- Did some cleanup on `validateAssetPayload` to avoid it growing indefinitely
- Removed the `createdByTokenId` from streams which just increases our leakage risk (API keys IDs are the keys themselves)