### PR TITLE
api: Livestream recording customization

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -33,7 +33,7 @@
     "go-livepeer:broadcaster": "bin/livepeer -broadcaster -datadir ./bin/broadcaster -orchAddr 127.0.0.1:3086 -rtmpAddr 0.0.0.0:3035 -httpAddr :3085 -cliAddr :3075 -v 6 -authWebhookUrl http://127.0.0.1:3004/api/stream/hook -orchWebhookUrl http://127.0.0.1:3004/api/orchestrator",
     "go-livepeer:orchestrator": "bin/livepeer -orchestrator -datadir ./bin/orchestrator -transcoder -serviceAddr 127.0.0.1:3086 -cliAddr :3076 -v 6",
     "test": "POSTGRES_CONNECT_TIMEOUT=120000 jest -i --silent \"${PWD}/src\"",
-    "test-single": "POSTGRES_CONNECT_TIMEOUT=120000 jest -i --silent \"${PWD}/src/controllers/$filename\"",
+    "test-single": "POSTGRES_CONNECT_TIMEOUT=120000 jest -i --silent \"${PWD}/src/.*$filename.*\"",
     "test:dev": "jest \"${PWD}/src\" -i --silent --watch",
     "test:build": "parcel build --no-autoinstall --no-minify --bundle-node-modules -t browser --out-dir ../dist-worker ../src/worker.js",
     "coverage": "yarn run test --coverage",

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -85,6 +85,7 @@ const EMPTY_NEW_STREAM_PAYLOAD: Required<
   multistream: undefined,
   pull: undefined,
   record: undefined,
+  recordingSpec: undefined,
   userTags: undefined,
   creatorId: undefined,
   playbackPolicy: undefined,

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -629,6 +629,21 @@ components:
             customization, create and configure an object store.
           type: boolean
           example: false
+        recordingSpec:
+          type: object
+          description: |
+            Configuration for recording the stream. This can only be set if
+            `record` is true.
+          additionalProperties: false
+          properties:
+            profiles:
+              type: array
+              items:
+                $ref: "#/components/schemas/ffmpeg-profile"
+              description: |
+                Profiles to record the stream in. If not specified, the stream
+                will be recorded in the same profiles as the stream itself. Keep
+                in mind that the source rendition will always be recorded.
         multistream:
           type: object
           additionalProperties: false
@@ -682,6 +697,8 @@ components:
             $ref: "#/components/schemas/ffmpeg-profile"
         record:
           $ref: "#/components/schemas/stream/properties/record"
+        recordingSpec:
+          $ref: "#/components/schemas/stream/properties/recordingSpec"
         multistream:
           $ref: "#/components/schemas/stream/properties/multistream"
         userTags:
@@ -911,6 +928,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ffmpeg-profile"
+        recordingSpec:
+          $ref: "#/components/schemas/stream/properties/recordingSpec"
     error:
       type: object
       properties:

--- a/packages/api/src/test-server.ts
+++ b/packages/api/src/test-server.ts
@@ -2,9 +2,9 @@
  * This file is imported from all the integration tests. It boots up a server based on the provided argv.
  */
 import fs from "fs-extra";
-import { v4 as uuid } from "uuid";
-import path from "path";
 import os from "os";
+import path from "path";
+import { v4 as uuid } from "uuid";
 
 import makeApp, { AppServer } from "./index";
 import argParser from "./parse-cli";
@@ -38,6 +38,7 @@ params.sendgridTemplateId = sendgridTemplateId;
 params.sendgridApiKey = sendgridApiKey;
 params.postgresUrl = `postgresql://postgres@127.0.0.1/${testId}`;
 params.recordObjectStoreId = "mock_store";
+params.recordCatalystObjectStoreId = "mock_store";
 params.vodObjectStoreId = "mock_vod_store";
 params.trustedIpfsGateways = [
   "https://ipfs.example.com/ipfs/",

--- a/packages/api/src/webhooks/cannon.test.ts
+++ b/packages/api/src/webhooks/cannon.test.ts
@@ -1,13 +1,21 @@
 import fetch from "node-fetch";
-import serverPromise, { TestServer } from "../test-server";
+import { v4 as uuid } from "uuid";
+
+import { sign } from "../controllers/helpers";
+import { USER_SESSION_TIMEOUT } from "../controllers/stream";
+import { ObjectStore, Stream, User, Webhook } from "../schema/types";
+import { db } from "../store";
+import { DBSession } from "../store/session-table";
+import { DBStream } from "../store/stream-table";
+import { WithID } from "../store/types";
 import {
+  AuxTestServer,
   TestClient,
   clearDatabase,
   startAuxTestServer,
-  AuxTestServer,
 } from "../test-helpers";
+import serverPromise, { TestServer } from "../test-server";
 import { semaphore, sleep } from "../util";
-import { sign } from "../controllers/helpers";
 
 const bodyParser = require("body-parser");
 jest.setTimeout(15000);
@@ -17,10 +25,11 @@ describe("webhook cannon", () => {
   let webhookServer: AuxTestServer;
   let testHost;
 
-  let mockAdminUser;
-  let mockNonAdminUser;
-  let postMockStream;
-  let mockWebhook;
+  let mockAdminUser: User;
+  let mockNonAdminUser: User;
+  let postMockStream: Stream;
+  let mockStore: WithID<ObjectStore>;
+  let mockWebhook: Webhook;
   let client, adminUser, adminToken, nonAdminUser, nonAdminToken;
 
   async function setupUsers(server) {
@@ -108,7 +117,13 @@ describe("webhook cannon", () => {
 
     webhookServer = await startAuxTestServer(30000);
     testHost = `http://127.0.0.1:${webhookServer.port}`;
-    console.log("beforeALL done");
+
+    mockStore = {
+      id: "mock_store",
+      url: `s3+http://localhost:${webhookServer.port}/bucket-name`,
+      publicUrl: `http://localhost:${webhookServer.port}/bucket-name`,
+      userId: mockAdminUser.id,
+    };
   });
 
   afterAll(async () => {
@@ -118,6 +133,8 @@ describe("webhook cannon", () => {
   beforeEach(async () => {
     ({ client, adminUser, adminToken, nonAdminUser, nonAdminToken } =
       await setupUsers(server));
+
+    await db.objectStore.create(mockStore);
   });
 
   afterEach(async () => {
@@ -159,12 +176,13 @@ describe("webhook cannon", () => {
     beforeAll(() => {
       webhookServer.app.use(bodyParser.json());
       webhookServer.app.use((req, res, next) => {
-        console.log("WEBHOOK WORKS , body", req.body);
-        const signatureHeader = String(req.headers["livepeer-signature"]);
-        const signature: string = signatureHeader.split(",")[1].split("=")[1];
-        expect(signature).toEqual(
-          sign(JSON.stringify(req.body), mockWebhook.sharedSecret)
-        );
+        if (req.path.startsWith("/webhook")) {
+          const signatureHeader = String(req.headers["livepeer-signature"]);
+          const signature: string = signatureHeader.split(",")[1].split("=")[1];
+          expect(signature).toEqual(
+            sign(JSON.stringify(req.body), mockWebhook.sharedSecret)
+          );
+        }
         next();
       });
       webhookServer.app.post("/webhook", (req, res) => {
@@ -394,6 +412,145 @@ describe("webhook cannon", () => {
 
       await Promise.all(sems.map((s) => s.wait(3000)));
       expect(calledCounts).toEqual([4, 2]);
+    });
+
+    describe("recording.waiting handling", () => {
+      let parentStream: DBStream;
+      let childStream: DBStream;
+      let session: DBSession;
+
+      beforeEach(async () => {
+        // create parent stream
+        let res = await client.post(`/stream`, {
+          ...postMockStream,
+          record: true,
+          recordingSpec: {
+            profiles: [
+              {
+                name: "720p",
+                bitrate: 2000000,
+                fps: 30,
+                width: 1280,
+                height: 720,
+              },
+            ],
+          },
+        });
+        expect(res.status).toBe(201);
+        parentStream = await res.json();
+
+        // create child stream and session
+        const sessionId = uuid();
+        res = await client.post(
+          `/stream/${parentStream.id}/stream?sessionId=${sessionId}`,
+          {
+            name: "session1",
+          }
+        );
+        expect(res.status).toBe(201);
+        childStream = await res.json();
+        expect(childStream).toMatchObject({
+          sessionId,
+          parentId: parentStream.id,
+          isActive: true,
+        });
+
+        session = await db.session.get(sessionId);
+        expect(session).toMatchObject({ id: sessionId });
+
+        const lastSeen = Date.now() - 2 * USER_SESSION_TIMEOUT;
+        await db.stream.update(childStream.id, { lastSeen });
+        await db.session.update(session.id, {
+          lastSeen,
+          sourceSegments: 1,
+        });
+
+        webhookServer.app.all("/bucket-name/*", (req, res) => {
+          console.log("req.url", req.url);
+          res.end("a good file");
+        });
+      });
+
+      it("should create asset from recording.waiting event", async () => {
+        const res = await client.post("/webhook", {
+          ...mockWebhook,
+          name: "test-recording-waiting",
+          events: ["recording.waiting"],
+        });
+        expect(res.status).toBe(201);
+        const webhook = await res.json();
+        expect(webhook.userId).toEqual(nonAdminUser.id);
+
+        const sem = semaphore();
+        let called = false;
+        webhookCallback = () => {
+          called = true;
+          sem.release();
+        };
+
+        await server.queue.publishWebhook("events.recording.waiting", {
+          type: "webhook_event",
+          id: "webhook_test_12",
+          timestamp: Date.now(),
+          streamId: parentStream.id,
+          sessionId: session.id,
+          event: "recording.waiting",
+          userId: nonAdminUser.id,
+        });
+
+        await sem.wait(3000);
+        expect(called).toBe(true);
+
+        const asset = await db.asset.get(session.id);
+        expect(asset).toMatchObject({
+          id: session.id,
+          userId: nonAdminUser.id,
+          source: {
+            type: "recording",
+            sessionId: session.id,
+          },
+          status: {
+            phase: "waiting",
+          },
+        });
+      });
+
+      it("should propagate recording spec to upload task", async () => {
+        const res = await client.post("/webhook", {
+          ...mockWebhook,
+          name: "test-recording-waiting",
+          events: ["recording.waiting"],
+        });
+        expect(res.status).toBe(201);
+        const webhook = await res.json();
+        expect(webhook.userId).toEqual(nonAdminUser.id);
+
+        const sem = semaphore();
+        let called = false;
+        webhookCallback = () => {
+          called = true;
+          sem.release();
+        };
+
+        await server.queue.publishWebhook("events.recording.waiting", {
+          type: "webhook_event",
+          id: "webhook_test_12",
+          timestamp: Date.now(),
+          streamId: parentStream.id,
+          sessionId: session.id,
+          event: "recording.waiting",
+          userId: nonAdminUser.id,
+        });
+
+        await sem.wait(3000);
+        expect(called).toBe(true);
+
+        const [tasks] = await db.task.find({ outputAssetId: session.id });
+        expect(tasks).toHaveLength(1);
+        expect(tasks[0].params?.upload).toMatchObject({
+          profiles: parentStream.recordingSpec.profiles,
+        });
+      });
     });
   });
 

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -585,6 +585,7 @@ export default class WebhookCannon {
         {
           upload: {
             url: url,
+            profiles: session.recordingSpec?.profiles,
             thumbnails: !(await isExperimentSubject(
               "vod-thumbs-off",
               session.userId


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This adds a new `recordingSpec` field on `stream` objects to allow customizing
the recordings created from it.

This builds on top of https://github.com/livepeer/catalyst-api/pull/1261 which gives
support for empty profiles to be specified, as well as copying the source instead of
transcoding to same profile.

All of this will be used in conjunction to allow a customer to have transcode-less
recordings. This is a bit more flexible than that, also allowing customizing the
transcoding profiles of the recordings, not only turning them off.

**Specific updates (required)**
- Add `recordingSpec` field to streams and sessions
- Propagate `recordingSpec` field across streams/sessions
- Use `recordingSpec` field when creating recording upload task

**How did you test each of these updates (required)**
`yarn test`

**Does this pull request close any open issues?**
Implements ENG-1997

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ]  I have added tests to cover my changes.
