### PR TITLE
api/stream: Only clear fps if isMobile === 2

### DIFF
--- a/packages/api/src/controllers/stream.test.ts
+++ b/packages/api/src/controllers/stream.test.ts
@@ -777,7 +777,7 @@ describe("controllers/stream", () => {
           wowza: undefined,
           pull: {
             ...postMockPullStream.pull,
-            isMobile: true,
+            isMobile: 2,
           },
           profiles: [
             {

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -1071,9 +1071,10 @@ function fixedTrovoProfiles({
   profiles,
   pull: { isMobile },
 }: NewStreamPayload) {
+  const isMobileCamera = isMobile === 2; // 0: not mobile, 1: mobile screen share, 2: mobile camera
   return profiles?.map((p) => ({
     ...p,
-    fps: isMobile && p.fps ? 0 : p.fps,
+    fps: isMobileCamera && p.fps ? 0 : p.fps,
     width: p.height === 480 && Math.abs(854 - p.width) <= 6 ? 854 : p.width,
   }));
 }


### PR DESCRIPTION
Implements [PS-569](https://linear.app/livepeer/issue/PS-569/studio-change-ismobile-from-bool-to-int)