### PR TITLE
lockPull: check isActive in the transaction and only by different nodes

### DIFF
--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1109,7 +1109,7 @@ app.post("/:id/lockPull", authorizer({ anyAdmin: true }), async (req, res) => {
       sql`id = ${stream.id}`,
       sql`data->>'pullLockedBy' = ${host} OR (COALESCE((data->>'pullLockedAt')::bigint,0) < ${
         Date.now() - leaseTimeout
-      } AND data->>'isActive::bool' = FALSE)`,
+      } AND COALESCE((data->>'isActive')::boolean,FALSE) = FALSE)`,
     ],
     { pullLockedAt: Date.now(), pullLockedBy: host },
     { throwIfEmpty: false }

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1107,9 +1107,9 @@ app.post("/:id/lockPull", authorizer({ anyAdmin: true }), async (req, res) => {
   const updateRes = await db.stream.update(
     [
       sql`id = ${stream.id}`,
-      sql`data->>'pullLockedBy' = ${host} OR (COALESCE((data->>'pullLockedAt')::bigint,0) < ${
+      sql`(data->>'pullLockedBy' = ${host} OR (COALESCE((data->>'pullLockedAt')::bigint,0) < ${
         Date.now() - leaseTimeout
-      } AND COALESCE((data->>'isActive')::boolean,FALSE) = FALSE)`,
+      } AND COALESCE((data->>'isActive')::boolean,FALSE) = FALSE))`,
     ],
     { pullLockedAt: Date.now(), pullLockedBy: host },
     { throwIfEmpty: false }


### PR DESCRIPTION
Change `isActive` inside the DB transaction, because:
- As @victorges pointed out in the other PR's comment, better to check it in the transaction
- We don't want to check it for the same host, otherwise we may have a race condition between setting isActive and locking pull (we want to lockPull only by other nodes)