### PR TITLE
api/stream: Order streams by lastSeen on active-cleanup

### DIFF
--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -2160,7 +2160,7 @@ app.post(
       ],
       {
         limit,
-        order: null,
+        order: "data->>'lastSeen' DESC",
       }
     );
 


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Realized that, during the migration time where the active-cleanup job will be
cleaning 1.2 MILLION streams, it could happen that we miss processing some of
the recent streams due to the job being busy with all the old ones (1000 at a time).

This fixes it by ordering the results by the `data->>'lastSeen' DESC` instead (without
converting to bigint on purpose, to use the index). This will make sure we process the
recent streams before the old ones.

After the table gets clean, this will be automatically optimized by Postgres, with a query
plan that uses both `isActive` and `lastSeen` indexes. Just checked this with some
`EXPLAIN ANALYZE` on prod and staging. 


**Specific updates (required)**
- Add `order` to the `active-cleanup` query

**How did you test each of these updates (required)**
Ran and explained queries on postgresql.

**Does this pull request close any open issues?**

No.

**Screenshots**

Current plan on prod:
<img width="962" alt="Screenshot 2024-05-07 at 11 26 12" src="https://github.com/livepeer/studio/assets/1613383/4b037b6e-be7c-4706-ba75-12804626d3c4">

Current plan on staging (already clean):
<img width="908" alt="Screenshot 2024-05-07 at 11 26 29" src="https://github.com/livepeer/studio/assets/1613383/cee68cbd-d7b3-4248-b0b3-913390fa5022">

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
