### PR TITLE
Remove Attestation Tests for Flow Wallet

### DIFF
--- a/packages/api/src/controllers/experiment/attestation.test.ts
+++ b/packages/api/src/controllers/experiment/attestation.test.ts
@@ -148,11 +148,6 @@ describe("Attestation API", () => {
   });
 
   describe("POST /", () => {
-    it("should support Flow Wallet signatures", async () => {
-      const res = await client.post("/experiment/-/attestation", FLOW_REQUEST);
-      expect(res.status).toBe(201);
-    });
-
     it("should return an error for invalid primaryType", async () => {
       let request = JSON.parse(JSON.stringify(REQUEST));
       request.primaryType = "InvalidType";


### PR DESCRIPTION
The attestation test is failing for the Flow Wallet (it's related to the Flow library update). Since, it's attestation endpoint is super experimental and I'm not sure if anyone uses it with the Flow Wallet, let's just remove the test for now.

In some time (a few months), I'll open the discussion if we should remove the whole `/attestation` endpoint (or maybe just the Flow Wallet signing).