### PR TITLE
Buffer webhook status updates

### DIFF
--- a/packages/api/src/controllers/webhook.test.ts
+++ b/packages/api/src/controllers/webhook.test.ts
@@ -3,6 +3,7 @@ import { TestClient, clearDatabase } from "../test-helpers";
 import { sleep } from "../util";
 import { jobsDb } from "../store";
 import { Webhook } from "../schema/types";
+import tracking from "../middleware/tracking";
 
 let server;
 let mockAdminUser;
@@ -296,13 +297,14 @@ describe("controllers/webhook", () => {
       let hooksCalled = 0;
       for (let i = 0; i < 5 && hooksCalled < 2; i++) {
         await sleep(500);
+        await tracking.flushAll();
 
         hooksCalled = 0;
         for (const id of [webhookResJson.id, webhookResJson2.id]) {
           const res = await client.get(`/webhook/${id}`);
           expect(res.status).toBe(200);
           const { status } = (await res.json()) as Webhook;
-          if (status.lastTriggeredAt >= now) {
+          if (status && status.lastTriggeredAt >= now) {
             hooksCalled++;
           }
         }

--- a/packages/api/src/middleware/tracking.ts
+++ b/packages/api/src/middleware/tracking.ts
@@ -2,6 +2,7 @@ import sql from "sql-template-strings";
 import { ApiToken } from "../schema/types";
 import { db } from "../store";
 import Table from "../store/table";
+import { DBWebhook } from "../store/webhook-table";
 
 const flushDelay = 60 * 1000; // 60s
 
@@ -12,7 +13,7 @@ type PendingLastSeen = {
 };
 
 class Tracker {
-  pendingUpdates: Map<string, PendingLastSeen> = new Map();
+  pendingLastSeenUpdates: Map<string, PendingLastSeen> = new Map();
 
   recordUser(userId: string) {
     this.recordLastSeen(db.user, userId);
@@ -31,16 +32,16 @@ class Tracker {
     id: string,
   ) {
     const key = `${table.name}-${id}`;
-    const alreadyScheduled = this.pendingUpdates.has(key);
-    this.pendingUpdates.set(key, { table, id, lastSeen: Date.now() });
+    const alreadyScheduled = this.pendingLastSeenUpdates.has(key);
+    this.pendingLastSeenUpdates.set(key, { table, id, lastSeen: Date.now() });
     if (alreadyScheduled) return;
 
     setTimeout(() => this.flushLastSeen(key), flushDelay);
   }
 
   private async flushLastSeen(key: string) {
-    const { table, id, lastSeen } = this.pendingUpdates.get(key) ?? {};
-    this.pendingUpdates.delete(key);
+    const { table, id, lastSeen } = this.pendingLastSeenUpdates.get(key) ?? {};
+    this.pendingLastSeenUpdates.delete(key);
     if (!id) {
       return;
     }
@@ -60,13 +61,40 @@ class Tracker {
     }
   }
 
-  async flushAll() {
-    const all = this.pendingUpdates;
-    this.pendingUpdates = new Map();
+  pendingWebhookStatusUpdates: Map<string, DBWebhook["status"]> = new Map();
 
-    for (const key of all.keys()) {
+  recordWebhookStatus(id: string, status: DBWebhook["status"]) {
+    const key = `${id}`;
+    const alreadyScheduled = this.pendingWebhookStatusUpdates.has(key);
+    this.pendingWebhookStatusUpdates.set(key, status);
+    if (alreadyScheduled) return;
+
+    setTimeout(() => this.flushWebhookStatus(key), flushDelay);
+  }
+
+  private async flushWebhookStatus(id: string) {
+    const status = this.pendingWebhookStatusUpdates.get(id) ?? {};
+    this.pendingWebhookStatusUpdates.delete(id);
+    if (!status) {
+      return;
+    }
+    try {
+      await db.webhook.updateStatus(id, status);
+    } catch (err) {
+      console.log(`error saving webhook status: id=${id} err=`, err);
+    }
+  }
+
+  async flushAll() {
+    for (const key of this.pendingLastSeenUpdates.keys()) {
       await this.flushLastSeen(key);
     }
+    this.pendingLastSeenUpdates = new Map();
+
+    for (const key of this.pendingWebhookStatusUpdates.keys()) {
+      await this.flushWebhookStatus(key);
+    }
+    this.pendingWebhookStatusUpdates = new Map();
   }
 }
 

--- a/packages/api/src/middleware/tracking.ts
+++ b/packages/api/src/middleware/tracking.ts
@@ -73,7 +73,7 @@ class Tracker {
   }
 
   private async flushWebhookStatus(id: string) {
-    const status = this.pendingWebhookStatusUpdates.get(id) ?? {};
+    const status = this.pendingWebhookStatusUpdates.get(id);
     this.pendingWebhookStatusUpdates.delete(id);
     if (!status) {
       return;

--- a/packages/api/src/webhooks/cannon.ts
+++ b/packages/api/src/webhooks/cannon.ts
@@ -24,6 +24,7 @@ import { DBStream } from "../store/stream-table";
 import { DBWebhook } from "../store/webhook-table";
 import { taskScheduler } from "../task/scheduler";
 import { RequestInitWithTimeout, fetchWithTimeout, sleep } from "../util";
+import tracking from "../middleware/tracking";
 
 const WEBHOOK_TIMEOUT = 30 * 1000;
 const MAX_BACKOFF = 60 * 60 * 1000;
@@ -761,7 +762,7 @@ export async function storeTriggerStatus(
         },
       };
     }
-    await db.webhook.updateStatus(webhook.id, status);
+    tracking.recordWebhookStatus(webhook.id, status);
   } catch (e) {
     console.log(
       `Unable to store status of webhook ${webhook.id} url: ${webhook.url}`,


### PR DESCRIPTION
We were finding the database was getting overloaded with these webhook status updates so we should buffer them up like we do with the lastSeen field.

<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional)**

<!-- Drag some screenshots here, if applicable -->

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
