### PR TITLE
Don't use db replica for asset get when trying to update asset

### DIFF
--- a/packages/api/src/task/scheduler.ts
+++ b/packages/api/src/task/scheduler.ts
@@ -592,7 +592,7 @@ export class TaskScheduler {
     filters?: { allowedPhases: Array<Asset["status"]["phase"]> },
   ) {
     if (typeof asset === "string") {
-      asset = await db.asset.get(asset);
+      asset = await db.asset.get(asset, { useReplica: false });
     }
     const phaseChanged =
       updates.status && asset.status.phase !== updates.status.phase;


### PR DESCRIPTION
This seems to have caused a vod problem where we failed to read an asset from the db when processing the task complete event
