### PR TITLE
api: Create entrypoints for long-running jobs

### DIFF
--- a/packages/api/src/app-router.ts
+++ b/packages/api/src/app-router.ts
@@ -89,7 +89,7 @@ export async function initClients(params: CliArgs, serviceName = "api") {
 
   // RabbitMQ
   const queue: Queue = amqpUrl
-    ? await RabbitQueue.connect(amqpUrl, amqpTasksExchange)
+    ? await RabbitQueue.connect(amqpUrl, appName, amqpTasksExchange)
     : new NoopQueue();
 
   process.on("beforeExit", (code) => {

--- a/packages/api/src/cli.ts
+++ b/packages/api/src/cli.ts
@@ -4,6 +4,7 @@ import makeStreamInfoSvc from "./app/stream-info/stream-info-app";
 import "./dotenv";
 import makeApp from "./index";
 import runActiveCleanup from "./jobs/active-cleanup";
+import createDbTables from "./jobs/create-db-tables";
 import parseCli from "./parse-cli";
 
 if (require.main === module) {
@@ -12,6 +13,8 @@ if (require.main === module) {
     makeStreamInfoSvc(args);
   } else if (args.job === "active-cleanup") {
     runActiveCleanup(args);
+  } else if (args.job === "create-db-tables") {
+    createDbTables(args);
   } else {
     makeApp(args);
   }

--- a/packages/api/src/cli.ts
+++ b/packages/api/src/cli.ts
@@ -1,14 +1,17 @@
 #!/usr/bin/env node
 
+import makeStreamInfoSvc from "./app/stream-info/stream-info-app";
 import "./dotenv";
 import makeApp from "./index";
-import makeStreamInfoSvc from "./app/stream-info/stream-info-app";
+import runActiveCleanup from "./jobs/active-cleanup";
 import parseCli from "./parse-cli";
 
 if (require.main === module) {
   const args = parseCli();
   if (args.streamInfoService) {
     makeStreamInfoSvc(args);
+  } else if (args.job === "active-cleanup") {
+    runActiveCleanup(args);
   } else {
     makeApp(args);
   }

--- a/packages/api/src/cli.ts
+++ b/packages/api/src/cli.ts
@@ -3,21 +3,15 @@
 import makeStreamInfoSvc from "./app/stream-info/stream-info-app";
 import "./dotenv";
 import makeApp from "./index";
-import activeCleanup from "./jobs/active-cleanup";
-import createDbTables from "./jobs/create-db-tables";
-import updateUsage from "./jobs/update-usage";
+import { runJob } from "./jobs";
 import parseCli from "./parse-cli";
 
 if (require.main === module) {
   const args = parseCli();
   if (args.streamInfoService) {
     makeStreamInfoSvc(args);
-  } else if (args.job === "active-cleanup") {
-    activeCleanup(args);
-  } else if (args.job === "create-db-tables") {
-    createDbTables(args);
-  } else if (args.job === "update-usage") {
-    updateUsage(args);
+  } else if (args.job) {
+    runJob(args.job, args);
   } else {
     makeApp(args);
   }

--- a/packages/api/src/cli.ts
+++ b/packages/api/src/cli.ts
@@ -5,6 +5,7 @@ import "./dotenv";
 import makeApp from "./index";
 import runActiveCleanup from "./jobs/active-cleanup";
 import createDbTables from "./jobs/create-db-tables";
+import updateUsage from "./jobs/update-usage";
 import parseCli from "./parse-cli";
 
 if (require.main === module) {
@@ -15,6 +16,8 @@ if (require.main === module) {
     runActiveCleanup(args);
   } else if (args.job === "create-db-tables") {
     createDbTables(args);
+  } else if (args.job === "update-usage") {
+    updateUsage(args);
   } else {
     makeApp(args);
   }

--- a/packages/api/src/cli.ts
+++ b/packages/api/src/cli.ts
@@ -3,7 +3,7 @@
 import makeStreamInfoSvc from "./app/stream-info/stream-info-app";
 import "./dotenv";
 import makeApp from "./index";
-import runActiveCleanup from "./jobs/active-cleanup";
+import activeCleanup from "./jobs/active-cleanup";
 import createDbTables from "./jobs/create-db-tables";
 import updateUsage from "./jobs/update-usage";
 import parseCli from "./parse-cli";
@@ -13,7 +13,7 @@ if (require.main === module) {
   if (args.streamInfoService) {
     makeStreamInfoSvc(args);
   } else if (args.job === "active-cleanup") {
-    runActiveCleanup(args);
+    activeCleanup(args);
   } else if (args.job === "create-db-tables") {
     createDbTables(args);
   } else if (args.job === "update-usage") {

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -381,7 +381,7 @@ function shouldCleanUpIsActive(stream: DBStream | DBSession) {
   return isActive && !isNaN(lastSeen) && Date.now() - lastSeen > ACTIVE_TIMEOUT;
 }
 
-function triggerCleanUpIsActiveJob(
+export function triggerCleanUpIsActiveJob(
   config: CliArgs,
   streams: DBStream[],
   queue: Queue,
@@ -2192,8 +2192,7 @@ app.get("/:id/clips", authorizer({}), async (req, res) => {
   return response;
 });
 
-// queries for all the streams with active clean up pending and triggers the
-// clean up logic for them.
+// TODO: Remove this API once we migrate to kubernetes cronjobs
 app.post(
   "/job/active-cleanup",
   authorizer({ anyAdmin: true }),

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -2200,7 +2200,7 @@ app.post(
   async (req, res) => {
     const limit = parseInt(req.query.limit?.toString()) || 1000;
 
-    const cleanedUp = await activeCleanup(
+    const { cleanedUp } = await activeCleanup(
       {
         ...req.config,
         activeCleanupLimit: limit,

--- a/packages/api/src/controllers/stripe.ts
+++ b/packages/api/src/controllers/stripe.ts
@@ -1,29 +1,41 @@
-import { Router, Request } from "express";
-import { db, jobsDb } from "../store";
-import { products } from "../config";
+import { Router } from "express";
 import sql from "sql-template-strings";
-import { sendgridEmailPaymentFailed, sendgridEmail } from "./helpers";
-import { WithID } from "../store/types";
-import { User } from "../schema/types";
+import Stripe from "stripe";
+import { products } from "../config";
 import { authorizer } from "../middleware";
+import { CliArgs } from "../parse-cli";
+import { User } from "../schema/types";
+import { db, jobsDb } from "../store";
+import { WithID } from "../store/types";
+import { Ingest } from "../types/common";
+import { sleep } from "../util";
+import { sendgridEmail, sendgridEmailPaymentFailed } from "./helpers";
 import { getRecentlyActiveHackers, getUsageData } from "./usage";
 import {
-  notifyUser,
-  getUsageNotifications,
   HACKER_DISABLE_CUTOFF_DATE,
+  getUsageNotifications,
+  notifyUser,
 } from "./utils/notification";
-import { sleep } from "../util";
 
 const app = Router();
 const HELP_EMAIL = "help@livepeer.org";
 
-export const reportUsage = async (req: Request, adminToken: string) => {
-  let payAsYouGoUsers = await getPayAsYouGoUsers(req);
+export const reportUsage = async (
+  stripe: Stripe,
+  config: CliArgs,
+  adminToken: string
+) => {
+  let payAsYouGoUsers = await getPayAsYouGoUsers(config.ingest, adminToken);
 
   let updatedUsers = [];
   for (const user of payAsYouGoUsers) {
     try {
-      let userUpdated = await reportUsageForUser(req, user, adminToken);
+      let userUpdated = await reportUsageForUser(
+        stripe,
+        config,
+        user,
+        adminToken
+      );
       updatedUsers.push(userUpdated);
     } catch (e) {
       console.log(`
@@ -42,7 +54,7 @@ export const reportUsage = async (req: Request, adminToken: string) => {
   };
 };
 
-async function getPayAsYouGoUsers(req: Request) {
+async function getPayAsYouGoUsers(ingests: Ingest[], adminToken: string) {
   const [users] = await jobsDb.user.find(
     [
       sql`users.data->>'stripeProductId' IN ('growth_1', 'scale_1', 'prod_O9XtHhI6rbTT1B','prod_O9XtcfOSMjSD5L')`,
@@ -53,14 +65,15 @@ async function getPayAsYouGoUsers(req: Request) {
     }
   );
 
-  const hackerUsers = await getRecentlyActiveHackers(req);
+  const hackerUsers = await getRecentlyActiveHackers(ingests, adminToken);
 
   const payAsYouGoUsers = [...users, ...hackerUsers];
   return payAsYouGoUsers;
 }
 
 async function reportUsageForUser(
-  req: Request,
+  stripe: Stripe,
+  config: CliArgs,
   user: WithID<User>,
   adminToken: string,
   actuallyReport: boolean = true,
@@ -78,7 +91,7 @@ async function reportUsageForUser(
     };
   }
 
-  const userSubscription = await req.stripe.subscriptions.retrieve(
+  const userSubscription = await stripe.subscriptions.retrieve(
     user.stripeCustomerSubscriptionId
   );
 
@@ -90,17 +103,15 @@ async function reportUsageForUser(
     billingCycleEnd = to;
   }
 
-  const ingests = await req.getIngest();
-
   const usageData = await getUsageData(
     user,
     billingCycleStart,
     billingCycleEnd,
-    ingests,
+    config.ingest,
     adminToken
   );
 
-  const subscriptionItems = await req.stripe.subscriptionItems.list({
+  const subscriptionItems = await stripe.subscriptionItems.list({
     subscription: user.stripeCustomerSubscriptionId,
   });
 
@@ -110,7 +121,7 @@ async function reportUsageForUser(
   );
 
   if (usageNotifications.length > 0) {
-    await notifyUser(usageNotifications, user, req);
+    await notifyUser(usageNotifications, user, { headers: {}, config });
   }
 
   if (actuallyReport) {
@@ -126,8 +137,8 @@ async function reportUsageForUser(
       usage: reporting usage to stripe for user=${user.id} email=${user.email} from=${billingCycleStart} to=${billingCycleEnd}
     `);
     await sendUsageRecordToStripe(
+      stripe,
       user,
-      req,
       subscriptionItemsByLookupKey,
       usageData.overUsage
     );
@@ -147,8 +158,8 @@ async function reportUsageForUser(
 }
 
 const sendUsageRecordToStripe = async (
+  stripe: Stripe,
   user: WithID<User>,
-  req: Request,
   subscriptionItemsByLookupKey,
   overUsage
 ) => {
@@ -156,7 +167,7 @@ const sendUsageRecordToStripe = async (
   await Promise.all(
     products[user.stripeProductId].usage.map(async (product) => {
       if (product.name === "Transcoding") {
-        await req.stripe.subscriptionItems.createUsageRecord(
+        await stripe.subscriptionItems.createUsageRecord(
           subscriptionItemsByLookupKey["transcoding_usage"],
           {
             quantity: parseInt(overUsage.TotalUsageMins.toFixed(0)),
@@ -165,7 +176,7 @@ const sendUsageRecordToStripe = async (
           }
         );
       } else if (product.name === "Delivery") {
-        await req.stripe.subscriptionItems.createUsageRecord(
+        await stripe.subscriptionItems.createUsageRecord(
           subscriptionItemsByLookupKey["tstreaming_usage"],
           {
             quantity: parseInt(overUsage.DeliveryUsageMins.toFixed(0)),
@@ -174,7 +185,7 @@ const sendUsageRecordToStripe = async (
           }
         );
       } else if (product.name === "Storage") {
-        await req.stripe.subscriptionItems.createUsageRecord(
+        await stripe.subscriptionItems.createUsageRecord(
           subscriptionItemsByLookupKey["tstorage_usage"],
           {
             quantity: parseInt(overUsage.StorageUsageMins.toFixed(0)),

--- a/packages/api/src/controllers/usage.ts
+++ b/packages/api/src/controllers/usage.ts
@@ -3,7 +3,6 @@ import Router from "express/lib/router";
 import fetch from "node-fetch";
 import qs from "qs";
 import { products } from "../config";
-import updateUsage from "../jobs/update-usage";
 import { authorizer } from "../middleware";
 import { User } from "../schema/types";
 import { db, jobsDb } from "../store";
@@ -339,6 +338,9 @@ app.get("/user/overage", authorizer({ anyAdmin: true }), async (req, res) => {
 
 // Runs the update-usage job on demand if necessary
 app.post("/update", authorizer({ anyAdmin: true }), async (req, res) => {
+  // import the job dynamically to avoid circular dependencies
+  const { default: updateUsage } = await import("../jobs/update-usage");
+
   let { fromTime, toTime } = req.query;
 
   const { usageHistory } = await updateUsage(

--- a/packages/api/src/controllers/usage.ts
+++ b/packages/api/src/controllers/usage.ts
@@ -4,7 +4,7 @@ import fetch from "node-fetch";
 import qs from "qs";
 import { products } from "../config";
 import updateUsage from "../jobs/update-usage";
-import { authorizer, validatePost } from "../middleware";
+import { authorizer } from "../middleware";
 import { User } from "../schema/types";
 import { db, jobsDb } from "../store";
 import { NotFoundError } from "../store/errors";
@@ -338,26 +338,21 @@ app.get("/user/overage", authorizer({ anyAdmin: true }), async (req, res) => {
 });
 
 // Runs the update-usage job on demand if necessary
-app.post(
-  "/update",
-  authorizer({ anyAdmin: true }),
-  validatePost("usage"),
-  async (req, res) => {
-    let { fromTime, toTime } = req.query;
+app.post("/update", authorizer({ anyAdmin: true }), async (req, res) => {
+  let { fromTime, toTime } = req.query;
 
-    const { usageHistory } = await updateUsage(
-      {
-        ...req.config,
-        updateUsageFrom: fromTime,
-        updateUsageTo: toTime,
-        updateUsageApiToken: req.token.id,
-      },
-      { jobsDb, stripe: req.stripe }
-    );
+  const { usageHistory } = await updateUsage(
+    {
+      ...req.config,
+      updateUsageFrom: fromTime,
+      updateUsageTo: toTime,
+      updateUsageApiToken: req.token.id,
+    },
+    { jobsDb, stripe: req.stripe }
+  );
 
-    res.status(200);
-    res.json(usageHistory);
-  }
-);
+  res.status(200);
+  res.json(usageHistory);
+});
 
 export default app;

--- a/packages/api/src/controllers/user.ts
+++ b/packages/api/src/controllers/user.ts
@@ -6,38 +6,38 @@ import qs from "qs";
 import Stripe from "stripe";
 import { v4 as uuid } from "uuid";
 
+import sql from "sql-template-strings";
 import { products } from "../config";
 import hash from "../hash";
 import logger from "../logger";
 import { authorizer, validatePost } from "../middleware";
+import { EMAIL_VERIFICATION_CUTOFF_DATE } from "../middleware/auth";
+import { CliArgs } from "../parse-cli";
 import {
   CreateCustomer,
   CreateSubscription,
-  PasswordResetTokenRequest,
+  DisableUserPayload,
   PasswordResetConfirm,
+  PasswordResetTokenRequest,
+  RefreshTokenPayload,
+  SuspendUserPayload,
   UpdateSubscription,
   User,
-  SuspendUserPayload,
-  DisableUserPayload,
-  RefreshTokenPayload,
 } from "../schema/types";
 import { db } from "../store";
 import { InternalServerError, NotFoundError } from "../store/errors";
 import { WithID } from "../store/types";
 import {
+  FieldsMap,
   makeNextHREF,
-  sendgridEmail,
   parseFilters,
   parseOrder,
   recaptchaVerify,
+  sendgridEmail,
   sendgridValidateEmail,
   toStringValues,
-  FieldsMap,
   triggerCatalystStreamStopSessions,
 } from "./helpers";
-import { EMAIL_VERIFICATION_CUTOFF_DATE } from "../middleware/auth";
-import sql from "sql-template-strings";
-import { CliArgs } from "../parse-cli";
 
 const adminOnlyFields = ["verifiedAt", "planChangedAt"];
 
@@ -115,11 +115,12 @@ export const frontendUrl = (
   {
     headers: { "x-forwarded-proto": proto },
     config: { frontendDomain },
-  }: Request,
+  }: Pick<Request, "headers" | "config">,
   path: string
 ) => `${proto || "https"}://${frontendDomain}${path}`;
 
-export const unsubscribeUrl = (req: Request) => frontendUrl(req, "/contact");
+export const unsubscribeUrl = (req: Pick<Request, "headers" | "config">) =>
+  frontendUrl(req, "/contact");
 
 export async function terminateUserStreams(
   req: Request,

--- a/packages/api/src/controllers/utils/notification.ts
+++ b/packages/api/src/controllers/utils/notification.ts
@@ -1,10 +1,9 @@
-import { sendgridEmail } from "../helpers";
-import { frontendUrl, unsubscribeUrl } from "../user";
-import { db } from "../../store";
-import { sendgridEmailPaymentFailed } from "../helpers";
-import { WithID } from "../../store/types";
 import { Request } from "express";
 import { User } from "../../schema/types";
+import { db } from "../../store";
+import { WithID } from "../../store/types";
+import { sendgridEmail, sendgridEmailPaymentFailed } from "../helpers";
+import { frontendUrl, unsubscribeUrl } from "../user";
 
 export const HACKER_DISABLE_CUTOFF_DATE = 1698793200000;
 
@@ -83,7 +82,17 @@ export const getUsageNotifications = async (
   return notifications;
 };
 
-export const notifyUser = async (notifications, user: User, req: Request) => {
+type Notification = {
+  type: string;
+  title: string;
+  message: string;
+};
+
+export const notifyUser = async (
+  notifications: Notification[],
+  user: User,
+  req: Pick<Request, "headers" | "config">
+) => {
   for (let notification of notifications) {
     if (user.notifications?.usage?.[notification.type]) {
       continue;

--- a/packages/api/src/jobs/active-cleanup.test.ts
+++ b/packages/api/src/jobs/active-cleanup.test.ts
@@ -1,0 +1,162 @@
+import { v4 as uuid } from "uuid";
+
+import * as appRouter from "../app-router";
+import * as streamController from "../controllers/stream";
+import { cache } from "../store/cache";
+import { DB } from "../store/db";
+import { NoopQueue, RabbitQueue } from "../store/queue";
+import { rabbitMgmt } from "../test-helpers";
+import params, { testId } from "../test-params";
+import activeCleanup from "./active-cleanup";
+
+describe("active-cleanup", () => {
+  // There are further functional tests under controllers/stream.test.ts "active clean-up"
+
+  let db: DB;
+
+  beforeAll(async () => {
+    db = new DB();
+    await db.start({ postgresUrl: params.postgresUrl });
+    await rabbitMgmt.createVhost(testId);
+  });
+
+  afterAll(async () => {
+    await rabbitMgmt.deleteVhost(testId);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+    cache.storage = null;
+  });
+
+  const mockStream = (isActive: boolean, lastSeen: number) => {
+    return {
+      id: uuid(),
+      name: "stream1",
+      playbackId: uuid(),
+      streamKey: uuid(),
+      isActive,
+      lastSeen,
+    };
+  };
+
+  it("should not call initClients if clients are passed", async () => {
+    const initSpy = jest.spyOn(appRouter, "initClients");
+
+    await activeCleanup(params, { jobsDb: db, queue: new NoopQueue() });
+
+    expect(initSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not register any queue event handlers", async () => {
+    const originalInitClient = appRouter.initClients;
+    const initSpy = jest
+      .spyOn(appRouter, "initClients")
+      .mockImplementation(async (params, name) => {
+        const result = await originalInitClient(params, name);
+        jest.spyOn(result.queue, "consume");
+        return result;
+      });
+
+    await activeCleanup(params);
+
+    expect(initSpy).toHaveBeenCalledTimes(1);
+    expect(initSpy).toHaveBeenLastCalledWith(params, "active-cleanup-job");
+
+    const { queue } = await initSpy.mock.results[0].value;
+    expect(queue.consume).not.toHaveBeenCalled();
+  });
+
+  it("calls triggerCleanUpIsActiveJob with the lost active streams", async () => {
+    const triggerSpy = jest
+      .spyOn(streamController, "triggerCleanUpIsActiveJob")
+      .mockImplementation(() => [[], Promise.resolve()]);
+
+    const now = Date.now();
+    // 3 active streams
+    for (let i = 0; i < 3; i++) {
+      await db.stream.create(
+        mockStream(true, now - streamController.ACTIVE_TIMEOUT / 2)
+      );
+    }
+    // 3 inactive streams
+    for (let i = 0; i < 3; i++) {
+      await db.stream.create(
+        mockStream(false, now - streamController.ACTIVE_TIMEOUT - 5000)
+      );
+    }
+    // 3 active lost streams, only these should be cleaned up
+    let expectedCleanedUp = [];
+    for (let i = 0; i <= 3; i++) {
+      const stream = await db.stream.create(
+        mockStream(true, now - streamController.ACTIVE_TIMEOUT - i)
+      );
+      expectedCleanedUp.push(stream);
+    }
+
+    await activeCleanup(params);
+
+    expect(triggerSpy).toHaveBeenCalledTimes(1);
+    expect(triggerSpy).toHaveBeenLastCalledWith(
+      params,
+      expectedCleanedUp,
+      expect.any(RabbitQueue),
+      params.ingest[0].base
+    );
+  });
+
+  it("publishes messages for cleaned up streams", async () => {
+    const originalInitClient = appRouter.initClients;
+    const initSpy = jest
+      .spyOn(appRouter, "initClients")
+      .mockImplementation(async (params, name) => {
+        const result = await originalInitClient(params, name);
+        jest.spyOn(result.queue, "consume");
+        jest.spyOn(result.queue, "delayedPublishWebhook");
+        return result;
+      });
+
+    const parentId = uuid();
+    const lastSeen = Date.now() - streamController.ACTIVE_TIMEOUT - 1;
+    const session = await db.session.create({
+      id: uuid(),
+      userId: uuid(),
+      name: "session1",
+      record: true,
+      parentId,
+      lastSeen,
+    });
+    await db.stream.create({
+      ...mockStream(true, lastSeen),
+      sessionId: session.id,
+      parentId,
+    });
+
+    await activeCleanup(params);
+
+    expect(initSpy).toHaveBeenCalledTimes(1);
+    const { queue } = await initSpy.mock.results[0].value;
+
+    expect(queue.consume).not.toHaveBeenCalled();
+    expect(queue.delayedPublishWebhook).toHaveBeenCalledTimes(1);
+    expect(queue.delayedPublishWebhook).toHaveBeenLastCalledWith(
+      "events.recording.waiting",
+      expect.anything(),
+      expect.any(Number),
+      "recording_waiting_delayed_events"
+    );
+    expect(queue.delayedPublishWebhook.mock.calls[0][1]).toMatchObject({
+      type: "webhook_event",
+      streamId: session.parentId,
+      event: "recording.waiting",
+      userId: session.userId,
+      sessionId: session.id,
+      payload: {
+        session: {
+          id: session.id,
+        },
+      },
+    });
+  });
+});

--- a/packages/api/src/jobs/active-cleanup.test.ts
+++ b/packages/api/src/jobs/active-cleanup.test.ts
@@ -25,7 +25,6 @@ describe("active-cleanup", () => {
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
     jest.restoreAllMocks();
     cache.storage = null;
   });

--- a/packages/api/src/jobs/active-cleanup.ts
+++ b/packages/api/src/jobs/active-cleanup.ts
@@ -4,7 +4,6 @@ import {
   ACTIVE_TIMEOUT,
   triggerCleanUpIsActiveJob,
 } from "../controllers/stream";
-import logger from "../logger";
 import { CliArgs } from "../parse-cli";
 import { DB } from "../store/db";
 import Queue from "../store/queue";
@@ -15,7 +14,6 @@ export default async function activeCleanup(
   config: CliArgs,
   clients?: { jobsDb: DB; queue: Queue }
 ) {
-  const startTime = process.hrtime();
   if (!config.ingest?.length) {
     throw new Error("ingest not configured");
   }
@@ -43,10 +41,8 @@ export default async function activeCleanup(
   );
   await jobPromise;
 
-  const elapsedTime = process.hrtime(startTime);
-  const elapsedTimeSec = elapsedTime[0] + elapsedTime[1] / 1e9;
-  logger.info(
-    `Ran active-cleanup job. elapsedTime=${elapsedTimeSec}s limit=${limit} numCleanedUp=${cleanedUp.length}`
-  );
-  return cleanedUp;
+  return {
+    cleanedUp,
+    logContext: `limit=${limit} numCleanedUp=${cleanedUp.length}`,
+  };
 }

--- a/packages/api/src/jobs/active-cleanup.ts
+++ b/packages/api/src/jobs/active-cleanup.ts
@@ -1,0 +1,45 @@
+import sql from "sql-template-strings";
+import { initClients } from "../app-router";
+import {
+  ACTIVE_TIMEOUT,
+  triggerCleanUpIsActiveJob,
+} from "../controllers/stream";
+import logger from "../logger";
+import { CliArgs } from "../parse-cli";
+
+// queries for all the streams with active clean up pending and triggers the
+// clean up logic for them.
+export default async function runActiveCleanup(config: CliArgs) {
+  const startTime = process.hrtime();
+  if (!config.ingest?.length) {
+    throw new Error("ingest not configured");
+  }
+  const { jobsDb, queue } = await initClients(config);
+  const { activeCleanupLimit: limit, ingest } = config;
+
+  const activeThreshold = Date.now() - ACTIVE_TIMEOUT;
+  let [streams] = await jobsDb.stream.find(
+    [
+      sql`data->>'isActive' = 'true'`,
+      sql`(data->>'lastSeen')::bigint < ${activeThreshold}`,
+    ],
+    {
+      limit,
+      order: "data->>'lastSeen' DESC",
+    }
+  );
+
+  const [cleanedUp, jobPromise] = triggerCleanUpIsActiveJob(
+    config,
+    streams,
+    queue,
+    ingest[0].base
+  );
+  await jobPromise;
+
+  const elapsedTime = process.hrtime(startTime);
+  const elapsedTimeSec = elapsedTime[0] + elapsedTime[1] / 1e9;
+  logger.info(
+    `Ran active-cleanup job. elapsedTime=${elapsedTimeSec}s limit=${limit} numCleanedUp=${cleanedUp.length}`
+  );
+}

--- a/packages/api/src/jobs/active-cleanup.ts
+++ b/packages/api/src/jobs/active-cleanup.ts
@@ -14,7 +14,7 @@ export default async function runActiveCleanup(config: CliArgs) {
   if (!config.ingest?.length) {
     throw new Error("ingest not configured");
   }
-  const { jobsDb, queue } = await initClients(config);
+  const { jobsDb, queue } = await initClients(config, "active-cleanup-job");
   const { activeCleanupLimit: limit, ingest } = config;
 
   const activeThreshold = Date.now() - ACTIVE_TIMEOUT;

--- a/packages/api/src/jobs/create-db-tables.test.ts
+++ b/packages/api/src/jobs/create-db-tables.test.ts
@@ -1,0 +1,29 @@
+import { db } from "../store";
+import params from "../test-params";
+import createDbTables from "./create-db-tables";
+
+describe("create-db-tables", () => {
+  it("should create tables and indexes in the DB", async () => {
+    // make sure it forces the creation of the tables, even with a bad config
+    await createDbTables({ ...params, postgresCreateTables: false });
+
+    const res = await db.query(
+      "SELECT indexname FROM pg_indexes WHERE indexname NOT LIKE '%_pkey'"
+    );
+    const indexes = res.rows?.map((r: any) => r.indexname).sort();
+
+    // test just a couple indexes from each table or this would be too long
+    const testIndexes = [
+      "stream_isActive",
+      "task_inputAssetId",
+      "users_email",
+      "webhook_log_userId",
+      "session_parentId",
+      "asset_source_url",
+      "api_token_projectId",
+    ];
+    for (const index of testIndexes) {
+      expect(indexes).toContain(index);
+    }
+  });
+});

--- a/packages/api/src/jobs/create-db-tables.ts
+++ b/packages/api/src/jobs/create-db-tables.ts
@@ -1,0 +1,15 @@
+import { initClients } from "../app-router";
+import { CliArgs } from "../parse-cli";
+
+export default async function createDbTables(config: CliArgs) {
+  const startTime = process.hrtime();
+
+  await initClients(
+    { ...config, createDbTables: true },
+    "create-db-tables-job"
+  );
+
+  const elapsedTime = process.hrtime(startTime);
+  const elapsedTimeSec = elapsedTime[0] + elapsedTime[1] / 1e9;
+  console.log(`Ran create-db-tables job. elapsedTime=${elapsedTimeSec}s`);
+}

--- a/packages/api/src/jobs/create-db-tables.ts
+++ b/packages/api/src/jobs/create-db-tables.ts
@@ -1,9 +1,9 @@
-import { initClients } from "../app-router";
+import { initDb } from "../app-router";
 import { CliArgs } from "../parse-cli";
 
 export default async function createDbTables(config: CliArgs) {
-  await initClients(
-    { ...config, createDbTables: true },
+  await initDb(
+    { ...config, postgresCreateTables: true },
     "create-db-tables-job"
   );
 }

--- a/packages/api/src/jobs/create-db-tables.ts
+++ b/packages/api/src/jobs/create-db-tables.ts
@@ -2,14 +2,8 @@ import { initClients } from "../app-router";
 import { CliArgs } from "../parse-cli";
 
 export default async function createDbTables(config: CliArgs) {
-  const startTime = process.hrtime();
-
   await initClients(
     { ...config, createDbTables: true },
     "create-db-tables-job"
   );
-
-  const elapsedTime = process.hrtime(startTime);
-  const elapsedTimeSec = elapsedTime[0] + elapsedTime[1] / 1e9;
-  console.log(`Ran create-db-tables job. elapsedTime=${elapsedTimeSec}s`);
 }

--- a/packages/api/src/jobs/index.ts
+++ b/packages/api/src/jobs/index.ts
@@ -1,0 +1,41 @@
+import logger from "../logger";
+import { CliArgs, JobType } from "../parse-cli";
+import { timeout } from "../util";
+import activeCleanup from "./active-cleanup";
+import createDbTables from "./create-db-tables";
+import updateUsage from "./update-usage";
+
+type JobFunc = (config: CliArgs) => Promise<void | { logContext?: string }>;
+
+const jobFuncs: Record<JobType, JobFunc> = {
+  "active-cleanup": activeCleanup,
+  "create-db-tables": createDbTables,
+  "update-usage": updateUsage,
+};
+
+export async function runJob(jobName: JobType, config: CliArgs): Promise<void> {
+  const startTime = process.hrtime();
+
+  logger.info(`Starting job. job=${jobName}`);
+  try {
+    const result = await timeout(config.jobTimeoutSec * 1000, () =>
+      jobFuncs[jobName](config)
+    );
+
+    const elapsedTime = process.hrtime(startTime);
+    const elapsedTimeSec = elapsedTime[0] + elapsedTime[1] / 1e9;
+
+    const logCtx = result && result.logContext;
+    logger.info(
+      `Ran job successfully. job=${jobName} time=${elapsedTimeSec}s ${logCtx}`
+    );
+    process.exit(0);
+  } catch (error) {
+    logger.error(
+      `Job failed. job=${jobName} error=${JSON.stringify(
+        error.message || error
+      )} stack=${JSON.stringify(error.stack)}`
+    );
+    process.exit(1);
+  }
+}

--- a/packages/api/src/jobs/index.ts
+++ b/packages/api/src/jobs/index.ts
@@ -7,7 +7,7 @@ import updateUsage from "./update-usage";
 
 type JobFunc = (config: CliArgs) => Promise<void | { logContext?: string }>;
 
-const jobFuncs: Record<JobType, JobFunc> = {
+export const jobFuncs: Record<JobType, JobFunc> = {
   "active-cleanup": activeCleanup,
   "create-db-tables": createDbTables,
   "update-usage": updateUsage,

--- a/packages/api/src/jobs/jobs.test.ts
+++ b/packages/api/src/jobs/jobs.test.ts
@@ -1,0 +1,41 @@
+import { jobFuncs, runJob } from ".";
+
+describe("runJob", () => {
+  let mockExit: jest.SpyInstance;
+  let jobMockFn: jest.Mock;
+
+  beforeAll(() => {
+    mockExit = jest
+      .spyOn(process, "exit")
+      .mockImplementation((() => {}) as any);
+  });
+
+  beforeEach(() => {
+    jobFuncs["create-db-tables"] = jobMockFn = jest.fn(() => Promise.resolve());
+  });
+
+  it("calls the corresponding job function", async () => {
+    await runJob("create-db-tables", { jobTimeoutSec: 1 } as any);
+    expect(jobMockFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("exits with status 0 on success", async () => {
+    await runJob("create-db-tables", { jobTimeoutSec: 1 } as any);
+    expect(process.exit).toHaveBeenCalledWith(0);
+  });
+
+  it("respects timeout configuration", async () => {
+    jobMockFn.mockImplementation(() => new Promise(() => {})); // never resolved
+    const startTime = Date.now();
+    await runJob("create-db-tables", { jobTimeoutSec: 1 } as any);
+    const elapsedTime = Date.now() - startTime;
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(elapsedTime).toBeGreaterThanOrEqual(1000);
+  });
+
+  it("catches errors and exits with status 1", async () => {
+    jobMockFn.mockRejectedValue(new Error("job failed"));
+    await runJob("create-db-tables", { jobTimeoutSec: 1 } as any);
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/api/src/jobs/update-usage.test.ts
+++ b/packages/api/src/jobs/update-usage.test.ts
@@ -1,0 +1,44 @@
+import * as appRouter from "../app-router";
+import * as stripeController from "../controllers/stripe";
+import { cache } from "../store/cache";
+import { rabbitMgmt } from "../test-helpers";
+import params, { testId } from "../test-params";
+import updateUsage from "./update-usage";
+
+describe("update-usage", () => {
+  beforeAll(async () => {
+    await rabbitMgmt.createVhost(testId);
+  });
+
+  afterAll(async () => {
+    await rabbitMgmt.deleteVhost(testId);
+  });
+
+  let reportUsageSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    reportUsageSpy = jest
+      .spyOn(stripeController, "reportUsage")
+      .mockResolvedValue({ updatedUsers: [{ id: "test" }] });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    cache.storage = null;
+  });
+
+  it("should not call initClients if clients are passed", async () => {
+    const clients = await appRouter.initClients(params);
+    const initSpy = jest.spyOn(appRouter, "initClients");
+
+    await updateUsage(params, clients);
+    expect(initSpy).not.toHaveBeenCalled();
+  });
+
+  it("calls stripe reportUsage", async () => {
+    const { updatedUsers } = await updateUsage(params);
+
+    expect(updatedUsers).toEqual([{ id: "test" }]);
+    expect(reportUsageSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/jobs/update-usage.ts
+++ b/packages/api/src/jobs/update-usage.ts
@@ -9,7 +9,6 @@ export default async function updateUsage(
   config: CliArgs,
   clients?: { jobsDb: DB; stripe: Stripe }
 ) {
-  const startTime = process.hrtime();
   const { jobsDb, stripe } =
     clients ?? (await initClients(config, "update-usage-job"));
 
@@ -62,10 +61,9 @@ export default async function updateUsage(
   // New automated billing usage report
   const { updatedUsers } = await reportUsage(stripe, config, token);
 
-  const elapsedTime = process.hrtime(startTime);
-  const elapsedTimeSec = elapsedTime[0] + elapsedTime[1] / 1e9;
-  logger.info(
-    `Ran update-usage job. elapsedTime=${elapsedTimeSec}s from=${fromTime} to=${toTime} numUpdatedUsers=${updatedUsers.length}`
-  );
-  return { usageHistory, updatedUsers };
+  return {
+    usageHistory,
+    updatedUsers,
+    logContext: `from=${fromTime} to=${toTime} numUpdatedUsers=${updatedUsers.length}`,
+  };
 }

--- a/packages/api/src/jobs/update-usage.ts
+++ b/packages/api/src/jobs/update-usage.ts
@@ -1,0 +1,64 @@
+import { initClients } from "../app-router";
+import { reportUsage } from "../controllers/stripe";
+import logger from "../logger";
+import { CliArgs } from "../parse-cli";
+
+export default async function updateUsage(config: CliArgs) {
+  const startTime = process.hrtime();
+  const { jobsDb, stripe } = await initClients(config, "update-usage-job");
+
+  let {
+    updateUsageFrom: fromTime,
+    updateUsageTo: toTime,
+    updateUsageApiToken: token,
+  } = config;
+
+  // if time range isn't specified return all usage
+  if (!fromTime) {
+    let rows = (
+      await jobsDb.usage.find(
+        {},
+        { limit: 1, order: "data->>'date' DESC", useReplica: true }
+      )
+    )[0];
+
+    if (rows.length) {
+      fromTime = rows[0].date; // get last updated date from cache
+    } else {
+      fromTime = +new Date(2020, 0); // start at beginning
+    }
+  }
+
+  if (!toTime) {
+    toTime = +new Date();
+  }
+
+  const usageHistory = await jobsDb.stream.usageHistory(fromTime, toTime, {
+    useReplica: true,
+  });
+  logger.info(
+    `Updating usage from=${fromTime} to=${toTime} usageHistory=${JSON.stringify(
+      usageHistory
+    )}`
+  );
+
+  // store each day of usage
+  for (const row of usageHistory) {
+    const dbRow = await jobsDb.usage.get(row.id);
+    // if row already exists in cache, update it, otherwise create it
+    if (dbRow) {
+      await jobsDb.usage.replace({ kind: "usage", ...row });
+    } else {
+      await jobsDb.usage.create({ kind: "usage", ...row });
+    }
+  }
+
+  // New automated billing usage report
+  const { updatedUsers } = await reportUsage(stripe, config, token);
+
+  const elapsedTime = process.hrtime(startTime);
+  const elapsedTimeSec = elapsedTime[0] + elapsedTime[1] / 1e9;
+  logger.info(
+    `Ran update-usage job. elapsedTime=${elapsedTimeSec}s from=${fromTime} to=${toTime} numUpdatedUsers=${updatedUsers.length}`
+  );
+}

--- a/packages/api/src/jobs/update-usage.ts
+++ b/packages/api/src/jobs/update-usage.ts
@@ -1,11 +1,17 @@
+import Stripe from "stripe";
 import { initClients } from "../app-router";
 import { reportUsage } from "../controllers/stripe";
 import logger from "../logger";
 import { CliArgs } from "../parse-cli";
+import { DB } from "../store/db";
 
-export default async function updateUsage(config: CliArgs) {
+export default async function updateUsage(
+  config: CliArgs,
+  clients?: { jobsDb: DB; stripe: Stripe }
+) {
   const startTime = process.hrtime();
-  const { jobsDb, stripe } = await initClients(config, "update-usage-job");
+  const { jobsDb, stripe } =
+    clients ?? (await initClients(config, "update-usage-job"));
 
   let {
     updateUsageFrom: fromTime,
@@ -61,4 +67,5 @@ export default async function updateUsage(config: CliArgs) {
   logger.info(
     `Ran update-usage job. elapsedTime=${elapsedTimeSec}s from=${fromTime} to=${toTime} numUpdatedUsers=${updatedUsers.length}`
   );
+  return { usageHistory, updatedUsers };
 }

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -17,7 +17,11 @@ const DEFAULT_ARWEAVE_GATEWAY_PREFIXES = [
   "https://gateway.arweave.net/",
 ];
 
-const JOB_TYPES = ["active-cleanup", "create-db-tables"] as const;
+const JOB_TYPES = [
+  "active-cleanup",
+  "create-db-tables",
+  "update-usage",
+] as const;
 
 const yargs = Yargs() as unknown as Argv;
 
@@ -523,6 +527,21 @@ export default function parseCli(argv?: string | readonly string[]) {
         describe: "job/active-cleanup: max number of streams to clean up",
         type: "number",
         default: 1000,
+      },
+      "update-usage-from": {
+        describe:
+          "job/update-usage: unix millis timestamp for start time of update usage job",
+        type: "number",
+      },
+      "update-usage-to": {
+        describe:
+          "job/update-usage: unix millis timestamp for end time of update usage job",
+        type: "number",
+      },
+      "update-usage-api-token": {
+        describe:
+          "job/update-usage: Admin API token to be used in the update usage job internal calls",
+        type: "string",
       },
       "stream-info-service": {
         describe: "start the Stream Info service instead of Studio API",

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -17,6 +17,8 @@ const DEFAULT_ARWEAVE_GATEWAY_PREFIXES = [
   "https://gateway.arweave.net/",
 ];
 
+const JOB_TYPES = ["active-cleanup"] as const;
+
 const yargs = Yargs() as unknown as Argv;
 
 function coerceArr(arg: any) {
@@ -511,6 +513,17 @@ export default function parseCli(argv?: string | readonly string[]) {
         type: "boolean",
         default: true,
       },
+      job: {
+        describe:
+          "run a specific job from start to finish instead of Studio API",
+        type: "string",
+        choices: JOB_TYPES,
+      },
+      "active-cleanup-limit": {
+        describe: "job/active-cleanup: max number of streams to clean up",
+        type: "number",
+        default: 1000,
+      },
       "stream-info-service": {
         describe: "start the Stream Info service instead of Studio API",
         type: "boolean",
@@ -586,7 +599,9 @@ export default function parseCli(argv?: string | readonly string[]) {
     .help()
     .parse(argv);
   // yargs returns a Promise even tho we don't have any async middlewares
-  const parsed = parsedProm as Awaited<typeof parsedProm>;
+  const parsed = parsedProm as Awaited<typeof parsedProm> & {
+    job?: (typeof JOB_TYPES)[number];
+  };
   const mistOutput = yargsToMist(allOptions);
   if (parsed.json === true) {
     console.log(JSON.stringify(mistOutput));

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -23,6 +23,8 @@ const JOB_TYPES = [
   "update-usage",
 ] as const;
 
+export type JobType = (typeof JOB_TYPES)[number];
+
 const yargs = Yargs() as unknown as Argv;
 
 function coerceArr(arg: any) {
@@ -523,6 +525,11 @@ export default function parseCli(argv?: string | readonly string[]) {
         type: "string",
         choices: JOB_TYPES,
       },
+      "job-timeout-sec": {
+        describe: "job timeout in seconds",
+        type: "number",
+        default: 120,
+      },
       "active-cleanup-limit": {
         describe: "job/active-cleanup: max number of streams to clean up",
         type: "number",
@@ -618,9 +625,7 @@ export default function parseCli(argv?: string | readonly string[]) {
     .help()
     .parse(argv);
   // yargs returns a Promise even tho we don't have any async middlewares
-  const parsed = parsedProm as Awaited<typeof parsedProm> & {
-    job?: (typeof JOB_TYPES)[number];
-  };
+  const parsed = parsedProm as Awaited<typeof parsedProm> & { job?: JobType };
   const mistOutput = yargsToMist(allOptions);
   if (parsed.json === true) {
     console.log(JSON.stringify(mistOutput));

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -17,7 +17,7 @@ const DEFAULT_ARWEAVE_GATEWAY_PREFIXES = [
   "https://gateway.arweave.net/",
 ];
 
-const JOB_TYPES = ["active-cleanup"] as const;
+const JOB_TYPES = ["active-cleanup", "create-db-tables"] as const;
 
 const yargs = Yargs() as unknown as Argv;
 

--- a/packages/api/src/store/stream-table.ts
+++ b/packages/api/src/store/stream-table.ts
@@ -1,7 +1,7 @@
-import sql from "sql-template-strings";
-import Table from "./table";
-import { Stream } from "../schema/types";
 import { QueryResult, QueryResultRow } from "pg";
+import sql from "sql-template-strings";
+import { Stream } from "../schema/types";
+import Table from "./table";
 import { DBLegacyObject, QueryOptions, WithID } from "./types";
 
 interface UsageData {
@@ -135,7 +135,7 @@ export default class StreamTable extends Table<DBStream> {
       ORDER BY day
     `;
 
-    let usage = [];
+    let usage: WithID<UsageData>[] = [];
 
     let res: QueryResult<DBUsageHistoryData>;
     res = await this.db.queryWithOpts(q1, opts);

--- a/packages/api/src/test-params.ts
+++ b/packages/api/src/test-params.ts
@@ -1,0 +1,62 @@
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import { v4 as uuid } from "uuid";
+
+import argParser from "./parse-cli";
+
+export const testId = `test_${Date.now()}`;
+export const dbPath = path.resolve(os.tmpdir(), "livepeer", uuid());
+
+const clientId = "EXPECTED_AUDIENCE";
+const trustedDomain = "livepeer.org";
+const jwtAudience = "livepeer";
+const jwtSecret = "secret";
+// enable to test SendGrid integration
+const supportAddr: [string, string] = ["Livepeer Team", "angie@livepeer.org"];
+const sendgridTemplateId = "iamanid";
+const sendgridApiKey = "SG. iamanapikey";
+
+fs.ensureDirSync(dbPath);
+
+const params = argParser();
+// Some overrides... we want to run on a random port for parallel reasons
+delete params.port;
+params.dbPath = dbPath;
+params.clientId = clientId;
+params.trustedDomain = trustedDomain;
+params.jwtAudience = jwtAudience;
+params.jwtSecret = jwtSecret;
+params.supportAddr = supportAddr;
+params.sendgridTemplateId = sendgridTemplateId;
+params.sendgridApiKey = sendgridApiKey;
+params.postgresUrl = `postgresql://postgres@127.0.0.1/${testId}`;
+params.recordObjectStoreId = "mock_store";
+params.recordCatalystObjectStoreId = "mock_store";
+params.vodObjectStoreId = "mock_vod_store";
+params.trustedIpfsGateways = [
+  "https://ipfs.example.com/ipfs/",
+  /https:\/\/.+\.ipfs-provider.io\/ipfs\//,
+];
+params.ingest = [
+  {
+    ingest: "rtmp://test/live",
+    playback: "https://test/hls",
+    playbackDirect: "https://test/hls",
+    base: "https://test",
+    baseDirect: "https://test",
+    origin: "http://test",
+  },
+];
+params.amqpUrl = `amqp://127.0.0.1:5672/${testId}`;
+if (!params.insecureTestToken) {
+  params.insecureTestToken = uuid();
+}
+params.listen = true;
+params.requireEmailVerification = true;
+params.livekitHost = "livekit";
+params.frontend = false;
+
+console.log(`test run parameters: ${JSON.stringify(params)}`);
+
+export default params;

--- a/packages/api/src/test-server.ts
+++ b/packages/api/src/test-server.ts
@@ -2,71 +2,13 @@
  * This file is imported from all the integration tests. It boots up a server based on the provided argv.
  */
 import fs from "fs-extra";
-import os from "os";
-import path from "path";
-import { v4 as uuid } from "uuid";
 
 import makeApp, { AppServer } from "./index";
-import argParser from "./parse-cli";
 import { rabbitMgmt, startAuxTestServer } from "./test-helpers";
-
-const dbPath = path.resolve(os.tmpdir(), "livepeer", uuid());
-const clientId = "EXPECTED_AUDIENCE";
-const trustedDomain = "livepeer.org";
-const jwtAudience = "livepeer";
-const jwtSecret = "secret";
-// enable to test SendGrid integration
-const supportAddr: [string, string] = ["Livepeer Team", "angie@livepeer.org"];
-const sendgridTemplateId = "iamanid";
-const sendgridApiKey = "SG. iamanapikey";
-
-fs.ensureDirSync(dbPath);
-
-const params = argParser();
-// Secret code used for back-door DB access in test env
-
-// Some overrides... we want to run on a random port for parallel reasons
-const testId = `test_${Date.now()}`;
-delete params.port;
-params.dbPath = dbPath;
-params.clientId = clientId;
-params.trustedDomain = trustedDomain;
-params.jwtAudience = jwtAudience;
-params.jwtSecret = jwtSecret;
-params.supportAddr = supportAddr;
-params.sendgridTemplateId = sendgridTemplateId;
-params.sendgridApiKey = sendgridApiKey;
-params.postgresUrl = `postgresql://postgres@127.0.0.1/${testId}`;
-params.recordObjectStoreId = "mock_store";
-params.recordCatalystObjectStoreId = "mock_store";
-params.vodObjectStoreId = "mock_vod_store";
-params.trustedIpfsGateways = [
-  "https://ipfs.example.com/ipfs/",
-  /https:\/\/.+\.ipfs-provider.io\/ipfs\//,
-];
-params.ingest = [
-  {
-    ingest: "rtmp://test/live",
-    playback: "https://test/hls",
-    playbackDirect: "https://test/hls",
-    base: "https://test",
-    baseDirect: "https://test",
-    origin: "http://test",
-  },
-];
-params.amqpUrl = `amqp://127.0.0.1:5672/${testId}`;
-if (!params.insecureTestToken) {
-  params.insecureTestToken = uuid();
-}
-params.listen = true;
-params.requireEmailVerification = true;
-params.livekitHost = "livekit";
-params.frontend = false;
+import params, { dbPath, testId } from "./test-params";
 
 let server: AppServer & { host?: string };
 let catalystServer;
-
-console.log(`test run parameters: ${JSON.stringify(params)}`);
 
 async function setupServer() {
   await rabbitMgmt.createVhost(testId);

--- a/packages/api/src/util.ts
+++ b/packages/api/src/util.ts
@@ -11,7 +11,7 @@ export interface RequestInitWithRedirects extends RequestInitWithTimeout {
 export const timeout = <T>(ms: number, fn: () => Promise<T>) => {
   return new Promise<T>((resolve, reject) => {
     const handle = setTimeout(() => {
-      reject(Error("timed out"));
+      reject(new Error(`Timed oout after ${ms}ms`));
     }, ms);
 
     fn()

--- a/packages/api/src/webhooks/cannon.test.ts
+++ b/packages/api/src/webhooks/cannon.test.ts
@@ -71,6 +71,7 @@ describe("webhook cannon", () => {
       console.log("postgres NAME", server.postgresUrl);
     } catch (error) {
       console.log("caught server error ", error);
+      throw error;
     }
     postMockStream =
       require("../controllers/wowza-hydrate.test-data.json").stream;


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This is to implement a long-due change, to start doing long-running jobs as a 
separate execution instead of calling an API to do it. The idea is that these jobs
will run directly in our Kubernetes clusters in a necessarily isolated environment,
not making calls to the API and potentially competing for resources.

There are 3 jobs being created here:
- `active-cleanup`: Runs the logic to clean-up active streams that are lost. This was
just created in #2013 and is currently running on a GitHub action.
- `update-usage`: Runs the logic to update the usage tables every hour. This is crucial
for our user billing workflow as well. Currently it's also running on a GitHub action that
always fails because it doesn't complete under 1 minute.
- `create-db-tables`: This will simply create new `DB` clients to create all tables and
indexes. The intention is to run this as an `initContainer` of the API, so we don't need to
do it on the main container startup instead.

**Specific updates (required)**
- Create CLI args to say which job should run (and some for custom args for each job)
- Call that separate job func from the startup
- Implement each of the jobs as separate functions on new `./jobs` dir
- Call the jobs from the APIs to avoid repetition (having the API might still be useful to run on demand)

**How did you test each of these updates (required)**
For now mostly made sure it still compiles after the refactors. Will run each job separately to make sure it works.

**Does this pull request close any open issues?**
Implement ENG-2034

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
