### PR TITLE
Add pullRegion to streams to make the ingest node sticky

### DIFF
--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -652,6 +652,9 @@ export const triggerCatalystPullStart =
           url.searchParams.set("lat", lat.toString());
           url.searchParams.set("lon", lon.toString());
           playbackUrl = url.toString();
+          console.log(
+            `triggering catalyst pull start for streamId=${stream.id} playbackId=${stream.playbackId} lat=${lat} lon=${lon} pullRegion=${stream.pullRegion}`
+          );
         }
 
         const deadline = Date.now() + 2 * PULL_START_TIMEOUT;

--- a/packages/api/src/controllers/stream.test.ts
+++ b/packages/api/src/controllers/stream.test.ts
@@ -728,7 +728,7 @@ describe("controllers/stream", () => {
           extractRegionFrom(
             "https://fra-staging-staging-catalyst-0.livepeer.monster:443/hls/video+not-used-playback/index.m3u8"
           )
-        ).toBe("fra");
+        ).toBe("fra-staging");
         expect(
           extractRegionFrom(
             "https://fra-staging-staging-catalyst-0.livepeer.monster:443/hls/video+other-playback/index.m3u8"

--- a/packages/api/src/controllers/stream.test.ts
+++ b/packages/api/src/controllers/stream.test.ts
@@ -23,6 +23,7 @@ import {
 import serverPromise, { TestServer } from "../test-server";
 import { semaphore, sleep } from "../util";
 import { generateUniquePlaybackId } from "./generate-keys";
+import { extractRegionFrom } from "./stream";
 
 const uuidRegex = /[0-9a-f]+(-[0-9a-f]+){4}/;
 
@@ -711,6 +712,28 @@ describe("controllers/stream", () => {
 
         const document = await db.stream.get(stream.id);
         expect(db.stream.addDefaultFields(document)).toEqual(updatedStream);
+      });
+      it("should extract region from redirected playback url", async () => {
+        expect(
+          extractRegionFrom(
+            "https://sto-prod-catalyst-0.lp-playback.studio:443/hls/video+not-used-playback/index.m3u8"
+          )
+        ).toBe("sto");
+        expect(
+          extractRegionFrom(
+            "https://mos2-prod-catalyst-0.lp-playback.studio:443/hls/video+not-used-playback/index.m3u8"
+          )
+        ).toBe("mos2");
+        expect(
+          extractRegionFrom(
+            "https://fra-staging-staging-catalyst-0.livepeer.monster:443/hls/video+not-used-playback/index.m3u8"
+          )
+        ).toBe("fra");
+        expect(
+          extractRegionFrom(
+            "https://fra-staging-staging-catalyst-0.livepeer.monster:443/hls/video+other-playback/index.m3u8"
+          )
+        ).toBe(null);
       });
     });
 

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1063,6 +1063,7 @@ app.put(
         ...oldStream,
         ...EMPTY_NEW_STREAM_PAYLOAD, // clear all fields that should be set from the payload
         suspended: false,
+        createdRegion: req.config.ownRegion,
         ...payload,
       };
       await db.stream.replace(stream);
@@ -1203,6 +1204,7 @@ async function handleCreateStream(req: Request) {
 
   const id = uuid();
   const createdAt = Date.now();
+  const createdRegion = req.config.ownRegion;
   // TODO: Don't create a streamKey if there's a pull source (here and on www)
   const streamKey = await generateUniqueStreamKey(id);
   let playbackId = await generateUniquePlaybackId(id, [streamKey]);
@@ -1230,6 +1232,7 @@ async function handleCreateStream(req: Request) {
     objectStoreId,
     id,
     createdAt,
+    createdRegion,
     streamKey,
     playbackId,
     createdByTokenName: req.token?.name,

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -252,6 +252,7 @@ async function resolvePullRegion(
     url.searchParams.set("lon", lon.toString());
   }
   const playbackUrl = url.toString();
+  // Send any playback request to catalyst-api, which effectively resolves the region using MistUtilLoad
   const response = await fetchWithTimeout(playbackUrl, { redirect: "manual" });
   if (response.status < 300 || response.status >= 400) {
     // not a redirect response, so we can't determine the region

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -265,7 +265,7 @@ async function resolvePullRegion(
 // Extracts region from redirected node URL, e.g. "sto" from "https://sto-prod-catalyst-0.lp-playback.studio:443/hls/video+foo/index.m3u8"
 export function extractRegionFrom(playbackUrl: string): string {
   const regionRegex =
-    /https?:\/\/(\w+)-.+-catalyst.+not-used-playback\/index.m3u8/;
+    /https?:\/\/(.+)-\w+-catalyst.+not-used-playback\/index.m3u8/;
   const matches = playbackUrl.match(regionRegex);
   return matches ? matches[1] : null;
 }

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1079,7 +1079,7 @@ app.put(
     let stream: DBStream;
     if (!streamExisted) {
       stream = await handleCreateStream(req);
-      stream.createdRegion = pullRegion;
+      stream.pullRegion = pullRegion;
       await db.stream.replace(stream);
     } else {
       const oldStream = streams[0];
@@ -1095,7 +1095,7 @@ app.put(
         ...oldStream,
         ...EMPTY_NEW_STREAM_PAYLOAD, // clear all fields that should be set from the payload
         suspended: false,
-        createdRegion: pullRegion,
+        pullRegion,
         ...payload,
       };
       await db.stream.replace(stream);

--- a/packages/api/src/schema/db-schema.yaml
+++ b/packages/api/src/schema/db-schema.yaml
@@ -688,6 +688,8 @@ components:
           type: object
         isActive:
           index: true
+        createdRegion:
+          type: string
         createdAt:
           index: true
         lastTerminatedAt:

--- a/packages/api/src/schema/db-schema.yaml
+++ b/packages/api/src/schema/db-schema.yaml
@@ -688,8 +688,6 @@ components:
           type: object
         isActive:
           index: true
-        createdRegion:
-          type: string
         createdAt:
           index: true
         lastTerminatedAt:
@@ -708,6 +706,8 @@ components:
           type: number
           example: 1587667174725
         pullLockedBy:
+          type: string
+        pullRegion:
           type: string
         playbackId:
           unique: true

--- a/packages/api/src/store/stream-table.ts
+++ b/packages/api/src/store/stream-table.ts
@@ -414,7 +414,7 @@ const adminOnlyFields = [
   "createdByTokenId",
   "pullLockedAt",
   "pullLockedBy",
-  "createdRegion",
+  "pullRegion",
 ];
 
 const privateFields = [

--- a/packages/api/src/store/stream-table.ts
+++ b/packages/api/src/store/stream-table.ts
@@ -414,6 +414,7 @@ const adminOnlyFields = [
   "createdByTokenId",
   "pullLockedAt",
   "pullLockedBy",
+  "createdRegion",
 ];
 
 const privateFields = [


### PR DESCRIPTION
This is the updated flow:
1. Fetch the region from Catalyst/Mist (effectively using MistUtilLoad to decide on region based on `stream.pull.location`)
2. Store this region in the stream object as `stream.pullRegion`
3. Use this region in catalyst-api (so if the it's being pulled by the wrong region, then it changes the region)

This way, we resolve region once in `/pull` and then re-use the same region for stream pulling. This should make some improvement in the ingest node, and what's even better, we can start logging that `(lat,lon)=>region`, and then have data to say if out method for choosing ingest node (`MistUtilLoad`) is correct.

One of the further idea would be to not use `MistUtilLoad`, but just always use the geographically closest node.

Related PRs:
- https://github.com/livepeer/go-api-client/pull/64
- https://github.com/livepeer/catalyst-api/pull/1215