### PR TITLE
api: Allow isMobile to be specified as an int (0 or 1... or 2!)

### DIFF
--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1067,7 +1067,10 @@ const testCreatorIds: string[] = [
 ];
 
 // TODO: Remove this logic once Trovo starts sending correct profiles to the /pull API. Maybe never :(
-function fixTrovoProfiles(profiles: Profile[], isMobile: boolean | 0 | 1) {
+function fixedTrovoProfiles({
+  profiles,
+  pull: { isMobile },
+}: NewStreamPayload) {
   return profiles?.map((p) => ({
     ...p,
     fps: isMobile && p.fps ? 0 : p.fps,
@@ -1093,8 +1096,7 @@ app.put(
     const payload: Partial<DBStream> & NewStreamPayload = {
       ...rawPayload,
       profiles:
-        fixTrovoProfiles(rawPayload.profiles, rawPayload.pull.isMobile) ||
-        req.config.defaultStreamProfiles,
+        fixedTrovoProfiles(rawPayload) || req.config.defaultStreamProfiles,
       creatorId: mapInputCreatorId(rawPayload.creatorId),
     };
 

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1067,7 +1067,7 @@ const testCreatorIds: string[] = [
 ];
 
 // TODO: Remove this logic once Trovo starts sending correct profiles to the /pull API. Maybe never :(
-function fixTrovoProfiles(profiles: Profile[], isMobile: boolean) {
+function fixTrovoProfiles(profiles: Profile[], isMobile: boolean | 0 | 1) {
   return profiles?.map((p) => ({
     ...p,
     fps: isMobile && p.fps ? 0 : p.fps,

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -544,7 +544,14 @@ components:
               example:
                 Authorization: "Bearer 123"
             isMobile:
-              type: boolean
+              type:
+                - boolean
+                - integer
+              enum:
+                - false
+                - true
+                - 0
+                - 1
               description: |-
                 If true, the stream will be pulled from a mobile source.
               default: false

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -552,6 +552,7 @@ components:
                 - true
                 - 0
                 - 1
+                - 2
               description: |-
                 If true, the stream will be pulled from a mobile source.
               default: false


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Design partner is sending it as an integer for some reason.

**Specific updates (required)**
- Add integer type to schema
- fix type hint on helper to fix profiles

**How did you test each of these updates (required)**
TypeScript, if it compiles it works lol

**Does this pull request close any open issues?**
https://discord.com/channels/423160867534929930/1161745351275982848/1237658648327618600

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
