### PR TITLE
fix: remove encodings from API schema

### DIFF
--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -23,7 +23,7 @@ components:
   schemas:
     ffmpeg-profile:
       type: object
-      description: LMPS ffmpeg profile
+      description: Transcode profile
       additionalProperties: false
       required:
         - width
@@ -71,9 +71,6 @@ components:
           type: string
           enum:
             - H.264
-            - HEVC
-            - VP8
-            - VP9
     transcode-profile:
       type: object
       description: Transcode API profile


### PR DESCRIPTION
Fixes https://linear.app/livepeer/issue/ENG-1853/fix-unsupported-profiles-in-api-reference