### PR TITLE
Try to avoid double Hubspot submission on Studio registration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,7 +58,7 @@ jobs:
           tar -czvf "${RELEASE_PATH}/livepeer-api.tar.gz" livepeer-api
 
       - name: Upload artifacts for cutting release
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-artifacts
           path: releases/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,7 +76,7 @@ jobs:
       - build
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: release-artifacts
           path: releases/

--- a/packages/www/pages/register.tsx
+++ b/packages/www/pages/register.tsx
@@ -122,7 +122,6 @@ const RegisterPage = () => {
               py: "$3",
             }}>
             <Register
-              id="register"
               onSubmit={onSubmit}
               buttonText="Create account"
               loading={loading}

--- a/packages/www/pages/register.tsx
+++ b/packages/www/pages/register.tsx
@@ -122,6 +122,7 @@ const RegisterPage = () => {
               py: "$3",
             }}>
             <Register
+              id="register-form"
               onSubmit={onSubmit}
               buttonText="Create account"
               loading={loading}


### PR DESCRIPTION
I think there's something going on in the Hubspot libraries that mean we double push to it - once to the form whose ID we specify in the code, but also once to a form called #register. Even if we delete the #register form in Hubspot, it gets recreated on a new form submission.