### PR TITLE
Unsuspend stream with a new call to /pull

### DIFF
--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1080,9 +1080,9 @@ app.put(
       stream = {
         ...streams[0],
         ...EMPTY_NEW_STREAM_PAYLOAD, // clear all fields that should be set from the payload
+        suspended: false,
         ...payload,
       };
-      stream.suspended = false;
       await db.stream.replace(stream);
       // read from DB again to keep exactly what got saved
       stream = await db.stream.get(stream.id, { useReplica: false });

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1082,6 +1082,7 @@ app.put(
         ...EMPTY_NEW_STREAM_PAYLOAD, // clear all fields that should be set from the payload
         ...payload,
       };
+      stream.suspended = false;
       await db.stream.replace(stream);
       // read from DB again to keep exactly what got saved
       stream = await db.stream.get(stream.id, { useReplica: false });


### PR DESCRIPTION
If a stream has been suspended we want to be able to start it back up on a new call to `/pull` so set to false here.