### PR TITLE
Do not sigterm on unhandled rejection

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -83,7 +83,6 @@ export default async function makeApp(params: CliArgs) {
   const unhandledRejection = (err) => {
     logger.error("fatal, unhandled promise rejection: ", err);
     err.stack && logger.error(err.stack);
-    sigterm();
   };
   process.on("unhandledRejection", unhandledRejection);
 


### PR DESCRIPTION
TUS library sometimes fails with the following error, resulting in SIGTERM (and the pod restart). Let's not sigterm in the case of unhandled promise rejection.

```
fatal, unhandled promise rejection:  The specified key does not exist. {
```

Discord thread: https://discord.com/channels/423160867534929930/1253604881160343655/1253617251022536746