### PR TITLE
Fix segment anything default model ID

### DIFF
--- a/packages/api/src/schema/ai-api-schema.yaml
+++ b/packages/api/src/schema/ai-api-schema.yaml
@@ -544,7 +544,7 @@ components:
           type: string
           title: Model Id
           description: Hugging Face model ID used for image generation.
-          default: 'facebook/sam2-hiera-large:'
+          default: 'facebook/sam2-hiera-large'
         point_coords:
           type: string
           title: Point Coords

--- a/packages/api/src/schema/pull-ai-schema.js
+++ b/packages/api/src/schema/pull-ai-schema.js
@@ -11,7 +11,7 @@ export const defaultModels = {
   "image-to-video": "stabilityai/stable-video-diffusion-img2vid-xt-1-1",
   upscale: "stabilityai/stable-diffusion-x4-upscaler",
   "audio-to-text": "openai/whisper-large-v3",
-  "segment-anything-2": "facebook/sam2-hiera-large:",
+  "segment-anything-2": "facebook/sam2-hiera-large",
 };
 const schemaDir = path.resolve(__dirname, ".");
 const aiSchemaUrl =


### PR DESCRIPTION
Model ID doesn't need trailing `:`, this was causing 503s when trying to use the segment anything api.