### PR TITLE
api: Fix boolean filters parsing on List APIs

### DIFF
--- a/packages/api/src/controllers/helpers.ts
+++ b/packages/api/src/controllers/helpers.ts
@@ -517,7 +517,7 @@ function parseFiltersRaw(fieldsMap: FieldsMap, val: string): SQLStatement[] {
 
   for (const filter of json) {
     const fv = fieldsMap[filter.id];
-    if (!filter.value) {
+    if (!("value" in filter)) {
       throw new Error(`missing filter value for id "${filter.id}"`);
     }
 


### PR DESCRIPTION
We were checking the value with !value, which fails if the value is a "falsy" field like an empty string or even the boolean `false` itself.

Fix it by checking if the filter object contains the key instead.