### PR TITLE
ci: add bucket upload of builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -166,3 +166,69 @@ jobs:
         with:
           name: release-artifacts
           path: releases/
+
+  upload:
+    name: Upload artifacts to google bucket
+    if:
+      ${{ github.event.pull_request.head.repo.full_name ==
+      github.event.pull_request.base.repo.full_name }}
+    permissions:
+      contents: "read"
+      id-token: "write"
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: release-artifacts
+          path: releases/
+
+      - name: Generate sha256 checksum and gpg signatures for release artifacts
+        uses: livepeer/action-gh-checksum-and-gpg-sign@latest
+        with:
+          artifacts-dir: releases
+          release-name:
+            ${{ github.ref_type == 'tag' && github.ref_name ||
+            github.event.pull_request.head.sha || github.sha }}
+          gpg-key: ${{ secrets.CI_GPG_SIGNING_KEY }}
+          gpg-key-passphrase: ${{ secrets.CI_GPG_SIGNING_PASSPHRASE }}
+
+      - name: Generate branch manifest
+        id: branch-manifest
+        uses: livepeer/branch-manifest-action@latest
+        with:
+          project-name: ${{ github.event.repository.name }}
+          platform: linux, darwin
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider:
+            ${{ secrets.CI_GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.CI_GOOGLE_SERVICE_ACCOUNT }}
+
+      - name: Upload release archives to Google Cloud
+        id: upload-archives
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: "releases"
+          destination:
+            "build.livepeer.live/${{ github.event.repository.name }}/${{
+            (github.ref_type == 'tag' && github.ref_name) ||
+            github.event.pull_request.head.sha || github.sha }}"
+          parent: false
+
+      - name: Upload branch manifest file
+        id: upload-manifest
+        uses: google-github-actions/upload-cloud-storage@v1
+        with:
+          path: ${{ steps.branch-manifest.outputs.manifest-file }}
+          destination:
+            "build.livepeer.live/${{ github.event.repository.name }}/"
+          parent: false
+
+      - name: Notify new build upload
+        run: curl -X POST https://holy-bread-207a.livepeer.workers.dev

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -178,6 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+      - macos
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v3


### PR DESCRIPTION
So we don't need to do new releases to get them in Catalyst.

Shockingly, this worked by copying the "upload" phase from catalyst-api with a one-line change to add a "macos" requirement. Neat!