### PR TITLE
Correct values for 'encoder' in Profiles

### DIFF
--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -70,10 +70,10 @@ components:
         encoder:
           type: string
           enum:
-            - h264
-            - hevc
-            - vp8
-            - vp9
+            - H.264
+            - HEVC
+            - VP8
+            - VP9
     transcode-profile:
       type: object
       description: Transcode API profile

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -119,10 +119,10 @@ components:
         encoder:
           type: string
           enum:
-            - h264
-            - hevc
-            - vp8
-            - vp9
+            - H.264
+            - HEVC
+            - VP8
+            - VP9
     webhook:
       type: object
       required:


### PR DESCRIPTION
The current values are not the same as the ones used in the transcode layer (Broadcaster / Orchestrator) and so attempting to use these values in a Profile will cause a failed transcode.