### PR TITLE
[INF-118] workflows: Bump github runner to ubuntu-24.04 or self-hosted

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3.2.0
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           # Check https://github.com/livepeer/go-livepeer/pull/1891
@@ -43,25 +43,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        if:
-          ${{ github.event_name == 'push' ||
-          github.event.pull_request.head.repo.full_name == github.repository }}
-        with:
-          username: ${{ secrets.CI_DOCKERHUB_USERNAME }}
-          password: ${{ secrets.CI_DOCKERHUB_TOKEN }}
-
-      # - name: Log in to the Container registry
-      #   uses: docker/login-action@v2
-      #   with:
-      #     registry: ghcr.io
-      #     username: ${{ github.actor }}
-      #     password: ${{ github.token }}
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             ${{ matrix.build.image }}
@@ -78,20 +62,32 @@ jobs:
             type=raw,value=${{ github.event.pull_request.head.ref }}
             type=raw,value=stable,enable=${{ startsWith(github.event.ref, 'refs/tags/v') }}
 
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        if:
+          ${{ github.event_name == 'push' ||
+          github.event.pull_request.head.repo.full_name == github.repository }}
+        with:
+          username: ${{ secrets.CI_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.CI_DOCKERHUB_TOKEN }}
+
       - name: Build and push livepeer docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           build-args: |
             VERSION=${{ (github.ref_type == 'tag' && github.ref_name) || (github.event.pull_request.head.sha || github.sha) }}
             GITHUB_SHA=${{ (github.event.pull_request.head.sha || github.sha) }}
           context: .
           platforms: linux/amd64
+          provenance: mode=max
+          sbom: true
           push:
             ${{ github.event_name == 'push' ||
             github.event.pull_request.head.repo.full_name == github.repository
             }}
-          tags: ${{ steps.meta.outputs.tags }}
           file: ${{ matrix.build.path }}/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: checkout

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   test:
     name: Run tests defined for the project
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     services:
       postgres:
         image: postgres:14-alpine
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           # Check https://github.com/livepeer/go-livepeer/pull/1891
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
bumps github runner to either 24.04 or self-hosted

**Specific updates (required)**
github removed the ubuntu-20 runners; and we were behind in bumping our workflows to switch newer runner.

**How did you test each of these updates (required)**
CI/CD workflows triggered in this PR

**Does this pull request close any open issues?**
probably not