### PR TITLE
api/tracking: Fix concurrency issues with status reporting

### DIFF
--- a/packages/api/src/middleware/tracking.ts
+++ b/packages/api/src/middleware/tracking.ts
@@ -86,15 +86,19 @@ class Tracker {
   }
 
   async flushAll() {
+    const flushTasks = [];
     for (const key of this.pendingLastSeenUpdates.keys()) {
-      await this.flushLastSeen(key);
+      flushTasks.push(this.flushLastSeen(key));
     }
-    this.pendingLastSeenUpdates = new Map();
-
     for (const key of this.pendingWebhookStatusUpdates.keys()) {
-      await this.flushWebhookStatus(key);
+      flushTasks.push(this.flushWebhookStatus(key));
     }
+
+    // Only await after clearing the maps to avoid concurrent updates
+    this.pendingLastSeenUpdates = new Map();
     this.pendingWebhookStatusUpdates = new Map();
+
+    await Promise.all(flushTasks);
   }
 }
 

--- a/packages/api/src/middleware/tracking.ts
+++ b/packages/api/src/middleware/tracking.ts
@@ -1,6 +1,6 @@
 import sql from "sql-template-strings";
 import { ApiToken } from "../schema/types";
-import { db } from "../store";
+import { jobsDb as db } from "../store";
 import Table from "../store/table";
 import { DBWebhook } from "../store/webhook-table";
 


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

After https://github.com/livepeer/studio/pull/2297 we fixed [a problem](https://github.com/livepeer/studio/pull/2297#discussion_r1729121674) with the
`flushAll` logic, but created a different one which was looping over the maps
while they were potentially mutated concurrently.

**Specific updates (required)**

Fixed this by:
- Batching the updates on the `flushAll` and only doing any `await` after clearing the maps (i.e. we don't lose execution context before clearing the maps)
- Switching to `jobsDb` connection pool with Postgres so that these batch updates (nor even the regular updates) compete with regular APIs for the DB connections

**How did you test each of these updates (required)**
`yarn test` 🤷 

**Does this pull request close any open issues?**
N/A

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
