### PR TITLE
api/stream: Make sure we use patched payload on /pull create stream

### DIFF
--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1042,7 +1042,7 @@ const testCreatorIds: string[] = [
   "73846_115939837_115939837",
 ];
 
-// TODO: Remove this logic once Trovo starts sending correct profiles to the /pull API.
+// TODO: Remove this logic once Trovo starts sending correct profiles to the /pull API. Maybe never :(
 function fixTrovoProfiles(profiles: Profile[], isMobile: boolean) {
   return profiles?.map((p) => ({
     ...p,
@@ -1066,7 +1066,7 @@ app.put(
     }
 
     // Make the payload compatible with the stream schema to simplify things
-    const payload: Partial<DBStream> = {
+    const payload: Partial<DBStream> & NewStreamPayload = {
       ...rawPayload,
       profiles:
         fixTrovoProfiles(rawPayload.profiles, rawPayload.pull.isMobile) ||
@@ -1131,7 +1131,7 @@ app.put(
       logger.info(
         `pull request creating a new stream with name=${rawPayload.name}`
       );
-      stream = await handleCreateStream(req);
+      stream = await handleCreateStream(req, payload);
       stream.pullRegion = pullRegion;
       await db.stream.replace(stream);
     } else {
@@ -1295,7 +1295,7 @@ app.post(
       }
     }
 
-    const stream = await handleCreateStream(req);
+    const stream = await handleCreateStream(req, req.body);
 
     if (autoStartPull === "true") {
       const ingest = await getIngestBase(req);
@@ -1311,9 +1311,7 @@ app.post(
   }
 );
 
-async function handleCreateStream(req: Request) {
-  const payload = req.body as NewStreamPayload;
-
+async function handleCreateStream(req: Request, payload: NewStreamPayload) {
   const id = uuid();
   const createdAt = Date.now();
   // TODO: Don't create a streamKey if there's a pull source (here and on www)


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

There was a bug in #2155 which didn't use the patched profiles when the stream
was created. This is because the `handleCreateStream` function just got the raw
request and fetched the `req.body` again.

**Specific updates (required)**
- Pass the patched payload to `handleCreateStream` so it gets the Trovo-hacked profiles

**How did you test each of these updates (required)**
`yarn test`

**Does this pull request close any open issues?**
Informal.

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
