### PR TITLE
api: webhook: improve asset webhooks behavior

### DIFF
--- a/packages/api/src/controllers/task.ts
+++ b/packages/api/src/controllers/task.ts
@@ -361,11 +361,15 @@ app.post("/:id/status", authorizer({ anyAdmin: true }), async (req, res) => {
   );
   if (task.outputAssetId) {
     const asset = await db.asset.get(task.outputAssetId);
+    let phase: Asset["status"]["phase"] = "processing";
+    if (asset.status?.phase === "deleting") {
+      phase = "deleting";
+    }
     await req.taskScheduler.updateAsset(
       asset,
       {
         status: {
-          phase: "processing",
+          phase,
           updatedAt: Date.now(),
           progress: Math.max(doc.progress, asset.status.progress ?? 0),
         },


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

There is currently some confusion in the way that the asset webhooks work.
This is to address the issue, making these changes to how webhooks behave

- Make sure the payload sent on asset.deleted is from before any internal updates made to the asset.
- Stop sending asset.updated for deleted assets.
- Move all assets to deleting when deleted, not only ready
- Stop updating assets deleting phase if there are further updates

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional)**

<!-- Drag some screenshots here, if applicable -->

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
