### PR TITLE
api/generate: Implement rate limiting based on req logs

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -33,7 +33,7 @@
     "go-livepeer:broadcaster": "bin/livepeer -broadcaster -datadir ./bin/broadcaster -orchAddr 127.0.0.1:3086 -rtmpAddr 0.0.0.0:3035 -httpAddr :3085 -cliAddr :3075 -v 6 -authWebhookUrl http://127.0.0.1:3004/api/stream/hook -orchWebhookUrl http://127.0.0.1:3004/api/orchestrator",
     "go-livepeer:orchestrator": "bin/livepeer -orchestrator -datadir ./bin/orchestrator -transcoder -serviceAddr 127.0.0.1:3086 -cliAddr :3076 -v 6",
     "test": "POSTGRES_CONNECT_TIMEOUT=120000 jest -i --silent \"${PWD}/src\"",
-    "test-single": "POSTGRES_CONNECT_TIMEOUT=120000 jest -i --silent \"${PWD}/src/.*$filename.*\"",
+    "test-single": "POSTGRES_CONNECT_TIMEOUT=120000 jest -i \"${PWD}/src/.*$filename.*\"",
     "test:dev": "jest \"${PWD}/src\" -i --silent --watch",
     "test:build": "parcel build --no-autoinstall --no-minify --bundle-node-modules -t browser --out-dir ../dist-worker ../src/worker.js",
     "coverage": "yarn run test --coverage",

--- a/packages/api/src/controllers/generate.ts
+++ b/packages/api/src/controllers/generate.ts
@@ -223,7 +223,7 @@ function registerGenerateHandler(
         }
       }
 
-      if (gatewayRes.status >= 500) {
+      if (!req.user.admin && gatewayRes.status >= 500) {
         // We hide internal server error details from the user.
         return res.status(500).json({ errors: [`Failed to generate ${type}`] });
       }

--- a/packages/api/src/controllers/signing-key.test.ts
+++ b/packages/api/src/controllers/signing-key.test.ts
@@ -1,21 +1,21 @@
-import serverPromise, { TestServer } from "../test-server";
-import {
-  TestClient,
-  clearDatabase,
-  createApiToken,
-  setupUsers,
-  verifyJwt,
-} from "../test-helpers";
+import jwt, { JsonWebTokenError, JwtPayload } from "jsonwebtoken";
 import {
   ApiToken,
   SigningKey,
   SigningKeyResponsePayload,
   User,
 } from "../schema/types";
-import { WithID } from "../store/types";
-import jwt, { JsonWebTokenError, JwtPayload } from "jsonwebtoken";
 import { db } from "../store";
-import { createProject } from "../test-helpers";
+import { WithID } from "../store/types";
+import {
+  TestClient,
+  clearDatabase,
+  createApiToken,
+  createProject,
+  setupUsers,
+  verifyJwt,
+} from "../test-helpers";
+import serverPromise, { TestServer } from "../test-server";
 
 // includes auth file tests
 
@@ -86,13 +86,13 @@ describe("controllers/signing-key", () => {
       apiKeyWithProject = await createApiToken({
         client: client,
         projectId: project.id,
-        jwtAuthToken: nonAdminToken,
       });
       expect(apiKeyWithProject).toMatchObject({
         id: expect.any(String),
         projectId: projectId,
       });
-      projectId = project.id;
+      client.jwtAuth = null;
+      client.apiKey = apiKeyWithProject.id;
     });
 
     it("should create a signing key and display the private key only on creation", async () => {

--- a/packages/api/src/controllers/stream.test.ts
+++ b/packages/api/src/controllers/stream.test.ts
@@ -1511,14 +1511,13 @@ describe("controllers/stream", () => {
       newApiKey = await createApiToken({
         client: client,
         projectId: project.id,
-        jwtAuthToken: nonAdminToken,
       });
       expect(newApiKey).toMatchObject({
         id: expect.any(String),
         projectId: project.id,
       });
 
-      client.jwtAuth = "";
+      client.jwtAuth = null;
       client.apiKey = newApiKey.id;
 
       // create streams with a projectId

--- a/packages/api/src/parse-cli.ts
+++ b/packages/api/src/parse-cli.ts
@@ -413,6 +413,12 @@ export default function parseCli(argv?: string | readonly string[]) {
         default: 100,
         type: "number",
       },
+      aiMaxRequestsPerMinutePerUser: {
+        describe:
+          "maximum number of AI generate requests that can be made by a user per minute",
+        default: 20,
+        type: "number",
+      },
       "ingest-region": {
         describe:
           "list of ingest endpoints to use as servers to consult for /api/ingest",

--- a/packages/api/src/schema/db-schema.yaml
+++ b/packages/api/src/schema/db-schema.yaml
@@ -1427,6 +1427,7 @@ components:
           example: 5b9e63bb-6fd0-4bea-aff2-cc5d4eb9cad0
         startedAt:
           type: number
+          index: true
           readOnly: true
           description:
             Timestamp (in milliseconds) at which the AI generation started

--- a/packages/api/src/test-helpers.ts
+++ b/packages/api/src/test-helpers.ts
@@ -2,12 +2,12 @@ import express, { Express } from "express";
 import fetch, { RequestInit } from "node-fetch";
 import { v4 as uuid } from "uuid";
 
-import schema from "./schema/schema.json";
-import { ApiToken, User } from "./schema/types";
-import { TestServer } from "./test-server";
 import fs from "fs";
 import jwt, { VerifyOptions } from "jsonwebtoken";
+import schema from "./schema/schema.json";
+import { ApiToken, User } from "./schema/types";
 import { WithID } from "./store/types";
+import { TestServer } from "./test-server";
 
 const vhostUrl = (vhost: string) =>
   `http://guest:guest@127.0.0.1:15672/api/vhosts/${vhost}`;
@@ -206,39 +206,28 @@ export async function createProject(client: TestClient) {
   return project;
 }
 
-export async function useApiTokenWithProject(
-  client: TestClient,
-  token: string,
-) {
-  client.jwtAuth = token;
+export async function createApiTokenInNewProject(client: TestClient) {
   const project = await createProject(client);
   const newApiKey = await createApiToken({
     client: client,
     projectId: project.id,
-    jwtAuthToken: token,
   });
-  client.apiKey = newApiKey.id;
-  return client;
+  return { project, newApiKey };
 }
 
 export async function createApiToken({
   client,
   projectId,
   tokenName = "test",
-  jwtAuthToken,
 }: {
   client: TestClient;
   projectId: string;
   tokenName?: string;
-  jwtAuthToken: string;
 }): Promise<WithID<ApiToken>> {
-  client.jwtAuth = jwtAuthToken;
   let res = await client.post(`/api-token/?projectId=${projectId}`, {
     name: tokenName,
   });
-  client.jwtAuth = null;
-  const apiKeyObj = await res.json();
-  return apiKeyObj;
+  return await res.json();
 }
 
 export async function createUser(

--- a/packages/api/src/test-params.ts
+++ b/packages/api/src/test-params.ts
@@ -39,6 +39,7 @@ params.trustedIpfsGateways = [
   /https:\/\/.+\.ipfs-provider.io\/ipfs\//,
 ];
 params.aiGatewayUrl = "http://localhost:30303/";
+params.aiMaxRequestsPerMinutePerUser = 5;
 params.ingest = [
   {
     ingest: "rtmp://test/live",


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

This creates the capability of rate-limiting API calls to the `/generate` endpoints.
It uses the request log built on #2273 to track the rate of requests and limits based
on a CLI argument.

We can later build support for per billing plan limits depending on the user, but I left
that for the future.

**Specific updates (required)**
- Create new rate limit logic on generate API through a middleware
- Add tests to the rate limiter logic

**How did you test each of these updates (required)**
`yarn test`

**Does this pull request close any open issues?**
Implements ENG-2180

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
