### PR TITLE
api: Add profiles field to asset

### DIFF
--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -1112,6 +1112,15 @@ components:
                     ID of the asset from which this asset was created.
         creatorId:
           $ref: "#/components/schemas/creator-id"
+        profiles:
+          type: array
+          description: |
+            Requested profiles for the asset to be transcoded into. Currently
+            only supported for livestream recording assets, configured through
+            the `stream.recordingSpec` field. If this is not present it means
+            that default profiles were derived from the input metadata.
+          items:
+            $ref: "#/components/schemas/ffmpeg-profile"
         storage:
           additionalProperties: false
           properties:

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -567,6 +567,7 @@ export default class WebhookCannon {
           projectId: session.projectId,
           createdAt: session.createdAt,
           source: { type: "recording", sessionId: session.id },
+          profiles: session.recordingSpec?.profiles,
           status: { phase: "waiting", updatedAt: Date.now() },
           name: `live-${startedAt}`,
           objectStoreId:


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This will be required by our billing workflow to skip transcode billing for copy-only assets. That flow is
only possible for recording assets, customized through `stream.recordingSpec` field.

**Specific updates (required)**
- Add `asset.profiles` field
- Propagate the `stream.recordingSpec.profiles` to it

**How did you test each of these updates (required)**
`yarn test`

**Does this pull request close any open issues?**
Part of ENG-2050

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
