### PR TITLE
api: Fix asset.ready webhook schema

### DIFF
--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -1,23 +1,22 @@
 import { ConsumeMessage } from "amqplib";
-import { jobsDb as db } from "../store"; // use only the jobs DB pool on queue logic
-import messages from "../store/messages";
-import Queue from "../store/queue";
-import { Asset, Task } from "../schema/types";
-import { v4 as uuid } from "uuid";
-import { WithID } from "../store/types";
-import { taskOutputToIpfsStorage } from "../store/asset-table";
-import { RoutingKey } from "../store/queue";
-import { EventKey } from "../store/webhook-table";
-import { sleep } from "../util";
 import sql from "sql-template-strings";
-import { TooManyRequestsError } from "../store/errors";
-import { CliArgs } from "../parse-cli";
+import { v4 as uuid } from "uuid";
+import { toExternalAsset } from "../controllers/asset";
+import { toExternalSession } from "../controllers/session";
 import {
   taskParamsWithoutCredentials,
   toExternalTask,
 } from "../controllers/task";
-import { toExternalAsset } from "../controllers/asset";
-import { toExternalSession } from "../controllers/session";
+import { CliArgs } from "../parse-cli";
+import { Asset, Task } from "../schema/types";
+import { jobsDb as db } from "../store"; // use only the jobs DB pool on queue logic
+import { taskOutputToIpfsStorage } from "../store/asset-table";
+import { TooManyRequestsError } from "../store/errors";
+import messages from "../store/messages";
+import Queue, { RoutingKey } from "../store/queue";
+import { WithID } from "../store/types";
+import { EventKey } from "../store/webhook-table";
+import { sleep } from "../util";
 
 const taskInfo = (task: WithID<Task>, config: CliArgs): messages.TaskInfo => ({
   id: task.id,

--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -646,6 +646,10 @@ export class TaskScheduler {
         payload: {
           id: asset.id,
           snapshot,
+          asset: {
+            id: asset.id,
+            snapshot,
+          },
         },
       });
     }

--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -614,7 +614,7 @@ export class TaskScheduler {
     }
     asset = { ...asset, ...updates };
 
-    const snapshot = toExternalAsset(asset, this.config, true);
+    const snapshot = await toExternalAsset(asset, this.config, true);
     const timestamp = asset.status.updatedAt;
     const event = updates.deleted ? "asset.deleted" : "asset.updated";
     await this.queue.publishWebhook(`events.${event}`, {

--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -644,8 +644,6 @@ export class TaskScheduler {
         userId: asset.userId,
         projectId: asset.projectId,
         payload: {
-          id: asset.id,
-          snapshot,
           asset: {
             id: asset.id,
             snapshot,

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -4,6 +4,7 @@ import isLocalIP from "is-local-ip";
 import _ from "lodash";
 import { isIP } from "net";
 import { Response } from "node-fetch";
+import promclient from "prom-client";
 import { parse as parseUrl } from "url";
 import { v4 as uuid } from "uuid";
 import { createAsset, primaryStorageExperiment } from "../controllers/asset";
@@ -28,6 +29,12 @@ const WEBHOOK_TIMEOUT = 30 * 1000;
 const MAX_BACKOFF = 60 * 60 * 1000;
 const BACKOFF_COEF = 2;
 const MAX_RETRIES = 33;
+const ASSET_HOOK_OLD_SCHEMA_THRESHOLD = 1722124800000; // 2024-07-28Z
+const oldHookCounter = new promclient.Counter({
+  name: "asset_webhook_old_schema_count",
+  help: "Count of webhooks fired with the old schema",
+  labelNames: ["event"],
+});
 
 const SIGNATURE_HEADER = "Livepeer-Signature";
 
@@ -352,7 +359,21 @@ export default class WebhookCannon {
     } else {
       console.log("preparing to fire webhook ", webhook.url);
       const timestamp = Date.now();
-      // go ahead
+      let { payload } = event;
+      if (
+        ["asset.ready", "asset.failed"].includes(event.event) &&
+        webhook.createdAt <= ASSET_HOOK_OLD_SCHEMA_THRESHOLD
+      ) {
+        // When these webhooks were originally created, the payload didn't include a nested `asset` field to encapsulate
+        // the fields from the asset. We fixed the schema but we need to keep supporting the old schema for old webhooks.
+        // TODO: Remove this once the metric below is all zeroed out.
+        payload = {
+          ...payload.asset,
+          ...payload,
+        };
+        oldHookCounter.inc({ event: event.event });
+      }
+
       let params = {
         method: "POST",
         headers: {
@@ -367,7 +388,7 @@ export default class WebhookCannon {
           timestamp,
           event: event.event,
           stream,
-          payload: event.payload,
+          payload,
         }),
       };
 


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This is to fix the `asset.ready` (and failed) webhook schemas, since they had an
inconsistent schema with the `asset.updated` one. The problem was that it missed
the wrapper `asset` field to hold the asset information, and instead everything was
going in the root with no specification. This was an oversight on initial impl. 

Maintained backward compatibility with all the webhooks created before we deploy
this, only adding a new field instead of removing the existing ones. For webhooks created
after Jul 28, we will only include the `asset` field and keep it consistent with the other hooks.

A related issue was that the asset `snapshot` was always coming out as an empty
object. This is just because there was a missed `await` when creating it.

**Specific updates (required)**
- `await` the result of `toExternalAsset` when building the `snapshot` field
- Wrap the `id`/`snapshot` fields in an `asset` field for the `asset.ready|failed` hooks
- Add a logic on the webhook cannon to add the old fields for old webhooks (backward compat)

**How did you test each of these updates (required)**
`yarn test` with the existing tests.  No new tests added since there's no existing testing infra
for these changed components and this is a quick hotfix for a customer.

Will double-check the fix works on `staging` after this gets merged.

**Does this pull request close any open issues?**

Fixes [DISCORD-1262837310601302079](https://discord.com/channels/423160867534929930/1262837310601302079)

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
