### PR TITLE
api: webhook: allow additional headers & payload to be sent in webhooks

### DIFF
--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -468,6 +468,12 @@ components:
           description: Used to form playback URL
         playbackPolicy:
           $ref: "#/components/schemas/playback-policy"
+        isTrovoAuth:
+          type: boolean
+          readOnly: true
+          description: >-
+            Wether the stream is authenticated by Trovo. If true, any webhook
+            policy will include the Trovo Auth header
         profiles:
           type: array
           default:
@@ -863,6 +869,12 @@ components:
           description: URL to manually download the asset if desired
         playbackPolicy:
           $ref: "#/components/schemas/playback-policy"
+        isTrovoAuth:
+          type: boolean
+          readOnly: true
+          description: >-
+            Wether the stream is authenticated by Trovo. If true, any webhook
+            policy will include the Trovo Auth header
         source:
           oneOf:
             - additionalProperties: false

--- a/packages/api/src/schema/db-schema.yaml
+++ b/packages/api/src/schema/db-schema.yaml
@@ -21,6 +21,13 @@ components:
         accessKey:
           type: string
           description: Access key used for access-control verification
+        webhookPayload:
+          type: object
+          description:
+            Payload to be sent in the body of the request to the webhook
+        webhookHeaders:
+          type: object
+          description: Headers to be used in the request to the webhook
     object-store-patch-payload:
       type: object
       additionalProperties: false


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Allow catalyst to specify two new objects when calling Studio gate
- `webhookPayload`
- `webhookHeaders` 
They will get appended to the JSON payload and the headers respectively when doing a webhook request for access control to an external party

Also added `Trovo-Auth-Version: 1.1` as header to any webhook fired for a stream created via the `pull` api

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional)**

<!-- Drag some screenshots here, if applicable -->

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
