### PR TITLE
logger: Allow enabling verbose logs for staging

### DIFF
--- a/packages/api/src/logger.js
+++ b/packages/api/src/logger.js
@@ -2,9 +2,13 @@ import winston from "winston";
 
 const isSilentTest =
   process.env.NODE_ENV === "test" && process.argv.indexOf("--silent") > 0;
+const verbose =
+  process.argv.indexOf("--verbose") > 0 ||
+  ["true", "1"].includes(process.env.LP_API_VERBOSE?.toLowerCase());
 
 export default winston.createLogger({
   silent: isSilentTest,
+  level: verbose ? "debug" : "info",
   format: winston.format.combine(
     winston.format.colorize(),
     winston.format.timestamp({ format: "YYYY-MM-DD HH:mm:ss" }),

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -560,6 +560,11 @@ export default function parseCli(argv?: string | readonly string[]) {
         ] as FfmpegProfile[]),
         coerce: coerceJsonProfileArr("default-stream-profiles"),
       },
+      // this is actually handled raw on ./logger.js but we declare it here so yargs recognizes it
+      verbose: {
+        describe: "enable verbose logging",
+        type: "boolean",
+      },
     })
     .usage(
       `


### PR DESCRIPTION
Far too often I want the DB logs on staging and we don't have them. I think
we should just keep debug logs enabled there.