### PR TITLE
.github: Create staging active streams cleanup job

### DIFF
--- a/.github/workflows/cron-streams-active-cleanup.yaml
+++ b/.github/workflows/cron-streams-active-cleanup.yaml
@@ -1,0 +1,15 @@
+name: "cron: Active streams cleanup"
+
+on:
+  schedule:
+    - cron: "*/5 * * * *" # run every 5 minutes
+
+jobs:
+  staging:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clean-up staging active streams
+        run: |
+          curl --fail --request POST \
+          --url 'https://livepeer.monster/api/stream/job/active-cleanup' \
+          --header 'Authorization: Bearer ${{ secrets.LP_STAGING_API_ADMIN_TOKEN }}'


### PR DESCRIPTION
This creates only the staging cronjob from #2013

Tested together with https://github.com/livepeer/livepeer-infra/pull/2091