### PR TITLE
Add index on stream.multistream.targets

### DIFF
--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -656,6 +656,20 @@ components:
                 Profiles to process the recording of this stream into. If not
                 specified, default profiles will be derived based on the stream
                 input. Keep in mind that the source rendition is always kept.
+        multistream:
+          type: object
+          additionalProperties: false
+          properties:
+            targets:
+              type: array
+              example:
+                - id: PUSH123
+                  profile: 720p
+              description: |
+                References to targets where this stream will be simultaneously
+                streamed to
+              items:
+                $ref: "#/components/schemas/target"
         suspended:
           type: boolean
           description: If currently suspended

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -656,20 +656,6 @@ components:
                 Profiles to process the recording of this stream into. If not
                 specified, default profiles will be derived based on the stream
                 input. Keep in mind that the source rendition is always kept.
-        multistream:
-          type: object
-          additionalProperties: false
-          properties:
-            targets:
-              type: array
-              example:
-                - id: PUSH123
-                  profile: 720p
-              description: |
-                References to targets where this stream will be simultaneously
-                streamed to
-              items:
-                $ref: "#/components/schemas/target"
         suspended:
           type: boolean
           description: If currently suspended

--- a/packages/api/src/schema/db-schema.yaml
+++ b/packages/api/src/schema/db-schema.yaml
@@ -745,21 +745,10 @@ components:
           type: string
           example: D8321C3E-B29C-45EB-A1BB-A623D8BE0F65
         multistream:
-          type: object
-          additionalProperties: false
           properties:
             targets:
-              type: array
               index: true
               indexType: gin
-              example:
-                - id: PUSH123
-                  profile: 720p
-              description: |
-                References to targets where this stream will be simultaneously
-                streamed to
-              items:
-                $ref: "#/components/schemas/target"
         presets:
           type: array
           items:

--- a/packages/api/src/schema/db-schema.yaml
+++ b/packages/api/src/schema/db-schema.yaml
@@ -744,6 +744,22 @@ components:
         objectStoreId:
           type: string
           example: D8321C3E-B29C-45EB-A1BB-A623D8BE0F65
+        multistream:
+          type: object
+          additionalProperties: false
+          properties:
+            targets:
+              type: array
+              index: true
+              indexType: gin
+              example:
+                - id: PUSH123
+                  profile: 720p
+              description: |
+                References to targets where this stream will be simultaneously
+                streamed to
+              items:
+                $ref: "#/components/schemas/target"
         presets:
           type: array
           items:

--- a/packages/api/src/store/table.ts
+++ b/packages/api/src/store/table.ts
@@ -371,15 +371,6 @@ export default class Table<T extends DBObject> {
 
   // on startup: auto-create indices if they don't exist
   async ensureIndex(propName: string, prop: FieldSpec, parents: string[] = []) {
-    if (
-      process.env.NODE_ENV !== "test" &&
-      ["stream", "session"].includes(this.name)
-    ) {
-      // avoid creating stream indexes in production right now. since the tables
-      // are large they can take 15+ minutes to index which hangs deployments.
-      // TODO: create an init container to create indexes before the server.
-      return;
-    }
     if (prop.oneOf?.length) {
       for (const oneSchema of prop.oneOf) {
         await this.ensureIndex(propName, oneSchema, parents);


### PR DESCRIPTION
Lack of this index caused issues with toggling multistream targets when user has many streams.

Fix https://linear.app/livepeer/issue/PS-793/august-22-2024-1142-am-stream-id-b924ca03-71fb-4af8-b526-087e2285576a#comment-7457b434