### PR TITLE
api: Remove LIMIT from queries using GIN index

### DIFF
--- a/packages/api/src/controllers/multistream.ts
+++ b/packages/api/src/controllers/multistream.ts
@@ -199,7 +199,7 @@ async function triggerCatalystMultistreamUpdated(req: Request, id: string) {
   query.push(
     `stream.data->>'userId' = '${req.user.id}' AND stream.data->'multistream'->'targets' @> '[{"id":"${id}"}]'`,
   );
-  const [streams] = await db.stream.find(query, {});
+  const [streams] = await db.stream.find(query, { limit: null });
 
   await Promise.all(
     streams.map((s) => triggerCatalystStreamUpdated(req, s.playbackId)),

--- a/packages/api/src/store/table.ts
+++ b/packages/api/src/store/table.ts
@@ -24,6 +24,9 @@ export interface TableOptions {
 }
 
 function parseLimit({ limit }: FindOptions<any>) {
+  if (limit === null) {
+    return null;
+  }
   if (typeof limit === "string") {
     limit = parseInt(limit);
   }

--- a/packages/api/src/store/webhook-table.ts
+++ b/packages/api/src/store/webhook-table.ts
@@ -24,7 +24,7 @@ export default class WebhookTable extends Table<DBWebhook> {
     projectId: string,
     defaultProjectId: string,
     streamId?: string,
-    limit = 100,
+    limit = null,
     cursor?: string,
     includeDeleted = false,
   ) {


### PR DESCRIPTION
We have some queries taking a long time on the DB because for some reason the planner refuses to use the GIN index when there's a LIMIT. This is an easy fix to unblock those for now since:
- on both cases the probability of having a lot of results is low
- on both cases we also want to process every item that wouldn't be on the first "page" anyway