### PR TITLE
api/access-control: Fix NRE on error log

### DIFF
--- a/packages/api/src/controllers/access-control.ts
+++ b/packages/api/src/controllers/access-control.ts
@@ -81,7 +81,7 @@ async function fireGateWebhook(
 
   const startTime = process.hrtime();
   let resp: Response;
-  let respBody: string;
+  let respBody = "";
   let errorMessage: string;
   let statusCode: number;
   let bodyStatusCode: number;


### PR DESCRIPTION
2024-10-09 15:08:18.542
2024-10-09 18:08:18 [error]: 	Unhandled error in API path=/api/access-control/gate errType=TypeError err="The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined" stack=TypeError: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined 2024-10-09 15:08:18.542
    at new NodeError (node:internal/errors:405:5)
2024-10-09 15:08:18.542
    at Function.from (node:buffer:325:9)
2024-10-09 15:08:18.542
    at ewa (/usr/local/src/controllers/access-control.ts:147:30)
2024-10-09 15:08:18.542
    at /usr/local/src/controllers/access-control.ts:372:28
