### PR TITLE
stream-info-service: Avoid creating indexes and reduce pool size

### DIFF
--- a/packages/api/src/app/stream-info/parse-cli.ts
+++ b/packages/api/src/app/stream-info/parse-cli.ts
@@ -37,6 +37,17 @@ export function parseCli() {
         type: "string",
         demandOption: true,
       },
+      "postgres-create-tables": {
+        describe:
+          "create tables and indexes on the database if they don't exist",
+        type: "boolean",
+        default: false,
+      },
+      "postgres-conn-pool-size": {
+        describe: "size of the postgres connection pool",
+        type: "number",
+        default: 5,
+      },
     })
     .help()
     .parse();

--- a/packages/api/src/app/stream-info/stream-info-app.ts
+++ b/packages/api/src/app/stream-info/stream-info-app.ts
@@ -1,19 +1,19 @@
 import express, { Router } from "express";
 import "express-async-errors"; // it monkeypatches, i guess
 import morgan from "morgan";
-import { db } from "../../store";
-import { healthCheck } from "../../middleware";
-import logger from "../../logger";
-import { Stream } from "../../schema/types";
 import fetch from "node-fetch";
 import { hostname } from "os";
+import logger from "../../logger";
+import { healthCheck } from "../../middleware";
+import { Stream } from "../../schema/types";
+import { db } from "../../store";
 
+import { DBStream } from "../../store/stream-table";
 import {
-  StatusResponse,
   MasterPlaylist,
   MasterPlaylistDictionary,
+  StatusResponse,
 } from "./livepeer-types";
-import { DBStream } from "../../store/stream-table";
 import { CliArgs } from "./parse-cli";
 
 const pollInterval = 2 * 1000; // 2s
@@ -377,9 +377,22 @@ class statusPoller {
 }
 
 export default async function makeApp(params: CliArgs) {
-  const { port, postgresUrl, ownRegion, listen = true, broadcaster } = params;
+  const {
+    port,
+    postgresUrl,
+    ownRegion,
+    listen = true,
+    broadcaster,
+    postgresCreateTables,
+    postgresConnPoolSize,
+  } = params;
   // Storage init
-  await db.start({ postgresUrl, appName: "stream-info" });
+  await db.start({
+    postgresUrl,
+    appName: "stream-info",
+    createTablesOnDb: postgresCreateTables,
+    poolMaxSize: postgresConnPoolSize,
+  });
 
   const { router } = await makeRouter(params);
   const app = express();


### PR DESCRIPTION


<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeer.studio/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Realized that every stream-info-service is trying to create all the DB tables and indexes on startup. Theoretically they return quickly as they already exist, but it still means we open up to 10 connections from each instance everytime a broadcaster pod starts (or the stream-info restarts).

This is hopefully what's been causing connection issues with Postgres just now.

**Specific updates (required)**

- Add CLI args equivalent to main Studio app
  - Notice that the main difference is that by default we don't create indexes, and allow up to 5 connections with Postgres (instead of `true`/`10` on main app)
- Use new args when initializing `db` client

**How did you test each of these updates (required)**
Config change only that reduces load and reuses already tested code in production on main app.
Will just test on staging and send to prod at a safe time.

**Does this pull request close any open issues?**
Related to PS-842

**Checklist**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
