### PR TITLE
api: Attempt processing recording up to 5 times

### DIFF
--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -482,7 +482,7 @@ export default class WebhookCannon {
 
   async handleRecordingWaitingChecks(
     sessionId: string,
-    isRetry = false
+    attempt = 1
   ): Promise<string> {
     const session = await db.session.get(sessionId, {
       useReplica: false,
@@ -497,13 +497,13 @@ export default class WebhookCannon {
       throw new UnprocessableEntityError("Session is unused");
     }
     if (lastSeen > activeThreshold) {
-      if (isRetry) {
+      if (attempt >= 5) {
         throw new UnprocessableEntityError("Session is still active");
       }
-      // there was an update after the delayed event was sent, so sleep a few
-      // secs (up to USER_SESSION_TIMEOUT) and re-check if it actually stopped.
+      // there was an update after the delayed event was sent, so sleep a few secs
+      // (up to 5s + USER_SESSION_TIMEOUT) and re-check if it actually stopped.
       await sleep(5000 + (lastSeen - activeThreshold));
-      return this.handleRecordingWaitingChecks(sessionId, true);
+      return this.handleRecordingWaitingChecks(sessionId, attempt + 1);
     }
 
     // if we got to this point, it means we're confident this session is inactive


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

We had only 1 retry and are seeing a couple errors in prod with sessions that don't
get processed on that time.

I believe `stream-info-service` is likely getting delayed and bumping the lastSeen of
the stream after it is done.

By increasing the amount of retries here, we effectively give more time for the system 
to stabilize and stop updating the stream that just stopped. It should mitigate some of
the errors, but the real fix is gonna be #2013 

**Specific updates (required)**
- Attempt processing recordings up to 5 times

**How did you test each of these updates (required)**
Nah

**Does this pull request close any open issues?**
Fixes PS-369 and PS-424

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
