### PR TITLE
Add a file extension to download url

### DIFF
--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -418,7 +418,12 @@ function getDownloadUrl(
     os.id !== vodObjectStoreId ? os.publicUrl : pathJoin(ingest, "asset");
   const source = asset.files?.find((f) => f.type === "source_file");
   if (source) {
-    return pathJoin(base, asset.playbackId, source.path);
+    return pathJoin(
+      base,
+      asset.playbackId,
+      source.path,
+      "download." + asset.videoSpec.format,
+    );
   }
   return pathJoin(base, asset.playbackId, "video");
 }

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -418,11 +418,22 @@ function getDownloadUrl(
     os.id !== vodObjectStoreId ? os.publicUrl : pathJoin(ingest, "asset");
   const source = asset.files?.find((f) => f.type === "source_file");
   if (source) {
+    const formatToFileExtension: Map<string, string> = new Map([
+      ["mpegts", "ts"],
+      ["mp4", "mp4"],
+    ]);
+
+    if (
+      source.path != "video" ||
+      !formatToFileExtension.has(asset.videoSpec.format)
+    ) {
+      return pathJoin(base, asset.playbackId, source.path);
+    }
     return pathJoin(
       base,
       asset.playbackId,
       source.path,
-      "download." + asset.videoSpec.format,
+      "download." + formatToFileExtension.get(asset.videoSpec.format),
     );
   }
   return pathJoin(base, asset.playbackId, "video");

--- a/packages/api/src/controllers/asset.ts
+++ b/packages/api/src/controllers/asset.ts
@@ -421,6 +421,9 @@ function getDownloadUrl(
     const formatToFileExtension: Map<string, string> = new Map([
       ["mpegts", "ts"],
       ["mp4", "mp4"],
+      ["mov", "mov"],
+      ["matroska", "mkv"],
+      ["avi", "avi"],
     ]);
 
     if (

--- a/packages/api/src/schema/api-schema.yaml
+++ b/packages/api/src/schema/api-schema.yaml
@@ -1059,7 +1059,7 @@ components:
         downloadUrl:
           readOnly: true
           type: string
-          example: "https://livepeercdn.com/asset/eaw4nk06ts2d0mzb/video"
+          example: "https://livepeercdn.com/asset/eaw4nk06ts2d0mzb/video/download.mp4"
           description: >-
             The URL to directly download the asset, e.g.
             `https://livepeercdn.com/asset/eawrrk06ts2d0mzb/video`. It is not


### PR DESCRIPTION
This relies on a CDN rule to re-route the request to the standard `/video` path. I'll probably put it behind an experiment to begin with and also probably should have the mapping of format to file extension in catalyst.

<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

<!-- Fixes # -->

**Screenshots (optional)**

<!-- Drag some screenshots here, if applicable -->

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
