### PR TITLE
Switch terminate to a stop sessions

### DIFF
--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -43,7 +43,6 @@ import {
   toStringValues,
   mapInputCreatorId,
   triggerCatalystStreamUpdated,
-  triggerCatalystStreamNuke,
   triggerCatalystPullStart,
   triggerCatalystStreamStopSessions,
 } from "./helpers";
@@ -1927,8 +1926,8 @@ app.delete("/:id/terminate", authorizer({}), async (req, res) => {
   }
 
   // we don't want to update the stream object on the `/terminate` API, so we
-  // just throw a single nuke
-  await triggerCatalystStreamNuke(req, stream.playbackId);
+  // just throw a single stop call
+  await triggerCatalystStreamStopSessions(req, stream.playbackId);
 
   res.status(204).end();
 });


### PR DESCRIPTION
This is a much safer call, nuke is meant if stop sessions has not worked and we just want to do an ungraceful kill

