### PR TITLE
api/jobs/update-usage: Process users in parallel and allow cancellation

### DIFF
--- a/packages/api/src/jobs/index.ts
+++ b/packages/api/src/jobs/index.ts
@@ -18,9 +18,17 @@ export async function runJob(jobName: JobType, config: CliArgs): Promise<void> {
 
   logger.info(`Starting job. job=${jobName}`);
   try {
-    const result = await timeout(config.jobTimeoutSec * 1000, () =>
-      jobFuncs[jobName](config)
-    );
+    const sigterm = new Promise<never>((_, reject) => {
+      process.on("SIGTERM", () => {
+        logger.warn("SIGTERM received, terminating immediately...");
+        reject(new Error("Job was terminated by SIGTERM"));
+      });
+    });
+    const job = timeout(config.jobTimeoutSec * 1000, () => {
+      return jobFuncs[jobName](config);
+    });
+
+    const result = await Promise.race([job, sigterm]);
 
     const elapsedTime = process.hrtime(startTime);
     const elapsedTimeSec = elapsedTime[0] + elapsedTime[1] / 1e9;

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -550,6 +550,12 @@ export default function parseCli(argv?: string | readonly string[]) {
           "job/update-usage: Admin API token to be used in the update usage job internal calls",
         type: "string",
       },
+      "update-usage-concurrency": {
+        describe:
+          "job/update-usage: number of concurrent workers to run for updating users usage",
+        type: "number",
+        default: 10,
+      },
       "stream-info-service": {
         describe: "start the Stream Info service instead of Studio API",
         type: "boolean",


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This improves the `update-usage` job by processing users in parallel (up to 10 at a time).

The job is currently taking ~70 minutes to run so I hope this would bring it under 10min.

**Specific updates (required)**
- Respect SIGTERM from the job runtime
- Paralelize user usage reporting
- Fix console.log logs to logger

**How did you test each of these updates (required)**
`yarn test`

**Does this pull request close any open issues?**
Fixes issue noticed after jobs reply, not tracked to Linear.

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
