### PR TITLE
api/api-token: Avoid read-after-write inconsistency on creation

### DIFF
--- a/packages/api/src/controllers/api-token.js
+++ b/packages/api/src/controllers/api-token.js
@@ -175,7 +175,7 @@ app.post("/", validatePost("api-token"), async (req, res) => {
     access: req.body.access,
     createdAt: Date.now(),
   });
-  const apiToken = await req.store.get(`api-token/${id}`);
+  const apiToken = await db.apiToken.get(id, { useReplica: false });
 
   if (apiToken) {
     res.status(201);


### PR DESCRIPTION
When we crete the API token for some reason we read it back instead of trusting the DB transaction worked. The problem is that we read from the DB replica by default and there might be some replication lag.

Fix it by flagging not to read from the replica instead. I could remove that logic altogether but I want to make as less intrusive of a fix as possible.
