### PR TITLE
Revert "Stick to the pull host while triggering the catalyst pull start"

### DIFF
--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -653,7 +653,7 @@ export const triggerCatalystPullStart =
           url.searchParams.set("lon", lon.toString());
           playbackUrl = url.toString();
           console.log(
-            `triggering catalyst pull start for streamId=${stream.id} playbackId=${stream.playbackId} lat=${lat} lon=${lon} pullRegion=${stream.pullRegion}, playbackUrl=${playbackUrl}`
+            `triggering catalyst pull start for streamId=${stream.id} playbackId=${stream.playbackId} lat=${lat} lon=${lon} pullRegion=${stream.pullRegion}`
           );
         }
 

--- a/packages/api/src/controllers/stream.test.ts
+++ b/packages/api/src/controllers/stream.test.ts
@@ -23,7 +23,7 @@ import {
 import serverPromise, { TestServer } from "../test-server";
 import { semaphore, sleep } from "../util";
 import { generateUniquePlaybackId } from "./generate-keys";
-import { extractHostFrom, extractRegionFrom } from "./stream";
+import { extractRegionFrom } from "./stream";
 
 const uuidRegex = /[0-9a-f]+(-[0-9a-f]+){4}/;
 
@@ -712,28 +712,6 @@ describe("controllers/stream", () => {
 
         const document = await db.stream.get(stream.id);
         expect(db.stream.addDefaultFields(document)).toEqual(updatedStream);
-      });
-      it("should extract host from redirected playback url", async () => {
-        expect(
-          extractHostFrom(
-            "https://sto-prod-catalyst-0.lp-playback.studio:443/hls/video+not-used-playback/index.m3u8"
-          )
-        ).toBe("https://sto-prod-catalyst-0.lp-playback.studio:443");
-        expect(
-          extractHostFrom(
-            "https://mos2-prod-catalyst-0.lp-playback.studio:443/hls/video+not-used-playback/index.m3u8"
-          )
-        ).toBe("https://mos2-prod-catalyst-0.lp-playback.studio:443");
-        expect(
-          extractHostFrom(
-            "https://fra-staging-staging-catalyst-0.livepeer.monster:443/hls/video+not-used-playback/index.m3u8"
-          )
-        ).toBe("https://fra-staging-staging-catalyst-0.livepeer.monster:443");
-        expect(
-          extractHostFrom(
-            "https://fra-staging-staging-catalyst-0.livepeer.monster:443/hls/video+other-playback/index.m3u8"
-          )
-        ).toBe(null);
       });
       it("should extract region from redirected playback url", async () => {
         expect(


### PR DESCRIPTION
Testing in staging I see a regression that for some reason `STREAM_BUFFER` is triggered multiple times. Not sure how it's possible that it's related, but reverting this PR.

Reverts livepeer/studio#2138