### PR TITLE
api: Fix double index creation with separate jobs DB pool

### DIFF
--- a/packages/api/src/app-router.ts
+++ b/packages/api/src/app-router.ts
@@ -1,33 +1,34 @@
 // import 'express-async-errors' // it monkeypatches, i guess
+import * as fcl from "@onflow/fcl";
 import { Router } from "express";
 import promBundle from "express-prom-bundle";
 import proxy from "http-proxy-middleware";
 import Stripe from "stripe";
-import makeStore from "./store";
-import {
-  errorHandler,
-  healthCheck,
-  subgraph,
-  hardcodedNodes,
-  insecureTest,
-  geolocateMiddleware,
-  authenticateWithCors,
-} from "./middleware";
 import controllers from "./controllers";
-import streamProxy from "./controllers/stream-proxy";
 import apiProxy from "./controllers/api-proxy";
+import { setupTestTus, setupTus } from "./controllers/asset";
 import { getBroadcasterHandler } from "./controllers/broadcaster";
-import WebhookCannon from "./webhooks/cannon";
-import Queue, { NoopQueue, RabbitQueue } from "./store/queue";
-import { CliArgs } from "./parse-cli";
-import { regionsGetter } from "./controllers/region";
 import { pathJoin } from "./controllers/helpers";
-import { taskScheduler } from "./task/scheduler";
-import { setupTus, setupTestTus } from "./controllers/asset";
-import * as fcl from "@onflow/fcl";
+import { regionsGetter } from "./controllers/region";
+import streamProxy from "./controllers/stream-proxy";
 import createFrontend from "./frontend";
-import { NotFoundError } from "./store/errors";
+import {
+  authenticateWithCors,
+  errorHandler,
+  geolocateMiddleware,
+  hardcodedNodes,
+  healthCheck,
+  insecureTest,
+  subgraph,
+} from "./middleware";
+import { CliArgs } from "./parse-cli";
+import makeStore from "./store";
 import { cache } from "./store/cache";
+import { PostgresParams } from "./store/db";
+import { NotFoundError } from "./store/errors";
+import Queue, { NoopQueue, RabbitQueue } from "./store/queue";
+import { taskScheduler } from "./task/scheduler";
+import WebhookCannon from "./webhooks/cannon";
 
 enum OrchestratorSource {
   hardcoded = "hardcoded",

--- a/packages/api/src/app-router.ts
+++ b/packages/api/src/app-router.ts
@@ -64,6 +64,7 @@ export default async function appRouter(params: CliArgs) {
     postgresReplicaUrl,
     postgresConnPoolSize: pgPoolSize,
     postgresJobsConnPoolSize: pgJobsPoolSize,
+    postgresCreateTables: createTablesOnDb,
     defaultCacheTtl,
     frontendDomain,
     supportAddr,
@@ -102,7 +103,12 @@ export default async function appRouter(params: CliArgs) {
   // Storage init
   const bodyParser = require("body-parser");
   const appName = ownRegion ? `${ownRegion}-api` : "api";
-  const pgBaseParams = { postgresUrl, postgresReplicaUrl, appName };
+  const pgBaseParams: PostgresParams = {
+    postgresUrl,
+    postgresReplicaUrl,
+    createTablesOnDb,
+    appName,
+  };
   const [db, jobsDb, store] = await makeStore(
     { ...pgBaseParams, poolMaxSize: pgPoolSize },
     { ...pgBaseParams, poolMaxSize: pgJobsPoolSize, appName: `${appName}-jobs` }

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -1,5 +1,8 @@
-import Yargs, { Options, Argv } from "yargs";
-import yargsToMist from "./yargs-to-mist";
+import { ErrorObject, ValidateFunction } from "ajv";
+import Yargs, { Argv, Options } from "yargs";
+import { FfmpegProfile } from "./schema/types";
+import profileValidator from "./schema/validators/ffmpeg-profile";
+import { defaultTaskExchange } from "./store/queue";
 import {
   CamelKeys,
   Ingest,
@@ -7,10 +10,7 @@ import {
   OrchestratorNodeAddress,
   Price,
 } from "./types/common";
-import { defaultTaskExchange } from "./store/queue";
-import { FfmpegProfile } from "./schema/types";
-import profileValidator from "./schema/validators/ffmpeg-profile";
-import { ValidateFunction, ErrorObject } from "ajv";
+import yargsToMist from "./yargs-to-mist";
 
 const DEFAULT_ARWEAVE_GATEWAY_PREFIXES = [
   "https://arweave.net/",

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -153,6 +153,12 @@ export default function parseCli(argv?: string | readonly string[]) {
         type: "number",
         default: 5,
       },
+      "postgres-create-tables": {
+        describe:
+          "create tables and indexes on the database if they don't exist",
+        type: "boolean",
+        default: true,
+      },
       "default-cache-ttl": {
         describe: "default TTL for entries cached in memory, in seconds",
         type: "number",

--- a/packages/api/src/store/db.ts
+++ b/packages/api/src/store/db.ts
@@ -1,35 +1,33 @@
+import { hostname } from "os";
 import { Pool, QueryConfig, QueryResult } from "pg";
 import { parse as parseUrl, format as stringifyUrl } from "url";
-import { hostname } from "os";
 
 import logger from "../logger";
 import schema from "../schema/schema.json";
 import {
-  ObjectStore,
   ApiToken,
-  User,
-  PasswordResetToken,
-  Usage,
-  Region,
-  Session,
-  SigningKey,
-  Room,
-  Attestation,
   JwtRefreshToken,
-  WebhookLog,
+  ObjectStore,
+  PasswordResetToken,
   Project,
+  Region,
+  Room,
+  SigningKey,
+  Usage,
+  User,
+  WebhookLog,
 } from "../schema/types";
-import BaseTable, { TableOptions } from "./table";
-import StreamTable from "./stream-table";
 import { kebabToCamel } from "../util";
-import { QueryOptions, WithID } from "./types";
-import MultistreamTargetTable from "./multistream-table";
-import WebhookTable from "./webhook-table";
 import AssetTable from "./asset-table";
-import TaskTable from "./task-table";
-import ExperimentTable from "./experiment-table";
 import AttestationTable from "./attestation-table";
-import SessionTable, { DBSession } from "./session-table";
+import ExperimentTable from "./experiment-table";
+import MultistreamTargetTable from "./multistream-table";
+import SessionTable from "./session-table";
+import StreamTable from "./stream-table";
+import BaseTable, { TableOptions } from "./table";
+import TaskTable from "./task-table";
+import { QueryOptions, WithID } from "./types";
+import WebhookTable from "./webhook-table";
 
 // Should be configurable, perhaps?
 export const CONNECT_TIMEOUT =

--- a/packages/api/src/store/index.ts
+++ b/packages/api/src/store/index.ts
@@ -9,7 +9,7 @@ export default async function makeStore(
   jobsDbParams: PostgresParams
 ): Promise<[DB, DB, Model]> {
   await db.start(dbParams);
-  await jobsDb.start(jobsDbParams);
+  await jobsDb.start({ ...jobsDbParams, createTablesOnDb: false });
   const store = new Model(db);
   return [db, jobsDb, store];
 }

--- a/packages/api/src/store/index.ts
+++ b/packages/api/src/store/index.ts
@@ -1,5 +1,5 @@
+import { DB, PostgresParams, db, jobsDb } from "./db";
 import Model from "./model";
-import { db, jobsDb, DB, PostgresParams } from "./db";
 
 export { db, jobsDb };
 


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This disables the table/index creation on the separate DB pool used for bg jobs.

It also allows disabling index creation completely, so we can quickly do it on regions
that may be having issues. We won't need to enable that for now though.

**Specific updates (required)**
- Disable index creation for jobs DB pool
- Allow disabling index creation from CLI for all DB clients

**How did you test each of these updates (required)**
`yarn test`. also ran API and check each index is created only once

**Does this pull request close any open issues?**
https://discord.com/channels/423160867534929930/1237342810508623913/1237342812903702538

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
