### PR TITLE
api/stream: Add a couple more hacks for testing Trovo profiles

### DIFF
--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1,15 +1,12 @@
-import { Router, Request } from "express";
+import { Request, Router } from "express";
+import _ from "lodash";
 import { QueryResult } from "pg";
 import sql from "sql-template-strings";
 import { parse as parseUrl } from "url";
 import { v4 as uuid } from "uuid";
-import _ from "lodash";
 
 import logger from "../logger";
-import { authorizer } from "../middleware";
-import { validatePost } from "../middleware";
-import { geolocateMiddleware } from "../middleware";
-import { fetchWithTimeoutAndRedirects } from "../util";
+import { authorizer, geolocateMiddleware, validatePost } from "../middleware";
 import { CliArgs } from "../parse-cli";
 import {
   DetectionWebhookPayload,
@@ -20,7 +17,6 @@ import {
   User,
 } from "../schema/types";
 import { db } from "../store";
-import { DBSession } from "../store/session-table";
 import {
   BadRequestError,
   InternalServerError,
@@ -28,34 +24,35 @@ import {
   TooManyRequestsError,
   UnprocessableEntityError,
 } from "../store/errors";
+import { ensureExperimentSubject } from "../store/experiment-table";
+import messages from "../store/messages";
+import Queue from "../store/queue";
+import { DBSession } from "../store/session-table";
 import { DBStream, StreamStats } from "../store/stream-table";
 import { WithID } from "../store/types";
-import messages from "../store/messages";
+import { fetchWithTimeoutAndRedirects, sleep } from "../util";
+import { withPlaybackUrls } from "./asset";
 import { getBroadcasterHandler } from "./broadcaster";
+import { getClips } from "./clip";
+import { experimentSubjectsOnly } from "./experiment";
 import {
   generateUniquePlaybackId,
   generateUniqueStreamKey,
 } from "./generate-keys";
 import {
+  FieldsMap,
   makeNextHREF,
+  mapInputCreatorId,
   parseFilters,
   parseOrder,
   pathJoin,
-  FieldsMap,
   toStringValues,
-  mapInputCreatorId,
-  triggerCatalystStreamUpdated,
   triggerCatalystPullStart,
   triggerCatalystStreamStopSessions,
+  triggerCatalystStreamUpdated,
 } from "./helpers";
-import wowzaHydrate from "./wowza-hydrate";
-import Queue from "../store/queue";
 import { toExternalSession } from "./session";
-import { withPlaybackUrls } from "./asset";
-import { getClips } from "./clip";
-import { ensureExperimentSubject } from "../store/experiment-table";
-import { experimentSubjectsOnly } from "./experiment";
-import { sleep } from "../util";
+import wowzaHydrate from "./wowza-hydrate";
 
 type Profile = DBStream["profiles"][number];
 type MultistreamOptions = DBStream["multistream"];

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1155,6 +1155,8 @@ app.put(
         ...payload,
       };
       if (testCreatorIds.includes(stream.creatorId?.value)) {
+        // Temporarily make this API non-idempotent for a couple creatorIds from Trovo, to facilitate testing profiles.
+        // TODO: Remove this once we define the right set of profiles for Trovo and they start sending them correctly.
         stream.profiles = oldStream.profiles;
       }
       await db.stream.replace(stream);

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1042,6 +1042,15 @@ const testCreatorIds: string[] = [
   "73846_115939837_115939837",
 ];
 
+// TODO: Remove this logic once Trovo starts sending correct profiles to the /pull API.
+function fixTrovoProfiles(profiles: Profile[], isMobile: boolean) {
+  return profiles?.map((p) => ({
+    ...p,
+    fps: isMobile && p.fps ? 0 : p.fps,
+    height: p.width === 480 && p.height === 853 ? 854 : p.height,
+  }));
+}
+
 app.put(
   "/pull",
   authorizer({}),
@@ -1058,8 +1067,10 @@ app.put(
 
     // Make the payload compatible with the stream schema to simplify things
     const payload: Partial<DBStream> = {
-      profiles: req.config.defaultStreamProfiles,
       ...rawPayload,
+      profiles:
+        fixTrovoProfiles(rawPayload.profiles, rawPayload.pull.isMobile) ||
+        req.config.defaultStreamProfiles,
       creatorId: mapInputCreatorId(rawPayload.creatorId),
     };
 


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

- When isMobileflag is set to true in the pull API endpoint, all transcode profiles set by the end user should be overwritten by fps=0. The rest of the parameters can remain as-is. So for example, if fps=30 is set by the user, we should replace that profile with fps=0 and keep remaining parameters the same. This is a temporary workaround required to resolve stuttering issues seen with Trovo's mobile app ([PS-382](https://linear.app/livepeer/issue/PS-382/mobile-playback-stream-not-working-properly-when-qa-pushes-480p-30-fps))

For example, a /pull API request where the user set profiles like this:

```json
"profiles": [ { "name": "360p0", "fps": 30, "bitrate": 800000, "width": 640, "height": 360, "profile": "H264ConstrainedHigh" }, { "name": "480p0", "fps": 30, "bitrate": 1600000, "width": 854, "height": 480, "profile": "H264ConstrainedHigh" }, ] }
```
will become the following (only fps field overwritten and set to 0): 

```json
"profiles": [ { "name": "360p0", "fps": 0, "bitrate": 800000, "width": 640, "height": 360, "profile": "H264ConstrainedHigh" }, { "name": "480p0", "fps": 0, "bitrate": 1600000, "width": 854, "height": 480, "profile": "H264ConstrainedHigh" }, ] }
```

- Any request that has a width=853 and height=480, should be updated so that width=854. This is because 853 is not a standard dimension and it results in a vertical green line on the right side of the frame ([PS-381](https://linear.app/livepeer/issue/PS-381/mobile-playback-green-screen-when-streamer-starts-or-ends-pk-with))

**Specific updates (required)**

The 2 things above.

**How did you test each of these updates (required)**

`yarn test`

**Does this pull request close any open issues?**

Implements PS-534

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
