### PR TITLE
api: Fix the hack for non-standard profiles on pull API

### DIFF
--- a/packages/api/src/controllers/stream.test.ts
+++ b/packages/api/src/controllers/stream.test.ts
@@ -25,9 +25,9 @@ import { semaphore, sleep } from "../util";
 import { generateUniquePlaybackId } from "./generate-keys";
 import {
   ACTIVE_TIMEOUT,
-  resolvePullUrlFromExistingStreams,
   extractRegionFrom,
   extractUrlFrom,
+  resolvePullUrlFromExistingStreams,
 } from "./stream";
 
 const uuidRegex = /[0-9a-f]+(-[0-9a-f]+){4}/;
@@ -801,6 +801,7 @@ describe("controllers/stream", () => {
             fps: 0,
           },
         ]);
+      });
 
       it("should resolve pull url and region from existing stream", async () => {
         expect(resolvePullUrlFromExistingStreams([])).toStrictEqual(null);

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1040,7 +1040,7 @@ function fixTrovoProfiles(profiles: Profile[], isMobile: boolean) {
   return profiles?.map((p) => ({
     ...p,
     fps: isMobile && p.fps ? 0 : p.fps,
-    height: p.width === 480 && p.height === 853 ? 854 : p.height,
+    width: p.height === 480 && Math.abs(854 - p.width) <= 6 ? 854 : p.width,
   }));
 }
 


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

The checks were inverted 🤦‍♂️ 

Fixed that, but also fixed the check on the non standard field, which can not only be 853 but go down up to 848.

**Specific updates (required)**
- Fix the fix
- Add test

**How did you test each of these updates (required)**
`yarn test`

**Does this pull request close any open issues?**
Fixes PS-554

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
