### PR TITLE
api,www: Create `failed` state for recordings

### DIFF
--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -847,6 +847,7 @@ components:
           enum:
             - waiting
             - ready
+            - failed
             - none
         recordingUrl:
           type: string

--- a/packages/www/components/Admin/Table-v2/cells/duration.tsx
+++ b/packages/www/components/Admin/Table-v2/cells/duration.tsx
@@ -1,17 +1,22 @@
 /** @jsxImportSource @emotion/react */
-import { jsx } from "theme-ui";
+import { Session } from "@livepeer.studio/api";
 import { formatDuration, intervalToDuration } from "date-fns";
 import { CellComponentProps, TableData } from "../types";
 
-export type DurationCellProps = { duration: number; status?: string };
+export type DurationCellProps = {
+  duration: number;
+  status?: Session["recordingStatus"];
+};
 
 const DurationCell = <D extends TableData>({
   cell,
 }: CellComponentProps<D, DurationCellProps>) => {
   if (cell.value.status === "waiting") {
     return "In progress";
+  } else if (cell.value.status === "failed") {
+    return "Failed";
   }
-  if (cell.value.duration === 0) {
+  if (cell.value.duration === 0 || cell.value.status !== "ready") {
     return "n/a";
   }
   try {

--- a/packages/www/components/Table/cells/duration.tsx
+++ b/packages/www/components/Table/cells/duration.tsx
@@ -1,9 +1,10 @@
+import { Session } from "@livepeer.studio/api";
 import { formatDuration, intervalToDuration } from "date-fns";
 import { CellComponentProps, TableData } from "../types";
 
 export type DurationCellProps = {
   sourceSegmentsDuration: number;
-  status?: string;
+  status?: Session["recordingStatus"];
 };
 
 const DurationCell = <D extends TableData>({
@@ -11,9 +12,14 @@ const DurationCell = <D extends TableData>({
 }: CellComponentProps<D, DurationCellProps>) => {
   if (cell.value.status === "waiting") {
     return "In progress";
+  } else if (cell.value.status === "failed") {
+    return "Failed";
   }
-  if (cell.value.sourceSegmentsDuration === 0) {
-    return "—";
+  if (
+    cell.value.sourceSegmentsDuration === 0 ||
+    cell.value.status !== "ready"
+  ) {
+    return "n/a";
   }
   try {
     const durationMins = Math.round(cell.value.sourceSegmentsDuration / 60);


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This is just to make a small improvement on the recordingStatus field of streams/sessions.

Previously we had a `none` state which was only set when we tried to create the recording but
the processing failed. This is pretty misleading as it looks like we never even tried creating one.

So I created a new `failed` state to be set on that case, and am setting `none` only when we
actually won't generate a recording, which is the case for stale sessions (exists today, will stop
happening with #2013).

**Specific updates (required)**
- Add new `failed` status and set it when processing failed
- Process it on frontend showing "Failed" when that's the case

**How did you test each of these updates (required)**
Simple hotfix, `yarn test` guarantees it's not breaking anything.

**Does this pull request close any open issues?**
No.

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
