### PR TITLE
api: Implement MVP of stream pull trigger

### DIFF
--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -644,7 +644,7 @@ export const triggerCatalystPullStart = async (
   stream: DBStream,
   playbackUrl: string
 ) => {
-  // TODO: use stream.location field to call catalyst on the closest region.
+  // TODO: use pull.location field to call catalyst on the closest region.
   // Ideally by calling catalyst-api/catabalancer and letting it figure it out.
 
   // Instead of the above, for now just access the stream playbackUrl to trigger

--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -640,38 +640,38 @@ export function isValidBase64(str: string) {
   }
 }
 
-export const triggerCatalystPullStart = async (
-  stream: DBStream,
-  playbackUrl: string
-) => {
-  // TODO: use pull.location field to call catalyst on the closest region.
-  // Ideally by calling catalyst-api/catabalancer and letting it figure it out.
+export const triggerCatalystPullStart =
+  process.env.NODE_ENV === "test"
+    ? async () => {} // noop in case of tests
+    : async (stream: DBStream, playbackUrl: string) => {
+        // TODO: use pull.location field to call catalyst on the closest region.
+        // Ideally by calling catalyst-api/catabalancer and letting it figure it out.
 
-  // Instead of the above, for now just access the stream playbackUrl to trigger
-  // the pull to start.
-  const deadline = Date.now() + 2 * PULL_START_TIMEOUT;
-  while (Date.now() < deadline) {
-    const res = await fetchWithTimeoutAndRedirects(playbackUrl, {
-      method: "GET",
-      timeout: PULL_START_TIMEOUT,
-      maxRedirects: 10,
-    });
-    if (res.ok) {
-      return;
-    }
+        // Instead of the above, for now just access the stream playbackUrl to trigger
+        // the pull to start.
+        const deadline = Date.now() + 2 * PULL_START_TIMEOUT;
+        while (Date.now() < deadline) {
+          const res = await fetchWithTimeoutAndRedirects(playbackUrl, {
+            method: "GET",
+            timeout: PULL_START_TIMEOUT,
+            maxRedirects: 10,
+          });
+          if (res.ok) {
+            return;
+          }
 
-    logger.warn(
-      `failed to trigger catalyst pull for stream=${
-        stream.id
-      } playbackUrl=${playbackUrl} status=${res.status} error=${JSON.stringify(
-        await res.text()
-      )}`
-    );
-    await sleep(1000);
-  }
+          logger.warn(
+            `failed to trigger catalyst pull for stream=${
+              stream.id
+            } playbackUrl=${playbackUrl} status=${
+              res.status
+            } error=${JSON.stringify(await res.text())}`
+          );
+          await sleep(1000);
+        }
 
-  throw new Error(`failed to trigger catalyst pull`);
-};
+        throw new Error(`failed to trigger catalyst pull`);
+      };
 
 export const triggerCatalystStreamNuke = (req: Request, playback_id: string) =>
   triggerCatalystEvent(req, { resource: "nuke", playback_id });

--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -14,9 +14,12 @@ import { CreatorId, InputCreatorId, ObjectStore, User } from "../schema/types";
 import { BadRequestError } from "../store/errors";
 import * as nativeCrypto from "crypto";
 import { DBStream } from "../store/stream-table";
+import { fetchWithTimeoutAndRedirects } from "../util";
+import logger from "../logger";
 
 const ITERATIONS = 10000;
 const PAYMENT_FAILED_TIMEFRAME = 3 * 24 * 60 * 60 * 1000;
+const PULL_START_TIMEOUT = 60 * 1000;
 
 const crypto = new Crypto();
 
@@ -637,8 +640,35 @@ export function isValidBase64(str: string) {
   }
 }
 
-export const TODOtriggerCatalystPullStart = async (stream: DBStream) => {
-  // TODO: trigger pull start on catalyst
+export const triggerCatalystPullStart = async (
+  stream: DBStream,
+  playbackUrl: string
+) => {
+  // TODO: use stream.location field to call catalyst on the closest region.
+  // Ideally by calling catalyst-api/catabalancer and letting it figure it out.
+
+  // Instead of the above, for now just access the stream playbackUrl to trigger
+  // the pull to start.
+  const deadline = Date.now() + 2 * PULL_START_TIMEOUT;
+  while (Date.now() < deadline) {
+    const res = await fetchWithTimeoutAndRedirects(playbackUrl, {
+      method: "GET",
+      timeout: PULL_START_TIMEOUT,
+    });
+    if (res.ok) {
+      return;
+    }
+
+    logger.warn(
+      `failed to trigger catalyst pull for stream=${
+        stream.id
+      } playbackUrl=${playbackUrl} status=${res.status} error=${JSON.stringify(
+        await res.text()
+      )}`
+    );
+  }
+
+  throw new Error(`failed to trigger catalyst pull`);
 };
 
 export const triggerCatalystStreamNuke = (req: Request, playback_id: string) =>

--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -14,7 +14,7 @@ import { CreatorId, InputCreatorId, ObjectStore, User } from "../schema/types";
 import { BadRequestError } from "../store/errors";
 import * as nativeCrypto from "crypto";
 import { DBStream } from "../store/stream-table";
-import { fetchWithTimeoutAndRedirects } from "../util";
+import { fetchWithTimeoutAndRedirects, sleep } from "../util";
 import logger from "../logger";
 
 const ITERATIONS = 10000;
@@ -667,6 +667,7 @@ export const triggerCatalystPullStart = async (
         await res.text()
       )}`
     );
+    await sleep(1000);
   }
 
   throw new Error(`failed to trigger catalyst pull`);

--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -656,7 +656,9 @@ export const triggerCatalystPullStart =
             timeout: PULL_START_TIMEOUT,
             maxRedirects: 10,
           });
-          if (res.ok) {
+          const body = await res.text();
+          const isHlsErr = body.includes("#EXT-X-ERROR: Stream open failed");
+          if (res.ok && !isHlsErr) {
             return;
           }
 
@@ -665,7 +667,7 @@ export const triggerCatalystPullStart =
               stream.id
             } playbackUrl=${playbackUrl} status=${
               res.status
-            } error=${JSON.stringify(await res.text())}`
+            } error=${JSON.stringify(body)}`
           );
           await sleep(1000);
         }

--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -654,6 +654,7 @@ export const triggerCatalystPullStart = async (
     const res = await fetchWithTimeoutAndRedirects(playbackUrl, {
       method: "GET",
       timeout: PULL_START_TIMEOUT,
+      maxRedirects: 10,
     });
     if (res.ok) {
       return;

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -44,7 +44,7 @@ import {
   mapInputCreatorId,
   triggerCatalystStreamUpdated,
   triggerCatalystStreamNuke,
-  TODOtriggerCatalystPullStart,
+  triggerCatalystPullStart,
 } from "./helpers";
 import wowzaHydrate from "./wowza-hydrate";
 import Queue from "../store/queue";
@@ -1082,7 +1082,8 @@ app.put(
       stream = await db.stream.get(stream.id, { useReplica: false });
     }
 
-    await TODOtriggerCatalystPullStart(stream);
+    const ingest = await getIngestBase(req);
+    await triggerCatalystPullStart(stream, getHLSPlaybackUrl(ingest, stream));
 
     if (waitActive === "true") {
       stream = await pollWaitStreamActive(req, stream.id);
@@ -1128,7 +1129,11 @@ app.post(
 
       if (streams.length === 1) {
         const stream = streams[0];
-        await TODOtriggerCatalystPullStart(stream);
+        const ingest = await getIngestBase(req);
+        await triggerCatalystPullStart(
+          stream,
+          getHLSPlaybackUrl(ingest, stream)
+        );
 
         return res
           .status(200)
@@ -1149,7 +1154,8 @@ app.post(
     const stream = await handleCreateStream(req);
 
     if (autoStartPull === "true") {
-      await TODOtriggerCatalystPullStart(stream);
+      const ingest = await getIngestBase(req);
+      await triggerCatalystPullStart(stream, getHLSPlaybackUrl(ingest, stream));
     }
 
     res.status(201);
@@ -1920,7 +1926,8 @@ app.post(
       return res.json({ errors: ["stream does not have a pull source"] });
     }
 
-    await TODOtriggerCatalystPullStart(stream);
+    const ingest = await getIngestBase(req);
+    await triggerCatalystPullStart(stream, getHLSPlaybackUrl(ingest, stream));
 
     res.status(204).end();
   }

--- a/packages/api/src/util.ts
+++ b/packages/api/src/util.ts
@@ -1,6 +1,11 @@
 import fetch, { RequestInit, Response } from "node-fetch";
+
 export interface RequestInitWithTimeout extends RequestInit {
   timeout?: number;
+}
+
+export interface RequestInitWithRedirects extends RequestInitWithTimeout {
+  maxRedirects?: number;
 }
 
 export const timeout = <T>(ms: number, fn: () => Promise<T>) => {
@@ -86,59 +91,31 @@ export const fetchWithTimeout = (
 
 export const fetchWithTimeoutAndRedirects = async (
   url: string,
-  options: RequestInitWithTimeout,
-  redirectCount = 5
+  options: RequestInitWithRedirects
 ): Promise<Response> => {
+  const { maxRedirects = 5 } = options;
+
   // Throw error if maximum number of redirects has been exceeded
-  if (redirectCount < 0) {
+  if (maxRedirects < 0) {
     throw new Error("Maximum number of redirects exceeded");
   }
 
   options = { ...options, redirect: "manual" };
 
-  return new Promise<Response>((resolve, reject) => {
-    let timeout = setTimeout(() => {
-      timeout = null;
-      reject("timeout");
-    }, options.timeout || 10 * 1000);
+  const response = await fetchWithTimeout(url, options);
+  if (response.status < 300 || response.status >= 400) {
+    return response;
+  }
 
-    fetch(url, options).then(
-      async (response) => {
-        if (timeout === null) {
-          // already timed out
-          return;
-        }
+  // Handle redirects
+  const newUrl = response.headers.get("location");
+  if (!newUrl) {
+    throw new Error("Redirect with no location");
+  }
 
-        clearTimeout(timeout);
-
-        // Handle redirects
-        if (response.status >= 300 && response.status < 400) {
-          const newUrl = response.headers.get("location");
-          if (!newUrl) {
-            reject("Redirect with no location");
-            return;
-          }
-
-          const newResponse = await fetchWithTimeoutAndRedirects(
-            newUrl,
-            options,
-            redirectCount - 1
-          );
-          resolve(newResponse);
-        } else {
-          resolve(response);
-        }
-      },
-      (rejectReason) => {
-        if (timeout === null) {
-          // already timed out
-          return;
-        }
-
-        clearTimeout(timeout);
-        reject(rejectReason);
-      }
-    );
+  return await fetchWithTimeoutAndRedirects(newUrl, {
+    ...options,
+    maxRedirects: maxRedirects - 1,
   });
 };
 


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This implements the simplest form of triggering a stream to start pulling, by making a
call to the stream `playbackUrl` after creating the stream.

The main missing feature here would be using the `pull.location` field to call the Catalyst
instance closest to the pull location. This might be implemented later through a Catalyst
API in `catalyst-api` instead, so Studio doesn't need to track the state of the serf cluster
to know what nodes are online.

**Specific updates (required)**
- Refactored the `fetchWithTimeoutAndRedirects` function as I was reading it to understand the logic
- Implemented `triggerCatalystPullStart` for real with some TODO/comments for context

**How did you test each of these updates (required)**
`yarn test`

**Does this pull request close any open issues?**
Implements ENG-1569

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
