### PR TITLE
Typos fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,7 +235,7 @@ This configuration file will determine the spacing rules for different editors
 - refactor(packages/explorer/.env.development): Added envars for Mining view
 - If envars are missing app doesn't work
 
-- fix(Removed previos edit that makes pages depend on localhost blockchain):
+- fix(Removed previous edit that makes pages depend on localhost blockchain):
 
 Removed previous change which make explorer depend on localhost blockchain
 
@@ -331,7 +331,7 @@ This configuration file will determine the spacing rules for different editors
 - refactor(packages/explorer/.env.development): Added envars for Mining view
 - If envars are missing app doesn't work
 
-- fix(Removed previos edit that makes pages depend on localhost blockchain):
+- fix(Removed previous edit that makes pages depend on localhost blockchain):
 
 Removed previous change which make explorer depend on localhost blockchain
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@ In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, gender identity and expression, level of
-experience, education, socio-economic status, nationality, personal appearance,
+experience, education, socioeconomic status, nationality, personal appearance,
 race, religion, or sexual identity and orientation.
 
 ## Our Standards


### PR DESCRIPTION
Fix: Corrected typos in source files

**Changes**

Corrected typo in /CODE_OF_CONDUCT.md (Line 9)

"socio-economic" → "socioeconomic"

Corrected typo in /CHANGELOG.md (Line 238)

"previos" → "previous"

Corrected typo in /CHANGELOG.md (Line 334)

"previos" → "previous"

**Purpose**

Improved code accuracy and professionalism by fixing typos.