### PR TITLE
Increase webhook timeout 5s => 30s

### DIFF
--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -23,7 +23,7 @@ import { buildRecordingUrl } from "../controllers/session";
 import { isExperimentSubject } from "../store/experiment-table";
 import { WebhookLog } from "../schema/types";
 
-const WEBHOOK_TIMEOUT = 5 * 1000;
+const WEBHOOK_TIMEOUT = 30 * 1000;
 const MAX_BACKOFF = 60 * 60 * 1000;
 const BACKOFF_COEF = 2;
 const MAX_RETRIES = 33;


### PR DESCRIPTION
Context: Switchboard mentioned that the timeout is too low.

I don't see any issues with increasing the timeout to way higher value like 30s, this calls are not time-senitive in any sense IMO.

Another solution would be to allow users to specify their timeouts, but I'm not sure we need it right now.

@thomshutt @victorges @mjh1 I'm interested in your thoughts here.