### PR TITLE
api,www: Create `deleted` state for recordings

### DIFF
--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -429,7 +429,7 @@ export async function withPlaybackUrls(
   asset: WithID<Asset>,
   os?: ObjectStore,
 ): Promise<WithID<Asset>> {
-  if (asset.files?.length < 1) {
+  if (asset.files?.length < 1 || asset.deleted) {
     // files is only set when playback is available
     return asset;
   }

--- a/packages/api/src/controllers/stream.ts
+++ b/packages/api/src/controllers/stream.ts
@@ -619,11 +619,12 @@ export async function getRecordingFields(
     const assetPhase = assetWithPlayback.status?.phase;
     return {
       recordingStatus:
-        assetPhase == "ready"
-          ? "ready"
-          : assetPhase == "failed"
-            ? "failed"
-            : "waiting",
+        {
+          ready: "ready",
+          failed: "failed",
+          deleting: "deleted",
+          deleted: "deleted",
+        }[assetPhase] ?? "waiting",
       recordingUrl: assetWithPlayback.playbackUrl,
       mp4Url: assetWithPlayback.downloadUrl,
     };

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -941,6 +941,7 @@ components:
             - waiting
             - ready
             - failed
+            - deleted
             - none
         recordingUrl:
           type: string

--- a/packages/www/components/Admin/Table-v2/cells/duration.tsx
+++ b/packages/www/components/Admin/Table-v2/cells/duration.tsx
@@ -11,14 +11,18 @@ export type DurationCellProps = {
 const DurationCell = <D extends TableData>({
   cell,
 }: CellComponentProps<D, DurationCellProps>) => {
-  if (cell.value.status === "waiting") {
-    return "In progress";
-  } else if (cell.value.status === "failed") {
-    return "Failed";
+  switch (cell.value.status) {
+    case "waiting":
+      return "In progress";
+    case "failed":
+      return "Failed";
+    case "deleted":
+      return "Deleted";
   }
   if (cell.value.duration === 0 || cell.value.status !== "ready") {
     return "n/a";
   }
+
   try {
     const dur = intervalToDuration({
       start: new Date(0),

--- a/packages/www/components/Table/cells/duration.tsx
+++ b/packages/www/components/Table/cells/duration.tsx
@@ -10,10 +10,13 @@ export type DurationCellProps = {
 const DurationCell = <D extends TableData>({
   cell,
 }: CellComponentProps<D, DurationCellProps>) => {
-  if (cell.value.status === "waiting") {
-    return "In progress";
-  } else if (cell.value.status === "failed") {
-    return "Failed";
+  switch (cell.value.status) {
+    case "waiting":
+      return "In progress";
+    case "failed":
+      return "Failed";
+    case "deleted":
+      return "Deleted";
   }
   if (
     cell.value.sourceSegmentsDuration === 0 ||
@@ -21,6 +24,7 @@ const DurationCell = <D extends TableData>({
   ) {
     return "n/a";
   }
+
   try {
     const durationMins = Math.round(cell.value.sourceSegmentsDuration / 60);
     if (!durationMins) {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Fix for the display bug reported by user on issue [PS-808](https://linear.app/livepeer/issue/PS-808/recordings-stuck-in-progress).

Basically creates a deleted state for the recordings to show that in the dashboard
instead of "in progress" when the recording asset is deleted.

**Specific updates (required)**
- Add new `deleted` field value on the API
- Show the `deleted` status on the UI

**How did you test each of these updates (required)**
`yarn test` 🤷 

**Does this pull request close any open issues?**

Fixes PS-808

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
