### PR TITLE
api: Handle active cleanup from pull lock API

### DIFF
--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1170,15 +1170,17 @@ app.post("/:id/lockPull", authorizer({ anyAdmin: true }), async (req, res) => {
     return res.json({ errors: ["not found"] });
   }
 
+  // We have an issue that some of the streams/sessions are not marked as inactive when they should be.
+  // This is a workaround to clean up the stream in the background
   const doingActiveCleanup = activeCleanupOne(
     req.config,
     stream,
     req.queue,
     await getIngestBase(req)
   );
+
   // the `isActive` field is only cleared later in background, so we ignore it
   // in the query below in case we triggered an active cleanup logic above.
-
   const leaseDeadline = Date.now() - leaseTimeout;
   const updateRes = await db.stream.update(
     [


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This is (yet another) hotfix for the active cleanup logic, specifically on the lock pull flow.

We were sometimes not allowing a stream to be locked because it was marked as active,
even tho it was lost (old lastSeen).

This adds some logic in the pull lock flow to handle the `lastSeen` as well.

**Specific updates (required)**
- Do active cleanup of streams on pull lock logic
- If cleanup was triggered, skip the isActive check on the actual lock query

**How did you test each of these updates (required)**
`yarn test`

**Does this pull request close any open issues?**
Fixes isActive issue on lock pull

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
