### PR TITLE
api: Query isHealthy field as a string to handle JSOnull

### DIFF
--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -523,6 +523,13 @@ function parseFiltersRaw(fieldsMap: FieldsMap, val: string): SQLStatement[] {
         q.push(sql``.append(fv).append(sql` = ${filter.value}`));
       } else if (fv.val) {
         if (fv.type === "boolean") {
+          if (typeof filter.value !== "boolean") {
+            throw new Error(
+              `expected boolean value for field "${
+                filter.id
+              }", got: ${JSON.stringify(filter.value)}`
+            );
+          }
           q.push(
             sql``.append(
               `coalesce((${fv.val})::boolean, FALSE) IS ${

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -389,7 +389,8 @@ const fieldsMap: FieldsMap = {
     val: `stream.data->'transcodedSegmentsDuration'`,
     type: "real",
   },
-  isHealthy: { val: `stream.data->'isHealthy'`, type: "boolean" },
+  // isHealthy field is sometimes JSON-`null` so we query it as a string (->>)
+  isHealthy: { val: `stream.data->>'isHealthy'`, type: "boolean" },
 };
 
 app.get("/", authorizer({}), async (req, res) => {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This fixes the `isHealthy` filter on streams list so we don't get this error:
`cannot cast jsonb null to type boolean`

This happened not when the field was not set, in which case `data->'isHealthy'` returns
a SQL `NULL` but when the field was actually set to a JSON `null` value, which is 
sometimes done [here](https://github.com/livepeer/livepeer-com/blob/7e8ab2f43390d9dd90a3ee1ae7ce7baf4b425af5/packages/api/src/controllers/stream.ts#L999).

Postgres supports converting `NULL` to boolean, but not `jsonb null` to boolean, which 
is when the query exploded. This fixes it by querying the field as `TEXT` (`->>`) instead,
which automatically converts `jsonb null` to a SQL `NULL` as well and everything works.

Also added a little validation that was missing in `parseFilters`.

**Specific updates (required)**
- Change `isHealthy` field query to `->>` instead of `->`
- Add validation for boolean filters on `parseFilters`

**How did you test each of these updates (required)**
Ran queries on Postgres DB.

**Does this pull request close any open issues?**
https://discord.com/channels/423160867534929930/611650333243867170/1231996105433157632

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
